### PR TITLE
Compute injection matrix in distributed case

### DIFF
--- a/include/agglomeration_accessor.h
+++ b/include/agglomeration_accessor.h
@@ -172,6 +172,12 @@ public:
   types::subdomain_id
   subdomain_id() const;
 
+  /**
+   * Returns a vector of indices identifying the children polytopes.
+   */
+  inline const std::vector<types::global_cell_index> &
+  children() const;
+
 private:
   /**
    * Private default constructor. This is not supposed to be used and hence will
@@ -767,6 +773,15 @@ inline types::subdomain_id
 AgglomerationAccessor<dim, spacedim>::subdomain_id() const
 {
   return present_subdomain_id;
+}
+
+template <int dim, int spacedim>
+inline const std::vector<types::global_cell_index> &
+AgglomerationAccessor<dim, spacedim>::children() const
+{
+  Assert(!handler->parent_child_info->empty(), ExcInternalError());
+  return handler->parent_child_info->at(
+    {present_index, handler->present_extraction_level});
 }
 
 

--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -47,6 +47,7 @@
 #include <deal.II/non_matching/immersed_surface_quadrature.h>
 
 #include <agglomeration_iterator.h>
+#include <agglomerator.h>
 
 #include <fstream>
 
@@ -540,6 +541,20 @@ public:
                             std::vector<std::vector<Tensor<1, spacedim>>>>>
     recv_gradients;
 
+  /**
+   * Given the index of a polytopic element, return a DoFHandler iterator
+   * for which DoFs associated to that polytope can be queried.
+   */
+  inline const typename DoFHandler<dim, spacedim>::active_cell_iterator
+  polytope_to_dh_iterator(const types::global_cell_index polytope_index) const;
+
+  /**
+   *
+   */
+  template <typename RtreeType>
+  void
+  connect_hierarchy(const CellsAgglomerator<dim, RtreeType> &agglomerator);
+
 private:
   /**
    * Initialize connectivity informations
@@ -615,6 +630,7 @@ private:
     std::unique_ptr<NonMatching::FEImmersedSurfaceValues<spacedim>>
       &agglo_isv_ptr) const;
 
+
   /**
    * Helper function to determine whether or not a cell is a slave cell, without
    * any information about his parents.
@@ -632,12 +648,6 @@ private:
   void
   setup_connectivity_of_agglomeration();
 
-  /**
-   * Given the index of a polytopic element, return a DoFHandler iterator for
-   * which DoFs associated to that polytope can be queried.
-   */
-  inline const typename DoFHandler<dim, spacedim>::active_cell_iterator
-  polytope_to_dh_iterator(const types::global_cell_index polytope_index) const;
 
   /**
    * Record the number of agglomerations on the grid.
@@ -881,6 +891,11 @@ private:
    * cells as (trivial) polytopes.
    */
   bool hybrid_mesh;
+
+  const std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+                 std::vector<types::global_cell_index>> *parent_child_info;
+
+  unsigned int present_extraction_level;
 };
 
 
@@ -1168,6 +1183,15 @@ AgglomerationHandler<dim, spacedim>::polytope_iterators() const
     begin(), end());
 }
 
+template <int dim, int spacedim>
+template <typename RtreeType>
+void
+AgglomerationHandler<dim, spacedim>::connect_hierarchy(
+  const CellsAgglomerator<dim, RtreeType> &agglomerator)
+{
+  parent_child_info        = &agglomerator.parent_node_to_children_nodes;
+  present_extraction_level = agglomerator.extraction_level;
+}
 
 
 #endif

--- a/include/agglomerator.h
+++ b/include/agglomerator.h
@@ -23,6 +23,8 @@
 #include <boost/geometry/index/rtree.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 
+template <int dim, int spacedim>
+class AgglomerationHandler;
 
 namespace dealii
 {
@@ -271,6 +273,9 @@ namespace dealii
   class CellsAgglomerator
   {
   public:
+    template <int, int>
+    friend class ::AgglomerationHandler;
+
     /**
      * Constructor. It takes a given rtree and an integer representing the
      * index of the level to be extracted.
@@ -306,7 +311,6 @@ namespace dealii
       std::pair<types::global_cell_index, types::global_cell_index>,
       std::vector<types::global_cell_index>> &
     get_hierarchy() const;
-
 
   private:
     /**

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,233 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+#ifndef utils_h
+#define utils_h
+
+#include <deal.II/base/point.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+
+template <int dim, typename RtreeType>
+class Agglomerator;
+template <int, int>
+class AgglomerationHandler;
+
+namespace Utils
+{
+  template <typename T>
+  inline constexpr T
+  constexpr_pow(T num, unsigned int pow)
+  {
+    return (pow >= sizeof(unsigned int) * 8) ? 0 :
+           pow == 0                          ? 1 :
+                                               num * constexpr_pow(num, pow - 1);
+  }
+
+
+
+  /**
+   * Given a coarse AgglomerationHandler @p coarse_ah and a fine
+   * AgglomerationHandler @p fine_ah, this function fills the injection matrix
+   * @p matrix and the associated SparsityPattern @p sp from the coarse space
+   * to the finer one.
+   *
+   * The matrix @p matrix (as well as @p sp) are assumed to be only
+   * default-constructed upon calling this function, i.e. the matrix should
+   * just be empty.
+   *
+   * @note Supported types are SparseMatrix<double> or TrilinosWrappers::SparseMatrix.
+   */
+  template <int dim, int spacedim, typename MatrixType>
+  void
+  fill_injection_matrix(const AgglomerationHandler<dim, spacedim> &coarse_ah,
+                        const AgglomerationHandler<dim, spacedim> &fine_ah,
+                        SparsityPattern                           &sp,
+                        MatrixType                                &matrix)
+  {
+    // First, check that we support the matrix types
+    static constexpr bool is_trilinos_matrix =
+      std::is_same_v<TrilinosWrappers::SparseMatrix, MatrixType>;
+    static constexpr bool is_serial_matrix =
+      std::is_same_v<SparseMatrix<double>, MatrixType>;
+    static constexpr bool is_supported_matrix =
+      is_trilinos_matrix || is_serial_matrix;
+    static_assert(is_supported_matrix);
+    Assert(matrix.empty() && sp.empty(),
+           ExcMessage(
+             "The destination matrix and its sparsity pattern must the empty "
+             "upon calling this function."));
+    Assert(coarse_ah.n_dofs() < fine_ah.n_dofs(), ExcInternalError());
+    AssertDimension(dim, spacedim);
+
+    using NumberType = typename MatrixType::value_type;
+
+    // Get information from the handlers
+    const DoFHandler<dim, spacedim> &coarse_agglo_dh = coarse_ah.agglo_dh;
+    const DoFHandler<dim, spacedim> &fine_agglo_dh   = fine_ah.agglo_dh;
+
+    const FiniteElement<dim, spacedim> &fe   = coarse_ah.get_fe();
+    const Triangulation<dim, spacedim> &tria = coarse_ah.get_triangulation();
+    const auto &coarse_bboxes                = coarse_ah.get_local_bboxes();
+
+    const IndexSet &locally_owned_dofs_fine =
+      fine_agglo_dh.locally_owned_dofs();
+    const IndexSet locally_relevant_dofs_fine =
+      DoFTools::extract_locally_relevant_dofs(fine_agglo_dh);
+
+    const IndexSet &locally_owned_dofs_coarse =
+      coarse_agglo_dh.locally_owned_dofs();
+
+    DynamicSparsityPattern               dsp(fine_agglo_dh.n_dofs(),
+                               coarse_agglo_dh.n_dofs());
+    const unsigned int                   dofs_per_cell = fe.dofs_per_cell;
+    std::vector<types::global_dof_index> agglo_dof_indices(dofs_per_cell);
+    std::vector<types::global_dof_index> standard_dof_indices(dofs_per_cell);
+    std::vector<types::global_dof_index> output_dof_indices(dofs_per_cell);
+
+    const std::vector<Point<dim>> &unit_support_points =
+      fe.get_unit_support_points();
+    Quadrature<dim>         quad(unit_support_points);
+    FEValues<dim, spacedim> output_fe_values(fe,
+                                             quad,
+                                             update_quadrature_points);
+
+    std::vector<types::global_dof_index> local_dof_indices_coarse(
+      dofs_per_cell);
+    std::vector<types::global_dof_index> local_dof_indices_child(dofs_per_cell);
+
+    for (const auto &polytope : coarse_ah.polytope_iterators())
+      if (polytope->is_locally_owned())
+        {
+          polytope->get_dof_indices(local_dof_indices_coarse);
+
+          // Get local children and their DoFs
+          const auto &children_polytopes = polytope->children();
+          for (const types::global_cell_index child_idx : children_polytopes)
+            {
+              const typename DoFHandler<dim>::active_cell_iterator &child_dh =
+                fine_ah.polytope_to_dh_iterator(child_idx);
+              child_dh->get_dof_indices(local_dof_indices_child);
+              for (const auto row : local_dof_indices_child)
+                dsp.add_entries(row,
+                                local_dof_indices_coarse.begin(),
+                                local_dof_indices_coarse.end());
+            }
+        }
+
+    const auto assemble_injection_matrix = [&]() {
+      FullMatrix<NumberType>  local_matrix(dofs_per_cell, dofs_per_cell);
+      std::vector<Point<dim>> reference_q_points(dofs_per_cell);
+
+      // Dummy AffineConstraints, only needed for loc2glb
+      AffineConstraints<NumberType> c;
+      c.close();
+
+      for (const auto &polytope : coarse_ah.polytope_iterators())
+        if (polytope->is_locally_owned())
+          {
+            const typename DoFHandler<dim>::active_cell_iterator
+              &coarse_polytope_dh =
+                coarse_ah.polytope_to_dh_iterator(polytope->index());
+
+            polytope->get_dof_indices(local_dof_indices_coarse);
+
+            // Get local children of the present polytope
+            const auto &children_polytopes = polytope->children();
+            for (const types::global_cell_index child_idx : children_polytopes)
+              {
+                const typename DoFHandler<dim>::active_cell_iterator &child_dh =
+                  fine_ah.polytope_to_dh_iterator(child_idx);
+                child_dh->get_dof_indices(local_dof_indices_child);
+
+                local_matrix = 0.;
+
+                // compute real location of support points
+                std::vector<Point<dim>> real_qpoints;
+                real_qpoints.reserve(unit_support_points.size());
+                for (const Point<dim> &p : unit_support_points)
+                  real_qpoints.push_back(
+                    fine_ah.euler_mapping->transform_unit_to_real_cell(child_dh,
+                                                                       p));
+                // real_qpoints.push_back(box_fine.unit_to_real(p));
+
+                for (unsigned int i = 0; i < local_dof_indices_coarse.size();
+                     ++i)
+                  {
+                    const auto &p =
+                      coarse_ah.euler_mapping->transform_real_to_unit_cell(
+                        coarse_polytope_dh, real_qpoints[i]);
+                    for (unsigned int j = 0; j < local_dof_indices_child.size();
+                         ++j)
+                      {
+                        local_matrix(i, j) = fe.shape_value(j, p);
+                      }
+                  }
+
+                c.distribute_local_to_global(local_matrix,
+                                             local_dof_indices_child,
+                                             local_dof_indices_coarse,
+                                             matrix);
+              }
+          }
+    };
+
+
+    if constexpr (is_trilinos_matrix)
+      {
+        const MPI_Comm &communicator = tria.get_communicator();
+        SparsityTools::distribute_sparsity_pattern(dsp,
+                                                   locally_owned_dofs_fine,
+                                                   communicator,
+                                                   locally_relevant_dofs_fine);
+
+        matrix.reinit(locally_owned_dofs_fine,
+                      locally_owned_dofs_coarse,
+                      dsp,
+                      communicator);
+        assemble_injection_matrix();
+      }
+    else if constexpr (is_serial_matrix)
+      {
+        sp.copy_from(dsp);
+        matrix.reinit(sp);
+        assemble_injection_matrix();
+      }
+    else
+      {
+        // PETSc, LA::d::v options not implemented.
+        (void)coarse_ah;
+        (void)fine_ah;
+        (void)matrix;
+        AssertThrow(false,
+                    ExcNotImplemented(
+                      "This injection does not support PETSc types."));
+      }
+
+    // If tria is distributed
+    if (dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
+          &tria) != nullptr)
+      matrix.compress(VectorOperation::add);
+  }
+
+} // namespace Utils
+
+
+
+#endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -98,8 +98,20 @@ namespace Utils
     const IndexSet &locally_owned_dofs_coarse =
       coarse_agglo_dh.locally_owned_dofs();
 
-    DynamicSparsityPattern               dsp(fine_agglo_dh.n_dofs(),
-                               coarse_agglo_dh.n_dofs());
+    std::conditional_t<is_trilinos_matrix,
+                       TrilinosWrappers::SparsityPattern,
+                       DynamicSparsityPattern>
+      dsp;
+
+    if constexpr (is_trilinos_matrix)
+      dsp.reinit(locally_owned_dofs_fine,
+                 locally_owned_dofs_coarse,
+                 tria.get_communicator());
+    else
+      dsp.reinit(fine_agglo_dh.n_dofs(),
+                 coarse_agglo_dh.n_dofs(),
+                 locally_relevant_dofs_fine);
+
     const unsigned int                   dofs_per_cell = fe.dofs_per_cell;
     std::vector<types::global_dof_index> agglo_dof_indices(dofs_per_cell);
     std::vector<types::global_dof_index> standard_dof_indices(dofs_per_cell);
@@ -189,16 +201,8 @@ namespace Utils
 
     if constexpr (is_trilinos_matrix)
       {
-        const MPI_Comm &communicator = tria.get_communicator();
-        SparsityTools::distribute_sparsity_pattern(dsp,
-                                                   locally_owned_dofs_fine,
-                                                   communicator,
-                                                   locally_relevant_dofs_fine);
-
-        matrix.reinit(locally_owned_dofs_fine,
-                      locally_owned_dofs_coarse,
-                      dsp,
-                      communicator);
+        dsp.compress();
+        matrix.reinit(dsp);
         assemble_injection_matrix();
       }
     else if constexpr (is_serial_matrix)

--- a/test/polydeal/distributed_injection_01.cc
+++ b/test/polydeal/distributed_injection_01.cc
@@ -1,0 +1,473 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// Check that we can interpolate from two different agglomeration handlers, one
+// finer than the other one, in parallel and with different grid types and
+// functions.
+
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/function_lib.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools_integrate_difference.templates.h>
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <agglomeration_handler.h>
+#include <agglomerator.h>
+#include <poly_utils.h>
+#include <utils.h>
+
+using namespace dealii;
+
+
+template <int dim>
+class SolutionLinear : public Function<dim>
+{
+public:
+  SolutionLinear()
+    : Function<dim>()
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+};
+
+template <int dim>
+double
+SolutionLinear<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  double sum = 0;
+  for (unsigned int d = 0; d < dim; ++d)
+    sum += p[d];
+
+  return sum - 1;
+}
+
+
+
+template <int dim>
+void
+SolutionLinear<dim>::value_list(const std::vector<Point<dim>> &points,
+                                std::vector<double>           &values,
+                                const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+
+
+template <int dim>
+class SolutionQuadratic : public Function<dim>
+{
+public:
+  SolutionQuadratic()
+    : Function<dim>()
+  {
+    Assert(dim == 2, ExcNotImplemented());
+  }
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+};
+
+
+
+template <int dim>
+double
+SolutionQuadratic<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  return p[0] * p[0] + p[1] * p[1] - 1;
+}
+
+
+
+template <int dim>
+void
+SolutionQuadratic<dim>::value_list(const std::vector<Point<dim>> &points,
+                                   std::vector<double>           &values,
+                                   const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+/*--------------------------------------------------------------------------*/
+
+
+
+enum class GridType
+{
+  grid_generator, // hyper_cube or hyper_ball
+  unstructured    // square generated with gmsh, unstructured
+};
+
+
+
+template <int dim>
+class DistributedHierarchyTest
+{
+public:
+  DistributedHierarchyTest(const GridType      &grid_type,
+                           const unsigned int   degree,
+                           const Function<dim> &func,
+                           const MPI_Comm       comm);
+  void
+  run();
+
+private:
+  void
+  make_fine_grid(const unsigned int);
+  void
+  setup_agglomerated_problem();
+
+  const MPI_Comm                                 comm;
+  const unsigned int                             n_ranks;
+  FE_DGQ<dim>                                    fe_dg;
+  const GridType                                &grid_type;
+  parallel::fullydistributed::Triangulation<dim> tria_pft;
+  const Function<dim>                           &func;
+  ConditionalOStream                             pcout;
+
+
+  std::unique_ptr<AgglomerationHandler<dim>> ah_coarse;
+  std::unique_ptr<AgglomerationHandler<dim>> ah_fine;
+
+  TrilinosWrappers::MPI::Vector interpolated_dst;
+};
+
+
+
+template <int dim>
+DistributedHierarchyTest<dim>::DistributedHierarchyTest(
+  const GridType      &grid_type_,
+  const unsigned int   degree,
+  const Function<dim> &func_,
+  const MPI_Comm       communicator)
+  : comm(communicator)
+  , n_ranks(Utilities::MPI::n_mpi_processes(comm))
+  , fe_dg(degree)
+  , grid_type(grid_type_)
+  , tria_pft(comm)
+  , func(func_)
+  , pcout(std::cout, (Utilities::MPI::this_mpi_process(comm) == 0))
+{
+  pcout << "*** Running with " << n_ranks << " MPI ranks ***" << std::endl;
+  pcout << "Grid type:";
+  grid_type == GridType::grid_generator ?
+    pcout << " Structured square" << std::endl :
+    pcout << " Unstructured square" << std::endl;
+}
+
+
+
+template <int dim>
+void
+DistributedHierarchyTest<dim>::make_fine_grid(
+  const unsigned int n_global_refinements)
+{
+  Triangulation<dim> tria;
+
+  if (grid_type == GridType::unstructured)
+    {
+      GridIn<dim> grid_in;
+      grid_in.attach_triangulation(tria);
+      std::ifstream gmsh_file(SOURCE_DIR "/input_grids/square.msh");
+      grid_in.read_msh(gmsh_file);
+      tria.refine_global(5); // 4
+    }
+  else if (grid_type == GridType::grid_generator)
+    {
+      GridGenerator::hyper_cube(tria, 0., 1.);
+      tria.refine_global(n_global_refinements);
+    }
+  else
+    {
+      Assert(false, ExcInternalError());
+    }
+
+  // Partition serial triangulation:
+  GridTools::partition_triangulation(n_ranks, tria);
+
+  // Create building blocks:
+  const TriangulationDescription::Description<dim, dim> description =
+    TriangulationDescription::Utilities::create_description_from_triangulation(
+      tria, comm);
+
+  tria_pft.create_triangulation(description);
+}
+
+
+
+template <int dim>
+void
+DistributedHierarchyTest<dim>::setup_agglomerated_problem()
+{
+  GridTools::Cache<dim> cached_tria(tria_pft);
+
+  ah_coarse = std::make_unique<AgglomerationHandler<dim>>(cached_tria);
+
+  // Partition with Rtree locally to each partition.
+  MappingQ1<dim> mapping; // use standard mapping
+
+  namespace bgi = boost::geometry::index;
+  static constexpr unsigned int max_elem_per_node =
+    Utils::constexpr_pow(2, dim); // 2^dim
+  std::vector<std::pair<BoundingBox<dim>,
+                        typename Triangulation<dim>::active_cell_iterator>>
+               boxes(tria_pft.n_locally_owned_active_cells());
+  unsigned int i = 0;
+  for (const auto &cell : tria_pft.active_cell_iterators())
+    if (cell->is_locally_owned())
+      boxes[i++] = std::make_pair(mapping.get_bounding_box(cell), cell);
+
+  auto tree = pack_rtree<bgi::rstar<max_elem_per_node>>(boxes);
+  Assert(n_levels(tree) >= 2, ExcMessage("At least two levels are needed."));
+  pcout << "Total number of available levels: " << n_levels(tree) << std::endl;
+
+
+  std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+                                         cells_per_material_id;
+  const unsigned int                     extraction_level = 2;
+  CellsAgglomerator<dim, decltype(tree)> agglomerator_coarse{tree,
+                                                             extraction_level};
+  const auto agglomerates_coarse = agglomerator_coarse.extract_agglomerates();
+  ah_coarse->connect_hierarchy(agglomerator_coarse);
+
+  std::size_t agglo_index = 0;
+  for (std::size_t i = 0; i < agglomerates_coarse.size(); ++i)
+    {
+      const auto &agglo = agglomerates_coarse[i];
+      for (const auto &el : agglo)
+        el->set_material_id(agglo_index);
+
+      ++agglo_index; // one agglomerate has been processed, increment
+                     // counter
+    }
+
+  cells_per_material_id.resize(agglo_index);
+  unsigned int total_agglomerates_coarse =
+    Utilities::MPI::sum(agglo_index, comm);
+  pcout << "Total coarse agglomerates: " << total_agglomerates_coarse
+        << std::endl;
+
+  for (const auto &cell : tria_pft.active_cell_iterators())
+    if (cell->is_locally_owned())
+      cells_per_material_id[cell->material_id()].push_back(cell);
+
+  // Agglomerate elements with same id
+  for (std::size_t i = 0; i < cells_per_material_id.size(); ++i)
+    ah_coarse->define_agglomerate(cells_per_material_id[i]);
+
+  ah_coarse->initialize_fe_values(QGauss<dim>(3),
+                                  update_values | update_gradients |
+                                    update_JxW_values |
+                                    update_quadrature_points,
+                                  QGauss<dim - 1>(3),
+                                  update_JxW_values);
+  ah_coarse->distribute_agglomerated_dofs(fe_dg);
+  pcout << "Distributed coarse DoFs" << std::endl;
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Do the same with finer level
+
+  CellsAgglomerator<dim, decltype(tree)> agglomerator_fine{tree,
+                                                           extraction_level +
+                                                             1};
+  const auto agglomerates_fine = agglomerator_fine.extract_agglomerates();
+  ah_fine = std::make_unique<AgglomerationHandler<dim>>(cached_tria);
+
+  std::size_t agglo_index_fine = 0;
+  for (std::size_t i = 0; i < agglomerates_fine.size(); ++i)
+    {
+      const auto &agglo = agglomerates_fine[i]; // i-th agglomerate fine
+      for (const auto &el : agglo)
+        {
+          el->set_material_id(agglo_index_fine);
+        }
+      ++agglo_index_fine;
+    }
+
+  const unsigned int n_subdomains_fine = agglo_index_fine;
+  unsigned int       total_agglomerates_fine =
+    Utilities::MPI::sum(n_subdomains_fine, comm);
+  pcout << "Total fine agglomerates: " << total_agglomerates_fine << std::endl;
+
+  std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+    cells_per_subdomain_fine(n_subdomains_fine);
+  for (const auto &cell : tria_pft.active_cell_iterators())
+    if (cell->is_locally_owned())
+      cells_per_subdomain_fine[cell->material_id()].push_back(cell);
+
+  // For every subdomain, agglomerate elements together
+  for (std::size_t i = 0; i < cells_per_subdomain_fine.size(); ++i)
+    ah_fine->define_agglomerate(cells_per_subdomain_fine[i]);
+
+  ah_fine->initialize_fe_values(QGauss<dim>(3),
+                                update_values | update_gradients |
+                                  update_JxW_values | update_quadrature_points,
+                                QGauss<dim - 1>(3),
+                                update_JxW_values);
+  ah_fine->distribute_agglomerated_dofs(fe_dg);
+
+  pcout << "Distributed fine DoFs" << std::endl;
+
+
+  // Check injection matrix
+  const IndexSet &locally_owned_dofs_coarse =
+    ah_coarse->agglo_dh.locally_owned_dofs();
+  TrilinosWrappers::MPI::Vector interp_coarse(locally_owned_dofs_coarse, comm);
+
+  VectorTools::interpolate(*(ah_coarse->euler_mapping),
+                           ah_coarse->agglo_dh,
+                           func,
+                           interp_coarse);
+
+  const IndexSet &locally_owned_dofs_fine =
+    ah_fine->agglo_dh.locally_owned_dofs();
+  TrilinosWrappers::MPI::Vector  dst(locally_owned_dofs_fine, comm);
+  SparsityPattern                embedding_sp;
+  TrilinosWrappers::SparseMatrix embedding_matrix;
+  Utils::fill_injection_matrix(*ah_coarse,
+                               *ah_fine,
+                               embedding_sp,
+                               embedding_matrix);
+  embedding_matrix.vmult(dst, interp_coarse);
+  pcout << "Multiplication: done" << std::endl;
+
+
+#ifdef FALSE
+  {
+    PolyUtils::interpolate_to_fine_grid(*ah_fine, interpolated_dst, dst);
+
+    DataOut<dim> data_out;
+    data_out.attach_dof_handler(ah_fine->output_dh);
+
+    data_out.add_data_vector(interpolated_dst,
+                             "u",
+                             DataOut<dim>::type_dof_data);
+
+    Vector<float> subdomain(tria_pft.n_active_cells());
+
+    for (unsigned int i = 0; i < subdomain.size(); ++i)
+      subdomain(i) = tria_pft.locally_owned_subdomain();
+
+    data_out.add_data_vector(subdomain, "subdomain");
+
+    Vector<float> agglo_idx(tria_pft.n_active_cells());
+    for (const auto &cell : tria_pft.active_cell_iterators())
+      {
+        if (cell->is_locally_owned())
+          agglo_idx[cell->active_cell_index()] = cell->material_id();
+      }
+    data_out.add_data_vector(agglo_idx,
+                             "agglo_idx",
+                             DataOut<dim>::type_cell_data);
+
+    data_out.build_patches();
+    const std::string filename =
+      ("interpolated_dst." +
+       Utilities::int_to_string(tria_pft.locally_owned_subdomain(), 4));
+
+    std::ofstream output((filename + ".vtu").c_str());
+    data_out.write_vtu(output);
+
+
+    {
+      std::vector<std::string> filenames;
+      for (unsigned int i = 0; i < Utilities::MPI::n_mpi_processes(comm); i++)
+        {
+          filenames.push_back("interpolated_dst." +
+                              Utilities::int_to_string(i, 4) + ".vtu");
+        }
+      std::ofstream master_output("interpolated_dst.pvtu");
+      data_out.write_pvtu_record(master_output, filenames);
+    }
+  }
+#endif
+
+  // Compute error:
+  TrilinosWrappers::MPI::Vector interp_fine(
+    dst.locally_owned_elements(), comm); // take parallel layout from dst
+  VectorTools::interpolate(*(ah_fine->euler_mapping),
+                           ah_fine->agglo_dh,
+                           func,
+                           interp_fine);
+
+  TrilinosWrappers::MPI::Vector err(dst);
+  dst -= interp_fine;
+  const double l2_error = dst.l2_norm();
+  AssertThrow(l2_error < 1e-14, ExcMessage("Injection didn't work properly."));
+  pcout << "Norm of error(L2): " << l2_error << std::endl;
+}
+
+
+
+template <int dim>
+void
+DistributedHierarchyTest<dim>::run()
+{
+  make_fine_grid(6); // 6 global refinements of unit cube
+  setup_agglomerated_problem();
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  const MPI_Comm                   comm = MPI_COMM_WORLD;
+  static constexpr unsigned int    dim  = 2;
+
+
+  // number of agglomerates in each local subdomain
+  SolutionLinear<dim>            linear;
+  SolutionQuadratic<dim>         quadratic;
+  std::array<Function<dim> *, 2> functions{{&linear, &quadratic}};
+
+  for (const Function<dim> *func : functions)
+    for (unsigned int degree : {2})
+      for (const auto &grid_type :
+           {GridType::grid_generator, GridType::unstructured})
+        {
+          DistributedHierarchyTest<dim> problem(grid_type, degree, *func, comm);
+          problem.run();
+        }
+}

--- a/test/polydeal/distributed_injection_01.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/test/polydeal/distributed_injection_01.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,36 @@
+*** Running with 3 MPI ranks ***
+Grid type: Structured square
+Total number of available levels: 5
+Total coarse agglomerates: 18
+Distributed coarse DoFs
+Total fine agglomerates: 66
+Distributed fine DoFs
+Multiplication: done
+Norm of error(L2): 9.97775e-16
+*** Running with 3 MPI ranks ***
+Grid type: Unstructured square
+Total number of available levels: 7
+Total coarse agglomerates: 24
+Distributed coarse DoFs
+Total fine agglomerates: 93
+Distributed fine DoFs
+Multiplication: done
+Norm of error(L2): 2.75792e-15
+*** Running with 3 MPI ranks ***
+Grid type: Structured square
+Total number of available levels: 5
+Total coarse agglomerates: 18
+Distributed coarse DoFs
+Total fine agglomerates: 66
+Distributed fine DoFs
+Multiplication: done
+Norm of error(L2): 1.27391e-15
+*** Running with 3 MPI ranks ***
+Grid type: Unstructured square
+Total number of available levels: 7
+Total coarse agglomerates: 24
+Distributed coarse DoFs
+Total fine agglomerates: 93
+Distributed fine DoFs
+Multiplication: done
+Norm of error(L2): 2.80779e-15


### PR DESCRIPTION
Depends on #106 and #107, commits from fb01d98a2fad10d687696334298f8fcda72a0f47 are the relevant ones.

This PR adds a utility function to compute embedding matrices from two different `AgglomerationHandler`s. They represent a coarse and a fine level in a multigrid hierarchy. Internally, it is exploiting the other two PRs to get children and fine support points for a given coarse agglomerate element. As distributed matrix-types, it supports only Trilinos matrices.

~~Tested so far only in serial.~~ Tested both in serial and in parallel, varying grid types and degree of the finite element space (test added in https://github.com/fdrmrc/Polydeal/pull/108/commits/4eb646a84c798e0a71d43c7cae5acaacaf356ff7)


@luca-heltai Could you have a look at `Utils::fill_injection_matrix()`?https://github.com/fdrmrc/Polydeal/blob/4eb646a84c798e0a71d43c7cae5acaacaf356ff7/include/utils.h#L59 The other PRs are mostly done to have such a distributed version working. An example of its usage is in the added test.