### PR TITLE
Fix computation of volume of agglomerate: just use BBox

### DIFF
--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -622,8 +622,9 @@ public:
 
   /**
    *
-   * Compute the volume of an agglomerate. This @p cell argument takes the
-   * deal.II cell that identifies an agglomerate. If it's a standard cell,
+   * Compute the volume of an agglomerate by computing the volume of the
+   * bounding box enclosing the agglomerate. This @p cell argument takes
+   * the deal.II cell that identifies an agglomerate. If it's a standard cell,
    * than the this function is equivalent to cell->volume(). An exception is
    * thrown is the given cell is a slave cell.
    */

--- a/src/agglomeration_handler.cc
+++ b/src/agglomeration_handler.cc
@@ -327,10 +327,7 @@ AgglomerationHandler<dim, spacedim>::reinit_master(
 
       agglo_isv_ptr =
         std::make_unique<NonMatching::FEImmersedSurfaceValues<spacedim>>(
-          *euler_mapping,
-          *fe,
-          surface_quad,
-          agglomeration_face_flags);
+          *euler_mapping, *fe, surface_quad, agglomeration_face_flags);
 
       agglo_isv_ptr->reinit(cell);
 
@@ -693,27 +690,10 @@ AgglomerationHandler<dim, spacedim>::volume(
          ExcMessage("The present function cannot be called for slave cells."));
 
   if (is_master_cell(cell))
-    {
-      // Get the agglomerate
-      std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>
-        agglo_cells = get_slaves_of_idx(cell->active_cell_index());
-      // Push back master cell
-      agglo_cells.push_back(cell);
-
-      Quadrature<dim> quad =
-        agglomerated_quadrature(agglo_cells,
-                                QGauss<dim>{2 * fe->degree + 1},
-                                cell);
-
-      return std::accumulate(quad.get_weights().begin(),
-                             quad.get_weights().end(),
-                             0.);
-    }
+    return bboxes[cell->active_cell_index()].volume();
   else
-    {
-      // Standard deal.II way to get the measure of a cell.
-      return cell->measure();
-    }
+    // Standard deal.II way to get the measure of a cell.
+    return cell->measure();
 }
 
 


### PR DESCRIPTION
Instead of summing all the contributions from the underlying triangulation, just compute the volume of the bounding box associated to the polygon.