### PR TITLE
Improve Rtree handling

### DIFF
--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -602,6 +602,7 @@ private:
   void
   initialize_hp_structure();
 
+
   /**
    * Helper function to call reinit on a master cell.
    */
@@ -611,8 +612,6 @@ private:
     const unsigned int                                              face_number,
     std::unique_ptr<NonMatching::FEImmersedSurfaceValues<spacedim>>
       &agglo_isv_ptr) const;
-
-
 
   /**
    * Helper function to determine whether or not a cell is a slave cell, without
@@ -631,7 +630,12 @@ private:
   void
   setup_connectivity_of_agglomeration();
 
-
+  /**
+   * Given the index of a polytopic element, return a DoFHandler iterator for
+   * which DoFs associated to that polytope can be queried.
+   */
+  inline const typename DoFHandler<dim, spacedim>::active_cell_iterator
+  polytope_to_dh_iterator(const types::global_cell_index polytope_index) const;
 
   /**
    * Record the number of agglomerations on the grid.
@@ -1082,6 +1086,17 @@ inline unsigned int
 AgglomerationHandler<dim, spacedim>::n_agglomerates() const
 {
   return n_agglomerations;
+}
+
+
+
+template <int dim, int spacedim>
+inline const typename DoFHandler<dim, spacedim>::active_cell_iterator
+AgglomerationHandler<dim, spacedim>::polytope_to_dh_iterator(
+  const types::global_cell_index polytope_index) const
+{
+  return master_cells_container[polytope_index]->as_dof_handler_iterator(
+    agglo_dh);
 }
 
 

--- a/include/agglomerator.h
+++ b/include/agglomerator.h
@@ -1,0 +1,432 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+#ifndef agglomerator_h
+#define agglomerator_h
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/bounding_box.h>
+
+#include <boost/geometry/algorithms/distance.hpp>
+#include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
+
+
+namespace dealii
+{
+  namespace internal
+  {
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    struct Rtree_visitor
+      : public boost::geometry::index::detail::rtree::visitor<
+          Value,
+          typename Options::parameters_type,
+          Box,
+          Allocators,
+          typename Options::node_tag,
+          true>::type
+    {
+      inline Rtree_visitor(
+        const Translator  &translator,
+        const unsigned int target_level,
+        std::vector<std::vector<typename Triangulation<
+          boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+                                 &agglomerates_,
+        std::vector<std::size_t> &n_nodes_per_level,
+        std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+          &parent_to_children);
+
+      /**
+       * An alias that identifies an InternalNode of the tree.
+       */
+      using InternalNode =
+        typename boost::geometry::index::detail::rtree::internal_node<
+          Value,
+          typename Options::parameters_type,
+          Box,
+          Allocators,
+          typename Options::node_tag>::type;
+
+      /**
+       * An alias that identifies a Leaf of the tree.
+       */
+      using Leaf = typename boost::geometry::index::detail::rtree::leaf<
+        Value,
+        typename Options::parameters_type,
+        Box,
+        Allocators,
+        typename Options::node_tag>::type;
+
+      /**
+       * Implements the visitor interface for InternalNode objects. If the node
+       * belongs to the level next to @p target_level, then fill the bounding
+       * box vector for that node.
+       */
+      inline void
+      operator()(const InternalNode &node);
+
+      /**
+       * Implements the visitor interface for Leaf objects.
+       */
+      inline void
+      operator()(const Leaf &);
+
+      /**
+       * Translator interface, required by the boost implementation of the
+       * rtree.
+       */
+      const Translator &translator;
+
+      /**
+       * Store the level we are currently visiting.
+       */
+      size_t level;
+
+      /**
+       * Index used to keep track of the number of different visited nodes
+       * during recursion/
+       */
+      size_t node_counter;
+
+      /**
+       * The level where children are living.
+       * Before: "we want to extract from the RTree object."
+       */
+      const size_t target_level;
+
+      /**
+       * A reference to the input vector of vector of BoundingBox objects. This
+       * vector v has the following property: v[i] = vector with all the mesh
+       * iterators composing the i-th agglomerate.
+       */
+      std::vector<std::vector<typename Triangulation<
+        boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+        &agglomerates;
+
+      /**
+       * Store the total number of nodes on each level.
+       */
+      std::vector<std::size_t> &n_nodes_per_level;
+
+      /**
+       * Map that associates to a given node on level l its children, identified
+       * by their integer index.
+       */
+      std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+        &parent_node_to_children_nodes;
+    };
+
+
+
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    Rtree_visitor<Value, Options, Translator, Box, Allocators>::Rtree_visitor(
+      const Translator  &translator,
+      const unsigned int target_level,
+      std::vector<std::vector<typename Triangulation<
+        boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+                               &agglomerates_,
+      std::vector<std::size_t> &n_nodes_per_level_,
+      std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+        &parent_to_children)
+      : translator(translator)
+      , level(0)
+      , node_counter(0)
+      , target_level(target_level)
+      , agglomerates(agglomerates_)
+      , n_nodes_per_level(n_nodes_per_level_)
+      , parent_node_to_children_nodes(parent_to_children)
+    {}
+
+
+
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    void
+    Rtree_visitor<Value, Options, Translator, Box, Allocators>::operator()(
+      const Rtree_visitor::InternalNode &node)
+    {
+      using elements_type =
+        typename boost::geometry::index::detail::rtree::elements_type<
+          InternalNode>::type; //  pairs of bounding box and pointer to child
+                               //  node
+      const elements_type &elements =
+        boost::geometry::index::detail::rtree::elements(node);
+
+      if (level < target_level)
+        {
+          size_t level_backup = level;
+          ++level;
+
+          for (typename elements_type::const_iterator it = elements.begin();
+               it != elements.end();
+               ++it)
+            {
+              boost::geometry::index::detail::rtree::apply_visitor(*this,
+                                                                   *it->second);
+            }
+
+          level = level_backup;
+        }
+      else if (level == target_level)
+        {
+          const auto offset = agglomerates.size();
+          agglomerates.resize(offset + 1);
+          size_t level_backup = level;
+
+          ++level;
+          for (const auto &entry : elements)
+            {
+              boost::geometry::index::detail::rtree::apply_visitor(
+                *this, *entry.second);
+            }
+          // Done with node number 'node_counter' on level target_level.
+
+          ++node_counter; // visited all children of an internal node
+          n_nodes_per_level[target_level]++;
+
+          level = level_backup;
+        }
+      else if (level > target_level)
+        {
+          // I am on a child (internal) node on a deeper level.
+
+          // Keep visiting until you go to the leafs.
+          size_t level_backup = level;
+
+          ++level;
+
+          // looping through entries of node
+          for (const auto &entry : elements)
+            {
+              boost::geometry::index::detail::rtree::apply_visitor(
+                *this, *entry.second);
+            }
+          // done with node on level l > target_level (not just
+          // "target_level+1).
+          n_nodes_per_level[level_backup]++;
+          const std::size_t node_idx =
+            n_nodes_per_level[level_backup] - 1; // so to start from 0
+
+          parent_node_to_children_nodes[{n_nodes_per_level[level_backup - 1],
+                                         level_backup - 1}]
+            .push_back(node_idx);
+
+          level = level_backup;
+        }
+    }
+
+
+
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    void
+    Rtree_visitor<Value, Options, Translator, Box, Allocators>::operator()(
+      const Rtree_visitor::Leaf &leaf)
+    {
+      using elements_type =
+        typename boost::geometry::index::detail::rtree::elements_type<
+          Leaf>::type; //  pairs of bounding box and pointer to child node
+      const elements_type &elements =
+        boost::geometry::index::detail::rtree::elements(leaf);
+
+      for (const auto &it : elements)
+        agglomerates[node_counter].push_back(it.second);
+    }
+  } // namespace internal
+
+
+
+  /**
+   * Helper class which handles agglomeration based on the R-tree data
+   * structure. Notice that the R-tree type is assumed to be an R-star-tree.
+   */
+  template <int dim, typename RtreeType>
+  class CellsAgglomerator
+  {
+  public:
+    /**
+     * Constructor. It takes a given rtree and an integer representing the
+     * index of the level to be extracted.
+     */
+    CellsAgglomerator(const RtreeType   &rtree,
+                      const unsigned int extraction_level);
+
+    /**
+     * Extract agglomerates based on the current tree and the extraction level.
+     * This function returns a reference to
+     */
+    const std::vector<
+      std::vector<typename Triangulation<dim>::active_cell_iterator>> &
+    extract_agglomerates();
+
+    /**
+     * Get total number of levels.
+     */
+    inline unsigned int
+    get_n_levels() const;
+
+    /**
+     * Return the number of nodes present in level @p level.
+     */
+    inline std::size_t
+    get_n_nodes_per_level(const unsigned int level) const;
+
+    /**
+     * This function returns a map which associates to each node on level
+     * @p extraction_level a list of children.
+     */
+    inline const std::map<std::pair<std::size_t, std::size_t>,
+                          std::vector<std::size_t>> &
+    get_hierarchy() const;
+
+
+  private:
+    /**
+     * Raw pointer to the actual R-tree.
+     */
+    RtreeType *rtree;
+
+    /**
+     * Extraction level.
+     */
+    const unsigned int extraction_level;
+
+    /**
+     * Store agglomerates obtained after recursive extraction on nodes of
+     * level @p extraction_level.
+     */
+    std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+      agglomerates_on_level;
+
+    /**
+     * Vector storing the number of nodes (and, ultimately, agglomerates) for
+     * each level.
+     */
+    std::vector<std::size_t> n_nodes_per_level;
+
+    /**
+     * Map which maps a node parent @n on level @p l to a vector of integers
+     * which stores the index of children.
+     */
+    std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+      parent_node_to_children_nodes;
+  };
+
+
+
+  template <int dim, typename RtreeType>
+  CellsAgglomerator<dim, RtreeType>::CellsAgglomerator(
+    const RtreeType   &tree,
+    const unsigned int extraction_level_)
+    : extraction_level(extraction_level_)
+  {
+    rtree = const_cast<RtreeType *>(&tree);
+    Assert(n_levels(*rtree), ExcMessage("At least two levels are needed."));
+  }
+
+
+
+  template <int dim, typename RtreeType>
+  const std::vector<
+    std::vector<typename Triangulation<dim>::active_cell_iterator>> &
+  CellsAgglomerator<dim, RtreeType>::extract_agglomerates()
+  {
+    using RtreeView =
+      boost::geometry::index::detail::rtree::utilities::view<RtreeType>;
+    RtreeView rtv(*rtree);
+
+    n_nodes_per_level.resize(
+      rtv.depth()); // store how many nodes we have for each level.
+
+    if (rtv.depth() == 0)
+      {
+        // The below algorithm does not work for `rtv.depth()==0`, which might
+        // happen if the number entries in the tree is too small.
+        agglomerates_on_level.resize(1);
+        agglomerates_on_level[0].resize(1);
+      }
+    else
+      {
+        const unsigned int target_level =
+          std::min<unsigned int>(extraction_level, rtv.depth());
+
+        internal::Rtree_visitor<typename RtreeView::value_type,
+                                typename RtreeView::options_type,
+                                typename RtreeView::translator_type,
+                                typename RtreeView::box_type,
+                                typename RtreeView::allocators_type>
+          extractor_visitor(rtv.translator(),
+                            target_level,
+                            agglomerates_on_level,
+                            n_nodes_per_level,
+                            parent_node_to_children_nodes);
+
+
+        rtv.apply_visitor(extractor_visitor);
+      }
+    return agglomerates_on_level;
+  }
+
+
+
+  // ------------------------------ inline functions -------------------------
+
+
+  template <int dim, typename RtreeType>
+  inline unsigned int
+  CellsAgglomerator<dim, RtreeType>::get_n_levels() const
+  {
+    return n_levels(*rtree);
+  }
+
+
+
+  template <int dim, typename RtreeType>
+  inline std::size_t
+  CellsAgglomerator<dim, RtreeType>::get_n_nodes_per_level(
+    const unsigned int level) const
+  {
+    return n_nodes_per_level[level];
+  }
+
+
+
+  template <int dim, typename RtreeType>
+  inline const std::map<std::pair<std::size_t, std::size_t>,
+                        std::vector<std::size_t>> &
+  CellsAgglomerator<dim, RtreeType>::get_hierarchy() const
+  {
+    Assert(parent_node_to_children_nodes.size(),
+           ExcMessage(
+             "The hierarchy has not been computed. Did you forget to call"
+             " extract_agglomerates() first?"));
+    return parent_node_to_children_nodes;
+  }
+} // namespace dealii
+#endif

--- a/include/agglomerator.h
+++ b/include/agglomerator.h
@@ -47,10 +47,10 @@ namespace dealii
         const unsigned int target_level,
         std::vector<std::vector<typename Triangulation<
           boost::geometry::dimension<Box>::value>::active_cell_iterator>>
-                                 &agglomerates_,
-        std::vector<std::size_t> &n_nodes_per_level,
-        std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
-          &parent_to_children);
+                                                        &agglomerates_,
+        std::vector<types::global_cell_index>           &n_nodes_per_level,
+        std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+                 std::vector<types::global_cell_index>> &parent_to_children);
 
       /**
        * An alias that identifies an InternalNode of the tree.
@@ -122,13 +122,14 @@ namespace dealii
       /**
        * Store the total number of nodes on each level.
        */
-      std::vector<std::size_t> &n_nodes_per_level;
+      std::vector<types::global_cell_index> &n_nodes_per_level;
 
       /**
        * Map that associates to a given node on level l its children, identified
        * by their integer index.
        */
-      std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+      std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+               std::vector<types::global_cell_index>>
         &parent_node_to_children_nodes;
     };
 
@@ -144,10 +145,10 @@ namespace dealii
       const unsigned int target_level,
       std::vector<std::vector<typename Triangulation<
         boost::geometry::dimension<Box>::value>::active_cell_iterator>>
-                               &agglomerates_,
-      std::vector<std::size_t> &n_nodes_per_level_,
-      std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
-        &parent_to_children)
+                                                      &agglomerates_,
+      std::vector<types::global_cell_index>           &n_nodes_per_level_,
+      std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+               std::vector<types::global_cell_index>> &parent_to_children)
       : translator(translator)
       , level(0)
       , node_counter(0)
@@ -227,7 +228,7 @@ namespace dealii
           // done with node on level l > target_level (not just
           // "target_level+1).
           n_nodes_per_level[level_backup]++;
-          const std::size_t node_idx =
+          const types::global_cell_index node_idx =
             n_nodes_per_level[level_backup] - 1; // so to start from 0
 
           parent_node_to_children_nodes[{n_nodes_per_level[level_backup - 1],
@@ -294,15 +295,16 @@ namespace dealii
     /**
      * Return the number of nodes present in level @p level.
      */
-    inline std::size_t
+    inline types::global_cell_index
     get_n_nodes_per_level(const unsigned int level) const;
 
     /**
      * This function returns a map which associates to each node on level
      * @p extraction_level a list of children.
      */
-    inline const std::map<std::pair<std::size_t, std::size_t>,
-                          std::vector<std::size_t>> &
+    inline const std::map<
+      std::pair<types::global_cell_index, types::global_cell_index>,
+      std::vector<types::global_cell_index>> &
     get_hierarchy() const;
 
 
@@ -328,13 +330,14 @@ namespace dealii
      * Vector storing the number of nodes (and, ultimately, agglomerates) for
      * each level.
      */
-    std::vector<std::size_t> n_nodes_per_level;
+    std::vector<types::global_cell_index> n_nodes_per_level;
 
     /**
      * Map which maps a node parent @n on level @p l to a vector of integers
      * which stores the index of children.
      */
-    std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+    std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+             std::vector<types::global_cell_index>>
       parent_node_to_children_nodes;
   };
 
@@ -408,7 +411,7 @@ namespace dealii
 
 
   template <int dim, typename RtreeType>
-  inline std::size_t
+  inline types::global_cell_index
   CellsAgglomerator<dim, RtreeType>::get_n_nodes_per_level(
     const unsigned int level) const
   {
@@ -418,8 +421,9 @@ namespace dealii
 
 
   template <int dim, typename RtreeType>
-  inline const std::map<std::pair<std::size_t, std::size_t>,
-                        std::vector<std::size_t>> &
+  inline const std::map<
+    std::pair<types::global_cell_index, types::global_cell_index>,
+    std::vector<types::global_cell_index>> &
   CellsAgglomerator<dim, RtreeType>::get_hierarchy() const
   {
     Assert(parent_node_to_children_nodes.size(),


### PR DESCRIPTION
The goal of this PR is to enhance the R-tree handling and encapsulation of such information in user-codes. To this aim, a new class `CellsAgglomerator` has been added. It takes an already-built tree and has methods `extract_agglomerates()` and `get_hierarchy()` to retrieve such information. The latter is a new way to get parent-child relationships during traversal.

Roadmap (for this PR):
- [x] Add tests
- [ ] Remove old "explicit" way of doing this
- [ ] Update applications

