### PR TITLE
Iterate only over non slave cells

### DIFF
--- a/examples/poisson.cc
+++ b/examples/poisson.cc
@@ -75,7 +75,7 @@ public:
   void
   run();
 
-  double penalty = 50.;
+  double penalty = 20.;
 };
 
 
@@ -211,228 +211,217 @@ Poisson<dim>::assemble_system()
 
   for (const auto &cell : ah->agglomeration_cell_iterators())
     {
-      const double hf = cell->face(0)->measure();
+      std::cout << "Cell with idx: " << cell->active_cell_index() << std::endl;
+      cell_matrix              = 0;
+      cell_rhs                 = 0;
+      const auto &agglo_values = ah->reinit(cell);
 
-      if (!ah->is_slave_cell(cell))
+      const auto &        q_points  = agglo_values.get_quadrature_points();
+      const unsigned int  n_qpoints = q_points.size();
+      std::vector<double> rhs(n_qpoints);
+      rhs_function->value_list(q_points, rhs);
+
+      for (unsigned int q_index : agglo_values.quadrature_point_indices())
         {
-          std::cout << "Cell with idx: " << cell->active_cell_index()
-                    << std::endl;
-          cell_matrix              = 0;
-          cell_rhs                 = 0;
-          const auto &agglo_values = ah->reinit(cell);
-
-          const auto &        q_points  = agglo_values.get_quadrature_points();
-          const unsigned int  n_qpoints = q_points.size();
-          std::vector<double> rhs(n_qpoints);
-          rhs_function->value_list(q_points, rhs);
-
-          for (unsigned int q_index : agglo_values.quadrature_point_indices())
+          for (unsigned int i = 0; i < dofs_per_cell; ++i)
             {
-              for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              for (unsigned int j = 0; j < dofs_per_cell; ++j)
                 {
-                  for (unsigned int j = 0; j < dofs_per_cell; ++j)
-                    {
-                      cell_matrix(i, j) += agglo_values.shape_grad(i, q_index) *
-                                           agglo_values.shape_grad(j, q_index) *
-                                           agglo_values.JxW(q_index);
-                    }
-                  cell_rhs(i) += agglo_values.shape_value(i, q_index) *
-                                 rhs[q_index] * agglo_values.JxW(q_index);
+                  cell_matrix(i, j) += agglo_values.shape_grad(i, q_index) *
+                                       agglo_values.shape_grad(j, q_index) *
+                                       agglo_values.JxW(q_index);
                 }
+              cell_rhs(i) += agglo_values.shape_value(i, q_index) *
+                             rhs[q_index] * agglo_values.JxW(q_index);
             }
+        }
 
-          cell->get_dof_indices(local_dof_indices);
-          constraints.distribute_local_to_global(cell_matrix,
-                                                 cell_rhs,
-                                                 local_dof_indices,
-                                                 system_matrix,
-                                                 system_rhs);
+      cell->get_dof_indices(local_dof_indices);
+      constraints.distribute_local_to_global(
+        cell_matrix, cell_rhs, local_dof_indices, system_matrix, system_rhs);
 
-          // Face terms
-          const unsigned int n_faces = ah->n_faces(cell);
-          std::cout << "Number of (generalized) faces: " << n_faces
-                    << std::endl;
+      // Face terms
+      const unsigned int n_faces = ah->n_faces(cell);
+      std::cout << "Number of (generalized) faces: " << n_faces << std::endl;
 
-          for (unsigned int f = 0; f < n_faces; ++f)
+      for (unsigned int f = 0; f < n_faces; ++f)
+        {
+          double hf = cell->face(0)->measure();
+
+          if (ah->at_boundary(cell, f))
             {
-              if (ah->at_boundary(cell, f))
+              std::cout << "at boundary!" << std::endl;
+              const auto &fe_face = ah->reinit(cell, f);
+
+              const unsigned int dofs_per_cell = fe_face.dofs_per_cell;
+              std::cout << "With dofs_per_cell =" << fe_face.dofs_per_cell
+                        << std::endl;
+              std::vector<types::global_dof_index> local_dof_indices_bdary_cell(
+                dofs_per_cell);
+
+              // Get normal vectors seen from each agglomeration.
+              const auto &normals = fe_face.get_normal_vectors();
+              cell_matrix         = 0.;
+              for (unsigned int q_index : fe_face.quadrature_point_indices())
                 {
-                  std::cout << "at boundary!" << std::endl;
-                  const auto &fe_face = ah->reinit(cell, f);
+                  for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                    {
+                      for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                        {
+                          cell_matrix(i, j) +=
+                            (-fe_face.shape_value(i, q_index) *
+                               fe_face.shape_grad(j, q_index) *
+                               normals[q_index] -
+                             fe_face.shape_grad(i, q_index) * normals[q_index] *
+                               fe_face.shape_value(j, q_index) +
+                             (penalty / hf) * fe_face.shape_value(i, q_index) *
+                               fe_face.shape_value(j, q_index)) *
+                            fe_face.JxW(q_index);
+                        }
+                    }
+                }
 
-                  const unsigned int dofs_per_cell = fe_face.dofs_per_cell;
-                  std::cout << "With dofs_per_cell =" << fe_face.dofs_per_cell
+              // distribute DoFs
+              cell->get_dof_indices(local_dof_indices_bdary_cell);
+              system_matrix.add(local_dof_indices_bdary_cell, cell_matrix);
+            }
+          else
+            {
+              const auto &neigh_cell = ah->agglomerated_neighbor(cell, f);
+
+              // This is necessary to loop over internal faces only once.
+              if (cell->active_cell_index() < neigh_cell->active_cell_index())
+                {
+                  unsigned int nofn =
+                    ah->neighbor_of_agglomerated_neighbor(cell, f);
+                  const auto &fe_faces =
+                    ah->reinit_interface(cell, neigh_cell, f, nofn);
+
+                  const auto &fe_faces0 = fe_faces.first;
+                  const auto &fe_faces1 = fe_faces.second;
+
+                  std::cout << "Jump between " << cell->active_cell_index()
+                            << " and " << neigh_cell->active_cell_index()
                             << std::endl;
-                  std::vector<types::global_dof_index>
-                    local_dof_indices_bdary_cell(dofs_per_cell);
 
-                  // Get normal vectors seen from each agglomeration.
-                  const auto &normals = fe_face.get_normal_vectors();
-                  cell_matrix         = 0.;
+                  std::vector<types::global_dof_index>
+                    local_dof_indices_neighbor(dofs_per_cell);
+
+                  M11 = 0.;
+                  M12 = 0.;
+                  M21 = 0.;
+                  M22 = 0.;
+
+                  const auto &normals = fe_faces0.get_normal_vectors();
+                  // M11
                   for (unsigned int q_index :
-                       fe_face.quadrature_point_indices())
+                       fe_faces0.quadrature_point_indices())
+                    {
+                      std::cout << normals[q_index] << std::endl;
+                      for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                        {
+                          for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                            {
+                              M11(i, j) +=
+                                (-0.5 * fe_faces0.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(j, q_index) -
+                                 0.5 * fe_faces0.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(i, q_index) +
+                                 (penalty / hf) *
+                                   fe_faces0.shape_value(i, q_index) *
+                                   fe_faces0.shape_value(j, q_index)) *
+                                fe_faces0.JxW(q_index);
+                            }
+                        }
+                    }
+                  // M12
+                  for (unsigned int q_index :
+                       fe_faces0.quadrature_point_indices())
                     {
                       for (unsigned int i = 0; i < dofs_per_cell; ++i)
                         {
                           for (unsigned int j = 0; j < dofs_per_cell; ++j)
                             {
-                              cell_matrix(i, j) +=
-                                (-fe_face.shape_value(i, q_index) *
-                                   fe_face.shape_grad(j, q_index) *
-                                   normals[q_index] -
-                                 fe_face.shape_grad(i, q_index) *
+                              M12(i, j) +=
+                                (0.5 * fe_faces0.shape_grad(i, q_index) *
                                    normals[q_index] *
-                                   fe_face.shape_value(j, q_index) +
+                                   fe_faces1.shape_value(j, q_index) -
+                                 0.5 * fe_faces1.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(i, q_index) -
                                  (penalty / hf) *
-                                   fe_face.shape_value(i, q_index) *
-                                   fe_face.shape_value(j, q_index)) *
-                                fe_face.JxW(q_index);
+                                   fe_faces0.shape_value(i, q_index) *
+                                   fe_faces1.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
                             }
                         }
                     }
-
-                  // distribute DoFs
-                  cell->get_dof_indices(local_dof_indices_bdary_cell);
-                  system_matrix.add(local_dof_indices_bdary_cell, cell_matrix);
-                }
-              else
-                {
-                  const auto &neigh_cell = ah->agglomerated_neighbor(cell, f);
-
-                  if (cell->active_cell_index() <
-                      neigh_cell->active_cell_index())
+                  // A10
+                  for (unsigned int q_index :
+                       fe_faces0.quadrature_point_indices())
                     {
-                      unsigned int nofn =
-                        ah->neighbor_of_agglomerated_neighbor(cell, f);
-                      const auto &fe_faces =
-                        ah->reinit_interface(cell, neigh_cell, f, nofn);
-
-                      const auto &fe_faces0 = fe_faces.first;
-                      const auto &fe_faces1 = fe_faces.second;
-
-                      std::cout << "Jump between " << cell->active_cell_index()
-                                << " and " << neigh_cell->active_cell_index()
-                                << std::endl;
-
-                      std::vector<types::global_dof_index>
-                        local_dof_indices_neighbor(dofs_per_cell);
-
-                      M11 = 0.;
-                      M12 = 0.;
-                      M21 = 0.;
-                      M22 = 0.;
-
-                      const auto &normals = fe_faces0.get_normal_vectors();
-                      // M11
-                      for (unsigned int q_index :
-                           fe_faces0.quadrature_point_indices())
+                      for (unsigned int i = 0; i < dofs_per_cell; ++i)
                         {
-                          std::cout << normals[q_index] << std::endl;
-                          for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                          for (unsigned int j = 0; j < dofs_per_cell; ++j)
                             {
-                              for (unsigned int j = 0; j < dofs_per_cell; ++j)
-                                {
-                                  M11(i, j) +=
-                                    (-0.5 * fe_faces0.shape_grad(i, q_index) *
-                                       normals[q_index] *
-                                       fe_faces0.shape_value(j, q_index) -
-                                     0.5 * fe_faces0.shape_grad(j, q_index) *
-                                       normals[q_index] *
-                                       fe_faces0.shape_value(i, q_index) +
-                                     (penalty / hf) *
-                                       fe_faces0.shape_value(i, q_index) *
-                                       fe_faces0.shape_value(j, q_index)) *
-                                    fe_faces0.JxW(q_index);
-                                }
+                              M21(i, j) +=
+                                (-0.5 * fe_faces1.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(j, q_index) +
+                                 0.5 * fe_faces0.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(i, q_index) -
+                                 (penalty / hf) *
+                                   fe_faces1.shape_value(i, q_index) *
+                                   fe_faces0.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
                             }
                         }
-                      // M12
-                      for (unsigned int q_index :
-                           fe_faces0.quadrature_point_indices())
-                        {
-                          for (unsigned int i = 0; i < dofs_per_cell; ++i)
-                            {
-                              for (unsigned int j = 0; j < dofs_per_cell; ++j)
-                                {
-                                  M12(i, j) +=
-                                    (0.5 * fe_faces0.shape_grad(i, q_index) *
-                                       normals[q_index] *
-                                       fe_faces1.shape_value(j, q_index) -
-                                     0.5 * fe_faces1.shape_grad(j, q_index) *
-                                       normals[q_index] *
-                                       fe_faces0.shape_value(i, q_index) -
-                                     (penalty / hf) *
-                                       fe_faces0.shape_value(i, q_index) *
-                                       fe_faces1.shape_value(j, q_index)) *
-                                    fe_faces1.JxW(q_index);
-                                }
-                            }
-                        }
-                      // A10
-                      for (unsigned int q_index :
-                           fe_faces0.quadrature_point_indices())
-                        {
-                          for (unsigned int i = 0; i < dofs_per_cell; ++i)
-                            {
-                              for (unsigned int j = 0; j < dofs_per_cell; ++j)
-                                {
-                                  M21(i, j) +=
-                                    (-0.5 * fe_faces1.shape_grad(i, q_index) *
-                                       normals[q_index] *
-                                       fe_faces0.shape_value(j, q_index) +
-                                     0.5 * fe_faces0.shape_grad(j, q_index) *
-                                       normals[q_index] *
-                                       fe_faces1.shape_value(i, q_index) -
-                                     (penalty / hf) *
-                                       fe_faces1.shape_value(i, q_index) *
-                                       fe_faces0.shape_value(j, q_index)) *
-                                    fe_faces1.JxW(q_index);
-                                }
-                            }
-                        }
-                      // A11
-                      for (unsigned int q_index :
-                           fe_faces0.quadrature_point_indices())
-                        {
-                          for (unsigned int i = 0; i < dofs_per_cell; ++i)
-                            {
-                              for (unsigned int j = 0; j < dofs_per_cell; ++j)
-                                {
-                                  M22(i, j) +=
-                                    (0.5 * fe_faces1.shape_grad(i, q_index) *
-                                       normals[q_index] *
-                                       fe_faces1.shape_value(j, q_index) +
-                                     0.5 * fe_faces1.shape_grad(j, q_index) *
-                                       normals[q_index] *
-                                       fe_faces1.shape_value(i, q_index) +
-                                     (penalty / hf) *
-                                       fe_faces1.shape_value(i, q_index) *
-                                       fe_faces1.shape_value(j, q_index)) *
-                                    fe_faces1.JxW(q_index);
-                                }
-                            }
-                        }
-
-                      // distribute DoFs accordingly
-                      std::cout << "Neighbor is "
-                                << neigh_cell->active_cell_index() << std::endl;
-                      typename DoFHandler<dim>::cell_iterator neigh_dh(
-                        *neigh_cell, &(ah->agglo_dh));
-                      neigh_dh->get_dof_indices(local_dof_indices_neighbor);
-
-                      system_matrix.add(local_dof_indices, M11);
-                      system_matrix.add(local_dof_indices,
-                                        local_dof_indices_neighbor,
-                                        M12);
-                      system_matrix.add(local_dof_indices_neighbor,
-                                        local_dof_indices,
-                                        M21);
-                      system_matrix.add(local_dof_indices_neighbor, M22);
                     }
-                }
+                  // A11
+                  for (unsigned int q_index :
+                       fe_faces0.quadrature_point_indices())
+                    {
+                      for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                        {
+                          for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                            {
+                              M22(i, j) +=
+                                (0.5 * fe_faces1.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(j, q_index) +
+                                 0.5 * fe_faces1.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(i, q_index) +
+                                 (penalty / hf) *
+                                   fe_faces1.shape_value(i, q_index) *
+                                   fe_faces1.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
+                            }
+                        }
+                    }
+
+                  // distribute DoFs accordingly
+                  std::cout << "Neighbor is " << neigh_cell->active_cell_index()
+                            << std::endl;
+                  typename DoFHandler<dim>::cell_iterator neigh_dh(
+                    *neigh_cell, &(ah->agglo_dh));
+                  neigh_dh->get_dof_indices(local_dof_indices_neighbor);
+
+                  system_matrix.add(local_dof_indices, M11);
+                  system_matrix.add(local_dof_indices,
+                                    local_dof_indices_neighbor,
+                                    M12);
+                  system_matrix.add(local_dof_indices_neighbor,
+                                    local_dof_indices,
+                                    M21);
+                  system_matrix.add(local_dof_indices_neighbor, M22);
+                } // Loop only once trough internal faces
             }
-        }
-    }
+        } // Loop over faces of current cell
+    }     // Loop over cells
 }
 
 


### PR DESCRIPTION
This PR allows the assembly method to avoid the `if (!ah->is_slave_cell(cell))` when looping through cells. This way, the assembly is as close as possible to a standard DG loop, hiding all the internal details about which FEIndex a particular cell has.

This is achieved using the following class as predicate:
https://github.com/fdrmrc/AggloDeal/blob/9803c900b307780a733c82103e63a59766b14d0c/include/agglomeration_handler.h#L458-L475