### PR TITLE
New metrics: ´overlap factor´  and ´box ratio´

### DIFF
--- a/examples/metrics.cc
+++ b/examples/metrics.cc
@@ -310,6 +310,8 @@ void
 Mesh<dim>::compute_metrics()
 {
   // Check metrics
+  ah->initialize_fe_values(QGauss<dim>(2 * dg_fe.degree + 1),
+                           update_JxW_values);
   auto metrics = PolyUtils::compute_quality_metrics(*ah);
 
   // uniformity factors
@@ -323,6 +325,7 @@ Mesh<dim>::compute_metrics()
             << "Average: " << average_uniformity_factor << std::endl;
 
   std::cout << std::endl;
+
   // circle ratios
   const auto &cr = std::get<1>(metrics);
 
@@ -334,8 +337,19 @@ Mesh<dim>::compute_metrics()
             << "Average: " << average_circle_ratio << std::endl;
   std::cout << std::endl;
 
+  // box ratios
+  const auto &br = std::get<2>(metrics);
+
+  double average_box_ratio =
+    std::accumulate(br.begin(), br.end(), 0.) / br.size();
+  std::cout << "Box ratio:\n"
+            << "Min: " << *std::min_element(br.begin(), br.end()) << "\n"
+            << "Max: " << *std::max_element(br.begin(), br.end()) << "\n"
+            << "Average: " << average_box_ratio << std::endl;
+  std::cout << std::endl;
+
   // coverage
-  const double coverage = std::get<2>(metrics);
+  const double coverage = std::get<3>(metrics);
 
   std::cout << "Coverage factor: " << coverage << std::endl;
 }

--- a/examples/minimal_SIP.cc
+++ b/examples/minimal_SIP.cc
@@ -738,9 +738,16 @@ Poisson<dim>::output_results()
             << std::accumulate(cr.begin(), cr.end(), 0.) / cr.size()
             << std::endl;
 
+  // box ratios
+  const auto &br = std::get<2>(metrics);
+  std::cout << "Average Box Ratio: "
+            << std::accumulate(br.begin(), br.end(), 0.) / br.size()
+            << std::endl;
+
   // overlap factor
-  const double of = std::get<2>(metrics);
+  const double of = std::get<3>(metrics);
   std::cout << "Overlap factor: " << of << std::endl;
+
 #ifdef AGGLO_DEBUG
   for (const auto &m : cr)
     std::cout << m << std::endl;


### PR DESCRIPTION
This PR adds a new metric, which I named "coverage factor" (name can be discussed). It is computed as $\text{CV}(\mathcal{T}) = \frac{\sum_i\text{Vol}(B_i)}{\text{Vol}(\\mathcal{T})}$, where $B_i$ us the i-th bounding box, associated to polytope $K_i$.


For a perfect square, here is one result of the `examples/metrics.cc` benchmark program.

```
Compute quality metrics for a set of polygonal meshes:
TEST: ***********SQUARE GRID***********
Rtree: 
Number of background cells: 1024
R-tree agglomerates built in 0.000215974 seconds [Wall Clock]
N agglomerates = 16
Uniformity factor:
Min: 1
Max: 1
Average: 1

Circle ratio:
Min: 0.707107
Max: 0.707107
Average: 0.707107

**Coverage factor: 1**
----------------------------------------
Metis: 
Number of background cells: 1024
METIS agglomerates built in 0.0110522 seconds [Wall Clock]
N agglomerates: 16
Uniformity factor:
Min: 0.770884
Max: 1
Average: 0.844103

Circle ratio:
Min: 0.32366
Max: 0.58409
Average: 0.505435

**Coverage factor: 1.32227**


```