### PR TITLE
Add `children()` method to accessor class

### DIFF
--- a/include/agglomeration_accessor.h
+++ b/include/agglomeration_accessor.h
@@ -172,6 +172,12 @@ public:
   types::subdomain_id
   subdomain_id() const;
 
+  /**
+   * Returns a vector of indices identifying the children polytopes.
+   */
+  inline const std::vector<types::global_cell_index> &
+  children() const;
+
 private:
   /**
    * Private default constructor. This is not supposed to be used and hence will
@@ -767,6 +773,15 @@ inline types::subdomain_id
 AgglomerationAccessor<dim, spacedim>::subdomain_id() const
 {
   return present_subdomain_id;
+}
+
+template <int dim, int spacedim>
+inline const std::vector<types::global_cell_index> &
+AgglomerationAccessor<dim, spacedim>::children() const
+{
+  Assert(!handler->parent_child_info->empty(), ExcInternalError());
+  return handler->parent_child_info->at(
+    {present_index, handler->present_extraction_level});
 }
 
 

--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -47,6 +47,7 @@
 #include <deal.II/non_matching/immersed_surface_quadrature.h>
 
 #include <agglomeration_iterator.h>
+#include <agglomerator.h>
 
 #include <fstream>
 
@@ -540,6 +541,20 @@ public:
                             std::vector<std::vector<Tensor<1, spacedim>>>>>
     recv_gradients;
 
+  /**
+   * Given the index of a polytopic element, return a DoFHandler iterator
+   * for which DoFs associated to that polytope can be queried.
+   */
+  inline const typename DoFHandler<dim, spacedim>::active_cell_iterator
+  polytope_to_dh_iterator(const types::global_cell_index polytope_index) const;
+
+  /**
+   *
+   */
+  template <typename RtreeType>
+  void
+  connect_hierarchy(const CellsAgglomerator<dim, RtreeType> &agglomerator);
+
 private:
   /**
    * Initialize connectivity informations
@@ -615,6 +630,7 @@ private:
     std::unique_ptr<NonMatching::FEImmersedSurfaceValues<spacedim>>
       &agglo_isv_ptr) const;
 
+
   /**
    * Helper function to determine whether or not a cell is a slave cell, without
    * any information about his parents.
@@ -632,12 +648,6 @@ private:
   void
   setup_connectivity_of_agglomeration();
 
-  /**
-   * Given the index of a polytopic element, return a DoFHandler iterator for
-   * which DoFs associated to that polytope can be queried.
-   */
-  inline const typename DoFHandler<dim, spacedim>::active_cell_iterator
-  polytope_to_dh_iterator(const types::global_cell_index polytope_index) const;
 
   /**
    * Record the number of agglomerations on the grid.
@@ -881,6 +891,11 @@ private:
    * cells as (trivial) polytopes.
    */
   bool hybrid_mesh;
+
+  const std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+                 std::vector<types::global_cell_index>> *parent_child_info;
+
+  unsigned int present_extraction_level;
 };
 
 
@@ -1168,6 +1183,15 @@ AgglomerationHandler<dim, spacedim>::polytope_iterators() const
     begin(), end());
 }
 
+template <int dim, int spacedim>
+template <typename RtreeType>
+void
+AgglomerationHandler<dim, spacedim>::connect_hierarchy(
+  const CellsAgglomerator<dim, RtreeType> &agglomerator)
+{
+  parent_child_info        = &agglomerator.parent_node_to_children_nodes;
+  present_extraction_level = agglomerator.extraction_level;
+}
 
 
 #endif

--- a/include/agglomerator.h
+++ b/include/agglomerator.h
@@ -23,6 +23,8 @@
 #include <boost/geometry/index/rtree.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 
+template <int dim, int spacedim>
+class AgglomerationHandler;
 
 namespace dealii
 {
@@ -271,6 +273,9 @@ namespace dealii
   class CellsAgglomerator
   {
   public:
+    template <int, int>
+    friend class ::AgglomerationHandler;
+
     /**
      * Constructor. It takes a given rtree and an integer representing the
      * index of the level to be extracted.
@@ -306,7 +311,6 @@ namespace dealii
       std::pair<types::global_cell_index, types::global_cell_index>,
       std::vector<types::global_cell_index>> &
     get_hierarchy() const;
-
 
   private:
     /**


### PR DESCRIPTION
Depends on #106 

Adds a member `children()` to the Accessor class. It returns the indices of the children polytopes. This, together with the DoFHandler over which these children are living, allows retrieving DoF indices associated to children and, ultimately, to set embedding matrices up in a "two-level-transfer" fashion.

I have tried this locally and works as follows:

```C++
    std::vector<types::global_dof_index> local_dof_indices_child(dg_fe.n_dofs_per_cell());
    for (const auto &polytope : ah_coarse->polytope_iterators())
      {
        const types::global_cell_index polytope_index = polytope->index();
        const auto &children = polytope->children(); // ! method added by this PR
        for (const types::global_cell_index child_idx : children)
          {
            const typename DoFHandler<dim>::active_cell_iterator &child_dh =
              ah_fine->polytope_to_dh_iterator(child_idx);
            child_dh->get_dof_indices(local_dof_indices_child);
          }
          // define sparsity pattern and perform loc2glb distribution
      }
```

A test showing what I wrote above will be added.