### PR TITLE
Implement parallel transfer interface between agglomerated multigrid levels

### DIFF
--- a/citation.cff
+++ b/citation.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Feder"
+  given-names: "Marco"
+- family-names: "Heltai"
+  given-names: "Luca"
+- family-names: "Cangiani"
+  given-names: "Andrea"
+title: "polyDEAL"
+version: 0.0.1
+url: "https://github.com/fdrmrc/Polydeal"

--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -602,6 +602,7 @@ private:
   void
   initialize_hp_structure();
 
+
   /**
    * Helper function to call reinit on a master cell.
    */
@@ -611,8 +612,6 @@ private:
     const unsigned int                                              face_number,
     std::unique_ptr<NonMatching::FEImmersedSurfaceValues<spacedim>>
       &agglo_isv_ptr) const;
-
-
 
   /**
    * Helper function to determine whether or not a cell is a slave cell, without
@@ -631,7 +630,12 @@ private:
   void
   setup_connectivity_of_agglomeration();
 
-
+  /**
+   * Given the index of a polytopic element, return a DoFHandler iterator for
+   * which DoFs associated to that polytope can be queried.
+   */
+  inline const typename DoFHandler<dim, spacedim>::active_cell_iterator
+  polytope_to_dh_iterator(const types::global_cell_index polytope_index) const;
 
   /**
    * Record the number of agglomerations on the grid.
@@ -1082,6 +1086,17 @@ inline unsigned int
 AgglomerationHandler<dim, spacedim>::n_agglomerates() const
 {
   return n_agglomerations;
+}
+
+
+
+template <int dim, int spacedim>
+inline const typename DoFHandler<dim, spacedim>::active_cell_iterator
+AgglomerationHandler<dim, spacedim>::polytope_to_dh_iterator(
+  const types::global_cell_index polytope_index) const
+{
+  return master_cells_container[polytope_index]->as_dof_handler_iterator(
+    agglo_dh);
 }
 
 

--- a/include/agglomerator.h
+++ b/include/agglomerator.h
@@ -1,0 +1,432 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+#ifndef agglomerator_h
+#define agglomerator_h
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/bounding_box.h>
+
+#include <boost/geometry/algorithms/distance.hpp>
+#include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
+
+
+namespace dealii
+{
+  namespace internal
+  {
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    struct Rtree_visitor
+      : public boost::geometry::index::detail::rtree::visitor<
+          Value,
+          typename Options::parameters_type,
+          Box,
+          Allocators,
+          typename Options::node_tag,
+          true>::type
+    {
+      inline Rtree_visitor(
+        const Translator  &translator,
+        const unsigned int target_level,
+        std::vector<std::vector<typename Triangulation<
+          boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+                                 &agglomerates_,
+        std::vector<std::size_t> &n_nodes_per_level,
+        std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+          &parent_to_children);
+
+      /**
+       * An alias that identifies an InternalNode of the tree.
+       */
+      using InternalNode =
+        typename boost::geometry::index::detail::rtree::internal_node<
+          Value,
+          typename Options::parameters_type,
+          Box,
+          Allocators,
+          typename Options::node_tag>::type;
+
+      /**
+       * An alias that identifies a Leaf of the tree.
+       */
+      using Leaf = typename boost::geometry::index::detail::rtree::leaf<
+        Value,
+        typename Options::parameters_type,
+        Box,
+        Allocators,
+        typename Options::node_tag>::type;
+
+      /**
+       * Implements the visitor interface for InternalNode objects. If the node
+       * belongs to the level next to @p target_level, then fill the bounding
+       * box vector for that node.
+       */
+      inline void
+      operator()(const InternalNode &node);
+
+      /**
+       * Implements the visitor interface for Leaf objects.
+       */
+      inline void
+      operator()(const Leaf &);
+
+      /**
+       * Translator interface, required by the boost implementation of the
+       * rtree.
+       */
+      const Translator &translator;
+
+      /**
+       * Store the level we are currently visiting.
+       */
+      size_t level;
+
+      /**
+       * Index used to keep track of the number of different visited nodes
+       * during recursion/
+       */
+      size_t node_counter;
+
+      /**
+       * The level where children are living.
+       * Before: "we want to extract from the RTree object."
+       */
+      const size_t target_level;
+
+      /**
+       * A reference to the input vector of vector of BoundingBox objects. This
+       * vector v has the following property: v[i] = vector with all the mesh
+       * iterators composing the i-th agglomerate.
+       */
+      std::vector<std::vector<typename Triangulation<
+        boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+        &agglomerates;
+
+      /**
+       * Store the total number of nodes on each level.
+       */
+      std::vector<std::size_t> &n_nodes_per_level;
+
+      /**
+       * Map that associates to a given node on level l its children, identified
+       * by their integer index.
+       */
+      std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+        &parent_node_to_children_nodes;
+    };
+
+
+
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    Rtree_visitor<Value, Options, Translator, Box, Allocators>::Rtree_visitor(
+      const Translator  &translator,
+      const unsigned int target_level,
+      std::vector<std::vector<typename Triangulation<
+        boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+                               &agglomerates_,
+      std::vector<std::size_t> &n_nodes_per_level_,
+      std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+        &parent_to_children)
+      : translator(translator)
+      , level(0)
+      , node_counter(0)
+      , target_level(target_level)
+      , agglomerates(agglomerates_)
+      , n_nodes_per_level(n_nodes_per_level_)
+      , parent_node_to_children_nodes(parent_to_children)
+    {}
+
+
+
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    void
+    Rtree_visitor<Value, Options, Translator, Box, Allocators>::operator()(
+      const Rtree_visitor::InternalNode &node)
+    {
+      using elements_type =
+        typename boost::geometry::index::detail::rtree::elements_type<
+          InternalNode>::type; //  pairs of bounding box and pointer to child
+                               //  node
+      const elements_type &elements =
+        boost::geometry::index::detail::rtree::elements(node);
+
+      if (level < target_level)
+        {
+          size_t level_backup = level;
+          ++level;
+
+          for (typename elements_type::const_iterator it = elements.begin();
+               it != elements.end();
+               ++it)
+            {
+              boost::geometry::index::detail::rtree::apply_visitor(*this,
+                                                                   *it->second);
+            }
+
+          level = level_backup;
+        }
+      else if (level == target_level)
+        {
+          const auto offset = agglomerates.size();
+          agglomerates.resize(offset + 1);
+          size_t level_backup = level;
+
+          ++level;
+          for (const auto &entry : elements)
+            {
+              boost::geometry::index::detail::rtree::apply_visitor(
+                *this, *entry.second);
+            }
+          // Done with node number 'node_counter' on level target_level.
+
+          ++node_counter; // visited all children of an internal node
+          n_nodes_per_level[target_level]++;
+
+          level = level_backup;
+        }
+      else if (level > target_level)
+        {
+          // I am on a child (internal) node on a deeper level.
+
+          // Keep visiting until you go to the leafs.
+          size_t level_backup = level;
+
+          ++level;
+
+          // looping through entries of node
+          for (const auto &entry : elements)
+            {
+              boost::geometry::index::detail::rtree::apply_visitor(
+                *this, *entry.second);
+            }
+          // done with node on level l > target_level (not just
+          // "target_level+1).
+          n_nodes_per_level[level_backup]++;
+          const std::size_t node_idx =
+            n_nodes_per_level[level_backup] - 1; // so to start from 0
+
+          parent_node_to_children_nodes[{n_nodes_per_level[level_backup - 1],
+                                         level_backup - 1}]
+            .push_back(node_idx);
+
+          level = level_backup;
+        }
+    }
+
+
+
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    void
+    Rtree_visitor<Value, Options, Translator, Box, Allocators>::operator()(
+      const Rtree_visitor::Leaf &leaf)
+    {
+      using elements_type =
+        typename boost::geometry::index::detail::rtree::elements_type<
+          Leaf>::type; //  pairs of bounding box and pointer to child node
+      const elements_type &elements =
+        boost::geometry::index::detail::rtree::elements(leaf);
+
+      for (const auto &it : elements)
+        agglomerates[node_counter].push_back(it.second);
+    }
+  } // namespace internal
+
+
+
+  /**
+   * Helper class which handles agglomeration based on the R-tree data
+   * structure. Notice that the R-tree type is assumed to be an R-star-tree.
+   */
+  template <int dim, typename RtreeType>
+  class CellsAgglomerator
+  {
+  public:
+    /**
+     * Constructor. It takes a given rtree and an integer representing the
+     * index of the level to be extracted.
+     */
+    CellsAgglomerator(const RtreeType   &rtree,
+                      const unsigned int extraction_level);
+
+    /**
+     * Extract agglomerates based on the current tree and the extraction level.
+     * This function returns a reference to
+     */
+    const std::vector<
+      std::vector<typename Triangulation<dim>::active_cell_iterator>> &
+    extract_agglomerates();
+
+    /**
+     * Get total number of levels.
+     */
+    inline unsigned int
+    get_n_levels() const;
+
+    /**
+     * Return the number of nodes present in level @p level.
+     */
+    inline std::size_t
+    get_n_nodes_per_level(const unsigned int level) const;
+
+    /**
+     * This function returns a map which associates to each node on level
+     * @p extraction_level a list of children.
+     */
+    inline const std::map<std::pair<std::size_t, std::size_t>,
+                          std::vector<std::size_t>> &
+    get_hierarchy() const;
+
+
+  private:
+    /**
+     * Raw pointer to the actual R-tree.
+     */
+    RtreeType *rtree;
+
+    /**
+     * Extraction level.
+     */
+    const unsigned int extraction_level;
+
+    /**
+     * Store agglomerates obtained after recursive extraction on nodes of
+     * level @p extraction_level.
+     */
+    std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+      agglomerates_on_level;
+
+    /**
+     * Vector storing the number of nodes (and, ultimately, agglomerates) for
+     * each level.
+     */
+    std::vector<std::size_t> n_nodes_per_level;
+
+    /**
+     * Map which maps a node parent @n on level @p l to a vector of integers
+     * which stores the index of children.
+     */
+    std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+      parent_node_to_children_nodes;
+  };
+
+
+
+  template <int dim, typename RtreeType>
+  CellsAgglomerator<dim, RtreeType>::CellsAgglomerator(
+    const RtreeType   &tree,
+    const unsigned int extraction_level_)
+    : extraction_level(extraction_level_)
+  {
+    rtree = const_cast<RtreeType *>(&tree);
+    Assert(n_levels(*rtree), ExcMessage("At least two levels are needed."));
+  }
+
+
+
+  template <int dim, typename RtreeType>
+  const std::vector<
+    std::vector<typename Triangulation<dim>::active_cell_iterator>> &
+  CellsAgglomerator<dim, RtreeType>::extract_agglomerates()
+  {
+    using RtreeView =
+      boost::geometry::index::detail::rtree::utilities::view<RtreeType>;
+    RtreeView rtv(*rtree);
+
+    n_nodes_per_level.resize(
+      rtv.depth()); // store how many nodes we have for each level.
+
+    if (rtv.depth() == 0)
+      {
+        // The below algorithm does not work for `rtv.depth()==0`, which might
+        // happen if the number entries in the tree is too small.
+        agglomerates_on_level.resize(1);
+        agglomerates_on_level[0].resize(1);
+      }
+    else
+      {
+        const unsigned int target_level =
+          std::min<unsigned int>(extraction_level, rtv.depth());
+
+        internal::Rtree_visitor<typename RtreeView::value_type,
+                                typename RtreeView::options_type,
+                                typename RtreeView::translator_type,
+                                typename RtreeView::box_type,
+                                typename RtreeView::allocators_type>
+          extractor_visitor(rtv.translator(),
+                            target_level,
+                            agglomerates_on_level,
+                            n_nodes_per_level,
+                            parent_node_to_children_nodes);
+
+
+        rtv.apply_visitor(extractor_visitor);
+      }
+    return agglomerates_on_level;
+  }
+
+
+
+  // ------------------------------ inline functions -------------------------
+
+
+  template <int dim, typename RtreeType>
+  inline unsigned int
+  CellsAgglomerator<dim, RtreeType>::get_n_levels() const
+  {
+    return n_levels(*rtree);
+  }
+
+
+
+  template <int dim, typename RtreeType>
+  inline std::size_t
+  CellsAgglomerator<dim, RtreeType>::get_n_nodes_per_level(
+    const unsigned int level) const
+  {
+    return n_nodes_per_level[level];
+  }
+
+
+
+  template <int dim, typename RtreeType>
+  inline const std::map<std::pair<std::size_t, std::size_t>,
+                        std::vector<std::size_t>> &
+  CellsAgglomerator<dim, RtreeType>::get_hierarchy() const
+  {
+    Assert(parent_node_to_children_nodes.size(),
+           ExcMessage(
+             "The hierarchy has not been computed. Did you forget to call"
+             " extract_agglomerates() first?"));
+    return parent_node_to_children_nodes;
+  }
+} // namespace dealii
+#endif

--- a/include/agglomerator.h
+++ b/include/agglomerator.h
@@ -47,10 +47,10 @@ namespace dealii
         const unsigned int target_level,
         std::vector<std::vector<typename Triangulation<
           boost::geometry::dimension<Box>::value>::active_cell_iterator>>
-                                 &agglomerates_,
-        std::vector<std::size_t> &n_nodes_per_level,
-        std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
-          &parent_to_children);
+                                                        &agglomerates_,
+        std::vector<types::global_cell_index>           &n_nodes_per_level,
+        std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+                 std::vector<types::global_cell_index>> &parent_to_children);
 
       /**
        * An alias that identifies an InternalNode of the tree.
@@ -122,13 +122,14 @@ namespace dealii
       /**
        * Store the total number of nodes on each level.
        */
-      std::vector<std::size_t> &n_nodes_per_level;
+      std::vector<types::global_cell_index> &n_nodes_per_level;
 
       /**
        * Map that associates to a given node on level l its children, identified
        * by their integer index.
        */
-      std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+      std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+               std::vector<types::global_cell_index>>
         &parent_node_to_children_nodes;
     };
 
@@ -144,10 +145,10 @@ namespace dealii
       const unsigned int target_level,
       std::vector<std::vector<typename Triangulation<
         boost::geometry::dimension<Box>::value>::active_cell_iterator>>
-                               &agglomerates_,
-      std::vector<std::size_t> &n_nodes_per_level_,
-      std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
-        &parent_to_children)
+                                                      &agglomerates_,
+      std::vector<types::global_cell_index>           &n_nodes_per_level_,
+      std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+               std::vector<types::global_cell_index>> &parent_to_children)
       : translator(translator)
       , level(0)
       , node_counter(0)
@@ -227,7 +228,7 @@ namespace dealii
           // done with node on level l > target_level (not just
           // "target_level+1).
           n_nodes_per_level[level_backup]++;
-          const std::size_t node_idx =
+          const types::global_cell_index node_idx =
             n_nodes_per_level[level_backup] - 1; // so to start from 0
 
           parent_node_to_children_nodes[{n_nodes_per_level[level_backup - 1],
@@ -294,15 +295,16 @@ namespace dealii
     /**
      * Return the number of nodes present in level @p level.
      */
-    inline std::size_t
+    inline types::global_cell_index
     get_n_nodes_per_level(const unsigned int level) const;
 
     /**
      * This function returns a map which associates to each node on level
      * @p extraction_level a list of children.
      */
-    inline const std::map<std::pair<std::size_t, std::size_t>,
-                          std::vector<std::size_t>> &
+    inline const std::map<
+      std::pair<types::global_cell_index, types::global_cell_index>,
+      std::vector<types::global_cell_index>> &
     get_hierarchy() const;
 
 
@@ -328,13 +330,14 @@ namespace dealii
      * Vector storing the number of nodes (and, ultimately, agglomerates) for
      * each level.
      */
-    std::vector<std::size_t> n_nodes_per_level;
+    std::vector<types::global_cell_index> n_nodes_per_level;
 
     /**
      * Map which maps a node parent @n on level @p l to a vector of integers
      * which stores the index of children.
      */
-    std::map<std::pair<std::size_t, std::size_t>, std::vector<std::size_t>>
+    std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+             std::vector<types::global_cell_index>>
       parent_node_to_children_nodes;
   };
 
@@ -408,7 +411,7 @@ namespace dealii
 
 
   template <int dim, typename RtreeType>
-  inline std::size_t
+  inline types::global_cell_index
   CellsAgglomerator<dim, RtreeType>::get_n_nodes_per_level(
     const unsigned int level) const
   {
@@ -418,8 +421,9 @@ namespace dealii
 
 
   template <int dim, typename RtreeType>
-  inline const std::map<std::pair<std::size_t, std::size_t>,
-                        std::vector<std::size_t>> &
+  inline const std::map<
+    std::pair<types::global_cell_index, types::global_cell_index>,
+    std::vector<types::global_cell_index>> &
   CellsAgglomerator<dim, RtreeType>::get_hierarchy() const
   {
     Assert(parent_node_to_children_nodes.size(),

--- a/include/multigrid_amg.h
+++ b/include/multigrid_amg.h
@@ -34,7 +34,7 @@ namespace dealii
    * Galerkin projection.
    */
   template <int dim, typename Number = double>
-  class MatrixFreeAMG
+  class MatrixFreeProjector
   {
   public:
     using VectorType = LinearAlgebra::distributed::Vector<Number>;
@@ -42,7 +42,7 @@ namespace dealii
      * Constructor. It takes the matrix-free operator evaluation on the finest
      * level, and a series of transfers from levels.
      */
-    MatrixFreeAMG(
+    MatrixFreeProjector(
       const MatrixFreeOperators::
         Base<dim, LinearAlgebra::distributed::Vector<Number>> &mf_operator,
       const std::vector<TrilinosWrappers::SparseMatrix *>      transfers);

--- a/include/multigrid_amg.h
+++ b/include/multigrid_amg.h
@@ -1,0 +1,88 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+#ifndef multigrid_amg_h
+#define multigrid_amg_h
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/mg_level_object.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/linear_operator.h>
+
+#include <deal.II/matrix_free/operators.h>
+
+namespace dealii
+{
+  /**
+   * This class is responsible for the setup of level matrices for a given
+   * (matrix-free) operator evaluation. Such level matrices are the "level
+   * matrices" to be used in a multigrid method. The difference compared to
+   * standard multilevel methods is that we construct such matrices using a
+   * Galerkin projection.
+   */
+  template <int dim, typename Number = double>
+  class MatrixFreeAMG
+  {
+  public:
+    using VectorType = LinearAlgebra::distributed::Vector<Number>;
+    /**
+     * Constructor. It takes the matrix-free operator evaluation on the finest
+     * level, and a series of transfers from levels.
+     */
+    MatrixFreeAMG(
+      const MatrixFreeOperators::
+        Base<dim, LinearAlgebra::distributed::Vector<Number>> &mf_operator,
+      const std::vector<TrilinosWrappers::SparseMatrix *>      transfers);
+
+    /**
+     * Initialize level matrices using the operator evaluation and the transfer
+     * matrices provided in the constructor.
+     *
+     * In particular, matrix[0]= A0, while for the other levels it holds that:
+     * matrix[l] = P_l^T A0 P_l, being P_l the injection from the fine level
+     * (indexed by 0) and level l.
+     */
+    void
+    compute_level_matrices(
+      MGLevelObject<LinearOperator<VectorType, VectorType>> &mg_matrices);
+
+  private:
+    MPI_Comm communicator;
+
+    /**
+     * Matrix-free operator evaluation.
+     */
+    const MatrixFreeOperators::Base<dim, VectorType> *mf_operator;
+
+    /**
+     * Vector of (pointers of) Trilinos Matrices storing two-level projections.
+     */
+    std::vector<TrilinosWrappers::SparseMatrix *> transfer_matrices;
+
+    /**
+     * LinearOperator for each level, storing Galerkin projections.
+     */
+    std::vector<LinearOperator<VectorType, VectorType>> level_operators;
+
+    /**
+     * For matrix-free operator evaluation
+     */
+    LinearOperator<VectorType, VectorType> mf_linear_operator;
+  };
+} // namespace dealii
+
+
+#endif

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -3,7 +3,7 @@ SET(_d2_build_types "Release;Debug")
 SET(Release_postfix "")
 SET(Debug_postfix ".g")
 
-set(_files agglomeration_handler.cc)
+set(_files agglomeration_handler.cc multigrid_amg.cc)
 
 FOREACH(_build_type ${_d2_build_types})
   # Postfix to use everywhere

--- a/source/multigrid_amg.cc
+++ b/source/multigrid_amg.cc
@@ -17,7 +17,7 @@
 namespace dealii
 {
   template <int dim, typename Number>
-  MatrixFreeAMG<dim, Number>::MatrixFreeAMG(
+  MatrixFreeProjector<dim, Number>::MatrixFreeProjector(
     const MatrixFreeOperators::Base<dim,
                                     LinearAlgebra::distributed::Vector<Number>>
                                                        &mf_operator_,
@@ -106,7 +106,7 @@ namespace dealii
 
   template <int dim, typename Number>
   void
-  MatrixFreeAMG<dim, Number>::compute_level_matrices(
+  MatrixFreeProjector<dim, Number>::compute_level_matrices(
     MGLevelObject<LinearOperator<VectorType, VectorType>> &mg_matrices)
   {
     using VectorType            = LinearAlgebra::distributed::Vector<Number>;
@@ -125,9 +125,9 @@ namespace dealii
   }
 
   // explicit instantiations
-  template class MatrixFreeAMG<1, double>;
-  template class MatrixFreeAMG<2, double>;
-  template class MatrixFreeAMG<3, double>;
+  template class MatrixFreeProjector<1, double>;
+  template class MatrixFreeProjector<2, double>;
+  template class MatrixFreeProjector<3, double>;
 
 
 } // namespace dealii

--- a/source/multigrid_amg.cc
+++ b/source/multigrid_amg.cc
@@ -1,0 +1,133 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+#include <agglomeration_handler.h>
+#include <multigrid_amg.h>
+
+namespace dealii
+{
+  template <int dim, typename Number>
+  MatrixFreeAMG<dim, Number>::MatrixFreeAMG(
+    const MatrixFreeOperators::Base<dim,
+                                    LinearAlgebra::distributed::Vector<Number>>
+                                                       &mf_operator_,
+    const std::vector<TrilinosWrappers::SparseMatrix *> transfers_)
+  {
+    using VectorType = LinearAlgebra::distributed::Vector<Number>;
+
+    // Check parallel layout is identical on every level
+    for (unsigned int l = 0; l < transfers_.size(); ++l)
+      Assert((mf_operator_.get_matrix_free()->get_locally_owned_set() ==
+              transfers_[l]->locally_owned_range_indices()),
+             ExcInternalError());
+
+    transfer_matrices.resize(transfers_.size());
+    level_operators.resize(transfers_.size());
+    // get communicator from first Trilinos matrix
+    communicator = transfers_[0]->get_mpi_communicator();
+
+    for (unsigned int l = 0; l < transfers_.size(); ++l)
+      {
+        // Set the pointer to the correct matrix
+        transfer_matrices[l] = transfers_[l];
+
+        // Define vmult-type lambdas for each linear operator.
+        level_operators[l].vmult = [this, l](VectorType       &dst,
+                                             const VectorType &src) {
+          transfer_matrices[l]->vmult(dst, src);
+        };
+        level_operators[l].vmult_add = [this, l](VectorType       &dst,
+                                                 const VectorType &src) {
+          transfer_matrices[l]->vmult_add(dst, src);
+        };
+        level_operators[l].Tvmult = [this, l](VectorType       &dst,
+                                              const VectorType &src) {
+          transfer_matrices[l]->Tvmult(dst, src);
+        };
+        level_operators[l].Tvmult_add = [this, l](VectorType       &dst,
+                                                  const VectorType &src) {
+          transfer_matrices[l]->Tvmult_add(dst, src);
+        };
+
+        // Inform each linear operator about the parallel layout. Use the given
+        // trilinos matrices.
+        level_operators[l].reinit_domain_vector = [this, l](VectorType &v,
+                                                            bool) {
+          v.reinit(transfer_matrices[l]->locally_owned_domain_indices(),
+                   communicator);
+        };
+
+        level_operators[l].reinit_range_vector = [this, l](VectorType &v,
+                                                           bool) {
+          v.reinit(transfer_matrices[l]->locally_owned_range_indices(),
+                   communicator);
+        };
+      }
+
+    // Do the same for the matrix-free object.
+    // First, set the pointer
+    mf_operator = &mf_operator_;
+
+    // Then, populate the corresponding lambdas (std::functions)
+    mf_linear_operator.vmult = [this](VectorType &dst, const VectorType &src) {
+      mf_operator->vmult(dst, src);
+    };
+    mf_linear_operator.vmult_add = [this](VectorType       &dst,
+                                          const VectorType &src) {
+      mf_operator->vmult_add(dst, src);
+    };
+    mf_linear_operator.Tvmult = [this](VectorType &dst, const VectorType &src) {
+      mf_operator->Tvmult(dst, src);
+    };
+    mf_linear_operator.Tvmult_add = [this](VectorType       &dst,
+                                           const VectorType &src) {
+      mf_operator->Tvmult_add(dst, src);
+    };
+
+    mf_linear_operator.reinit_domain_vector = [&](VectorType &v, bool) {};
+    mf_linear_operator.reinit_range_vector  = [&](VectorType &v, bool) {
+      v.reinit(
+        mf_operator->get_matrix_free()->get_dof_handler().locally_owned_dofs(),
+        communicator);
+    };
+  }
+
+
+
+  template <int dim, typename Number>
+  void
+  MatrixFreeAMG<dim, Number>::compute_level_matrices(
+    MGLevelObject<LinearOperator<VectorType, VectorType>> &mg_matrices)
+  {
+    using VectorType            = LinearAlgebra::distributed::Vector<Number>;
+    const unsigned int n_levels = mg_matrices.n_levels();
+    Assert(n_levels > 1, ExcMessage("Vector of matrices set to invalid size."));
+    Assert(!mf_linear_operator.is_null_operator, ExcInternalError());
+    const unsigned int min_level = mg_matrices.min_level();
+    const unsigned int max_level = mg_matrices.max_level();
+
+    mg_matrices[min_level] = mf_linear_operator; // finest level
+
+    // do the same, but using transfers to define level matrices
+    for (unsigned int l = min_level + 1; l < max_level; l++)
+      mg_matrices[l] = transpose_operator(level_operators[l - 1]) *
+                       mf_linear_operator * level_operators[l - 1];
+  }
+
+  // explicit instantiations
+  template class MatrixFreeAMG<1, double>;
+  template class MatrixFreeAMG<2, double>;
+  template class MatrixFreeAMG<3, double>;
+
+
+} // namespace dealii

--- a/test/polydeal/coarse_operator_from_matrix_free.cc
+++ b/test/polydeal/coarse_operator_from_matrix_free.cc
@@ -530,10 +530,9 @@ TestMGMatrix<dim>::make_fine_grid(const unsigned int n_global_refinements)
       //   std::ifstream abaqus_file("../../meshes/piston_3.inp"); // piston
       //   mesh
       std::ifstream gmsh_file(
-        "../../meshes/t3.msh"); // unstructured square [0,1]^2
-                                //   grid_in.read_abaqus(abaqus_file);
+        SOURCE_DIR "/input_grids/square.msh"); // unstructured square [0,1]^2
       grid_in.read_msh(gmsh_file);
-      tria.refine_global(5); // 4
+      tria.refine_global(n_global_refinements - 2); // 4
     }
   else if (grid_type == GridType::grid_generator)
     {
@@ -709,7 +708,7 @@ template <int dim>
 void
 TestMGMatrix<dim>::run()
 {
-  make_fine_grid(6); // 6 global refinements of unit cube
+  make_fine_grid(6);
   agglomerate_and_compute_level_matrices();
   pcout << std::endl;
 }
@@ -731,7 +730,8 @@ main(int argc, char *argv[])
   std::array<Function<dim> *, 3>   functions{{&constant, &x, &xpy}};
 
   for (const Function<dim> *func : functions)
-    for (const GridType &grid_type : {GridType::grid_generator})
+    for (const GridType &grid_type :
+         {GridType::grid_generator, GridType::unstructured})
       {
         TestMGMatrix<dim> problem(grid_type,
                                   degree_finite_element,

--- a/test/polydeal/coarse_operator_from_matrix_free.cc
+++ b/test/polydeal/coarse_operator_from_matrix_free.cc
@@ -660,7 +660,7 @@ TestMGMatrix<dim>::agglomerate_and_compute_level_matrices()
   std::vector<TrilinosWrappers::SparseMatrix *> transfers(1);
   transfers[0] = &embedding_matrix;
 
-  MatrixFreeAMG<dim, double> mf_amg(system_matrix, transfers);
+  MatrixFreeProjector<dim, double> mf_amg(system_matrix, transfers);
   using VectorType = LinearAlgebra::distributed::Vector<double>;
   MGLevelObject<LinearOperator<VectorType, VectorType>> mg_matrices(0, 2);
   mf_amg.compute_level_matrices(mg_matrices);

--- a/test/polydeal/coarse_operator_from_matrix_free.cc
+++ b/test/polydeal/coarse_operator_from_matrix_free.cc
@@ -1,0 +1,742 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// Check the Galerkin projection of a matrix-free operator on coarser,
+// agglomerate, levels.
+
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/function_lib.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/linear_operator_tools.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+#include <deal.II/matrix_free/matrix_free.h>
+#include <deal.II/matrix_free/operators.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools_integrate_difference.templates.h>
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <agglomeration_handler.h>
+#include <agglomerator.h>
+#include <multigrid_amg.h>
+#include <poly_utils.h>
+
+using namespace dealii;
+
+static constexpr unsigned int degree_finite_element = 1;
+
+template <int dim, int spacedim, typename MatrixType>
+void
+fill_interpolation_matrix(
+  const AgglomerationHandler<dim, spacedim> &agglomeration_handler,
+  MatrixType                                &interpolation_matrix)
+{
+  Assert((dim == spacedim), ExcNotImplemented());
+
+  using NumberType = typename MatrixType::value_type;
+  constexpr bool is_trilinos_matrix =
+    std::is_same_v<MatrixType, TrilinosWrappers::MPI::Vector>;
+
+  [[maybe_unused]]
+  typename std::conditional_t<!is_trilinos_matrix, SparsityPattern, void *>
+    sp;
+
+  // Get some info from the handler
+  const DoFHandler<dim, spacedim> &agglo_dh = agglomeration_handler.agglo_dh;
+
+  DoFHandler<dim, spacedim> *output_dh =
+    const_cast<DoFHandler<dim, spacedim> *>(&agglomeration_handler.output_dh);
+  const FiniteElement<dim, spacedim> &fe = agglomeration_handler.get_fe();
+  const Triangulation<dim, spacedim> &tria =
+    agglomeration_handler.get_triangulation();
+  const auto &bboxes = agglomeration_handler.get_local_bboxes();
+
+  // Setup an auxiliary DoFHandler for output purposes
+  output_dh->reinit(tria);
+  output_dh->distribute_dofs(fe);
+
+  const IndexSet &locally_owned_dofs = output_dh->locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(*output_dh);
+
+  const IndexSet &locally_owned_dofs_agglo = agglo_dh.locally_owned_dofs();
+
+
+  DynamicSparsityPattern dsp(output_dh->n_dofs(), agglo_dh.n_dofs());
+
+  std::vector<types::global_dof_index> agglo_dof_indices(fe.dofs_per_cell);
+  std::vector<types::global_dof_index> standard_dof_indices(fe.dofs_per_cell);
+  std::vector<types::global_dof_index> output_dof_indices(fe.dofs_per_cell);
+
+  Quadrature<dim>         quad(fe.get_unit_support_points());
+  FEValues<dim, spacedim> output_fe_values(fe, quad, update_quadrature_points);
+
+  for (const auto &cell : agglo_dh.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        if (agglomeration_handler.is_master_cell(cell))
+          {
+            auto slaves = agglomeration_handler.get_slaves_of_idx(
+              cell->active_cell_index());
+            slaves.emplace_back(cell);
+
+            cell->get_dof_indices(agglo_dof_indices);
+
+            for (const auto &slave : slaves)
+              {
+                // addd master-slave relationship
+                const auto slave_output =
+                  slave->as_dof_handler_iterator(*output_dh);
+                slave_output->get_dof_indices(output_dof_indices);
+                for (const auto row : output_dof_indices)
+                  dsp.add_entries(row,
+                                  agglo_dof_indices.begin(),
+                                  agglo_dof_indices.end());
+              }
+          }
+      }
+
+
+  const auto assemble_interpolation_matrix = [&]() {
+    FullMatrix<NumberType>  local_matrix(fe.dofs_per_cell, fe.dofs_per_cell);
+    std::vector<Point<dim>> reference_q_points(fe.dofs_per_cell);
+
+    // Dummy AffineConstraints, only needed for loc2glb
+    AffineConstraints<NumberType> c;
+    c.close();
+
+    for (const auto &cell : agglo_dh.active_cell_iterators())
+      if (cell->is_locally_owned())
+        {
+          if (agglomeration_handler.is_master_cell(cell))
+            {
+              auto slaves = agglomeration_handler.get_slaves_of_idx(
+                cell->active_cell_index());
+              slaves.emplace_back(cell);
+
+              cell->get_dof_indices(agglo_dof_indices);
+
+              const types::global_cell_index polytope_index =
+                agglomeration_handler.cell_to_polytope_index(cell);
+
+              // Get the box of this agglomerate.
+              const BoundingBox<dim> &box = bboxes[polytope_index];
+
+              for (const auto &slave : slaves)
+                {
+                  // add master-slave relationship
+                  const auto slave_output =
+                    slave->as_dof_handler_iterator(*output_dh);
+
+                  slave_output->get_dof_indices(output_dof_indices);
+                  output_fe_values.reinit(slave_output);
+
+                  local_matrix = 0.;
+
+                  const auto &q_points =
+                    output_fe_values.get_quadrature_points();
+                  for (const auto i : output_fe_values.dof_indices())
+                    {
+                      const auto &p = box.real_to_unit(q_points[i]);
+                      for (const auto j : output_fe_values.dof_indices())
+                        {
+                          local_matrix(i, j) = fe.shape_value(j, p);
+                        }
+                    }
+                  c.distribute_local_to_global(local_matrix,
+                                               output_dof_indices,
+                                               agglo_dof_indices,
+                                               interpolation_matrix);
+                }
+            }
+        }
+  };
+
+
+  if constexpr (std::is_same_v<MatrixType, TrilinosWrappers::SparseMatrix>)
+    {
+      const MPI_Comm &communicator = tria.get_communicator();
+      SparsityTools::distribute_sparsity_pattern(dsp,
+                                                 locally_owned_dofs,
+                                                 communicator,
+                                                 locally_relevant_dofs);
+
+      interpolation_matrix.reinit(locally_owned_dofs,
+                                  locally_owned_dofs_agglo,
+                                  dsp,
+                                  communicator);
+      assemble_interpolation_matrix();
+    }
+  else if constexpr (std::is_same_v<MatrixType, SparseMatrix<NumberType>>)
+    {
+      sp.copy_from(dsp);
+      interpolation_matrix.reinit(sp);
+      assemble_interpolation_matrix();
+    }
+  else
+    {
+      // PETSc, LA::d::v options not implemented.
+      (void)agglomeration_handler;
+      AssertThrow(false, ExcNotImplemented());
+    }
+
+  // If tria is distributed
+  if (dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(&tria) !=
+      nullptr)
+    interpolation_matrix.compress(VectorOperation::add);
+}
+
+
+
+// Define coefficient needed by Matrix-free operator evaluation. Here, we set it
+// to 1.
+template <int dim>
+class Coefficient : public Function<dim>
+{
+public:
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  template <typename number>
+  number
+  value(const Point<dim, number> &p, const unsigned int component = 0) const;
+};
+
+
+
+template <int dim>
+template <typename number>
+number
+Coefficient<dim>::value(const Point<dim, number> &p,
+                        const unsigned int /*component*/) const
+{
+  (void)p;
+  return 1.;
+}
+
+
+
+template <int dim>
+double
+Coefficient<dim>::value(const Point<dim> &p, const unsigned int component) const
+{
+  return value<double>(p, component);
+}
+
+template <int dim, int fe_degree, typename number>
+class LaplaceOperator
+  : public MatrixFreeOperators::Base<dim,
+                                     LinearAlgebra::distributed::Vector<number>>
+{
+public:
+  using value_type = number;
+
+  LaplaceOperator();
+
+  void
+  clear() override;
+
+  void
+  evaluate_coefficient(const Coefficient<dim> &coefficient_function);
+
+  virtual void
+  compute_diagonal() override;
+
+private:
+  virtual void
+  apply_add(
+    LinearAlgebra::distributed::Vector<number>       &dst,
+    const LinearAlgebra::distributed::Vector<number> &src) const override;
+
+  void
+  local_apply(const MatrixFree<dim, number>                    &data,
+              LinearAlgebra::distributed::Vector<number>       &dst,
+              const LinearAlgebra::distributed::Vector<number> &src,
+              const std::pair<unsigned int, unsigned int> &cell_range) const;
+
+  void
+  local_compute_diagonal(
+    const MatrixFree<dim, number>               &data,
+    LinearAlgebra::distributed::Vector<number>  &dst,
+    const unsigned int                          &dummy,
+    const std::pair<unsigned int, unsigned int> &cell_range) const;
+
+  Table<2, VectorizedArray<number>> coefficient;
+};
+
+
+
+template <int dim, int fe_degree, typename number>
+LaplaceOperator<dim, fe_degree, number>::LaplaceOperator()
+  : MatrixFreeOperators::Base<dim, LinearAlgebra::distributed::Vector<number>>()
+{}
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+LaplaceOperator<dim, fe_degree, number>::clear()
+{
+  coefficient.reinit(0, 0);
+  MatrixFreeOperators::Base<dim, LinearAlgebra::distributed::Vector<number>>::
+    clear();
+}
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+LaplaceOperator<dim, fe_degree, number>::evaluate_coefficient(
+  const Coefficient<dim> &coefficient_function)
+{
+  const unsigned int n_cells = this->data->n_cell_batches();
+  FEEvaluation<dim, fe_degree, fe_degree + 1, 1, number> phi(*this->data);
+
+  coefficient.reinit(n_cells, phi.n_q_points);
+  for (unsigned int cell = 0; cell < n_cells; ++cell)
+    {
+      phi.reinit(cell);
+      for (const unsigned int q : phi.quadrature_point_indices())
+        coefficient(cell, q) =
+          coefficient_function.value(phi.quadrature_point(q));
+    }
+}
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+LaplaceOperator<dim, fe_degree, number>::local_apply(
+  const MatrixFree<dim, number>                    &data,
+  LinearAlgebra::distributed::Vector<number>       &dst,
+  const LinearAlgebra::distributed::Vector<number> &src,
+  const std::pair<unsigned int, unsigned int>      &cell_range) const
+{
+  FEEvaluation<dim, fe_degree, fe_degree + 1, 1, number> phi(data);
+
+  for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
+    {
+      AssertDimension(coefficient.size(0), data.n_cell_batches());
+      AssertDimension(coefficient.size(1), phi.n_q_points);
+
+      phi.reinit(cell);
+      phi.read_dof_values(src);
+      phi.evaluate(EvaluationFlags::gradients);
+      for (const unsigned int q : phi.quadrature_point_indices())
+        phi.submit_gradient(coefficient(cell, q) * phi.get_gradient(q), q);
+      phi.integrate(EvaluationFlags::gradients);
+      phi.distribute_local_to_global(dst);
+    }
+}
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+LaplaceOperator<dim, fe_degree, number>::apply_add(
+  LinearAlgebra::distributed::Vector<number>       &dst,
+  const LinearAlgebra::distributed::Vector<number> &src) const
+{
+  this->data->cell_loop(&LaplaceOperator::local_apply, this, dst, src);
+}
+
+
+
+template <int dim, int fe_degree, typename number>
+void
+LaplaceOperator<dim, fe_degree, number>::compute_diagonal()
+{
+  Assert(false, ExcInternalError());
+}
+
+
+// Then, define some functions for the test itself
+template <int dim>
+class XFunction : public Function<dim>
+{
+public:
+  XFunction()
+    : Function<dim>()
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+};
+
+template <int dim>
+double
+XFunction<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  return p[0];
+}
+
+
+
+template <int dim>
+void
+XFunction<dim>::value_list(const std::vector<Point<dim>> &points,
+                           std::vector<double>           &values,
+                           const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+
+
+template <int dim>
+class XplusYFunction : public Function<dim>
+{
+public:
+  XplusYFunction()
+    : Function<dim>()
+  {
+    Assert(dim > 1, ExcNotImplemented());
+  }
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+};
+
+
+
+template <int dim>
+double
+XplusYFunction<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  return p[0] + p[1];
+}
+
+
+
+template <int dim>
+void
+XplusYFunction<dim>::value_list(const std::vector<Point<dim>> &points,
+                                std::vector<double>           &values,
+                                const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+/*--------------------------------------------------------------------------*/
+
+
+
+enum class GridType
+{
+  grid_generator, // hyper_cube or hyper_ball
+  unstructured    // square generated with gmsh, unstructured
+};
+
+
+
+template <int dim>
+class TestMGMatrix
+{
+public:
+  TestMGMatrix(const GridType      &grid_type,
+               const unsigned int   degree,
+               const Function<dim> &func,
+               const MPI_Comm       comm);
+  void
+  run();
+
+private:
+  void
+  make_fine_grid(const unsigned int);
+  void
+  agglomerate_and_compute_level_matrices();
+
+  const MPI_Comm                                 comm;
+  const unsigned int                             n_ranks;
+  FE_DGQ<dim>                                    fe_dg;
+  const GridType                                &grid_type;
+  parallel::fullydistributed::Triangulation<dim> tria_pft;
+  DoFHandler<dim>                                dof_handler;
+  const Function<dim>                           &func;
+  ConditionalOStream                             pcout;
+
+  std::unique_ptr<AgglomerationHandler<dim>> agglomeration_handler;
+};
+
+
+
+template <int dim>
+TestMGMatrix<dim>::TestMGMatrix(const GridType      &grid_type_,
+                                const unsigned int   degree,
+                                const Function<dim> &func_,
+                                const MPI_Comm       communicator)
+  : comm(communicator)
+  , n_ranks(Utilities::MPI::n_mpi_processes(comm))
+  , fe_dg(degree)
+  , grid_type(grid_type_)
+  , tria_pft(comm)
+  , dof_handler(tria_pft)
+  , func(func_)
+  , pcout(std::cout, (Utilities::MPI::this_mpi_process(comm) == 0))
+{
+  pcout << "Running with " << n_ranks << " MPI ranks." << std::endl;
+  pcout << "Grid type:";
+  grid_type == GridType::grid_generator ?
+    pcout << " Structured square" << std::endl :
+    pcout << " Unstructured square" << std::endl;
+}
+
+
+
+template <int dim>
+void
+TestMGMatrix<dim>::make_fine_grid(const unsigned int n_global_refinements)
+{
+  Triangulation<dim> tria;
+
+  if (grid_type == GridType::unstructured)
+    {
+      GridIn<dim> grid_in;
+      grid_in.attach_triangulation(tria);
+      //   std::ifstream abaqus_file("../../meshes/piston_3.inp"); // piston
+      //   mesh
+      std::ifstream gmsh_file(
+        "../../meshes/t3.msh"); // unstructured square [0,1]^2
+                                //   grid_in.read_abaqus(abaqus_file);
+      grid_in.read_msh(gmsh_file);
+      tria.refine_global(5); // 4
+    }
+  else if (grid_type == GridType::grid_generator)
+    {
+      GridGenerator::hyper_cube(tria, 0., 1.);
+      tria.refine_global(n_global_refinements);
+    }
+  else
+    {
+      Assert(false, ExcInternalError());
+    }
+
+  // Partition serial triangulation:
+  GridTools::partition_triangulation(n_ranks, tria);
+
+  // Create building blocks:
+  const TriangulationDescription::Description<dim, dim> description =
+    TriangulationDescription::Utilities::create_description_from_triangulation(
+      tria, comm);
+
+  tria_pft.create_triangulation(description);
+}
+
+
+
+template <int dim>
+void
+TestMGMatrix<dim>::agglomerate_and_compute_level_matrices()
+{
+  GridTools::Cache<dim> cached_tria(tria_pft);
+
+
+
+  // Partition with Rtree locally to each partition.
+  MappingQ1<dim> mapping; // use standard mapping
+
+  namespace bgi = boost::geometry::index;
+  static constexpr unsigned int max_elem_per_node =
+    PolyUtils::constexpr_pow(2, dim); // 2^dim
+  std::vector<std::pair<BoundingBox<dim>,
+                        typename Triangulation<dim>::active_cell_iterator>>
+               boxes(tria_pft.n_locally_owned_active_cells());
+  unsigned int i = 0;
+  for (const auto &cell : tria_pft.active_cell_iterators())
+    if (cell->is_locally_owned())
+      boxes[i++] = std::make_pair(mapping.get_bounding_box(cell), cell);
+
+  auto tree = pack_rtree<bgi::rstar<max_elem_per_node>>(boxes);
+  Assert(n_levels(tree) >= 2, ExcMessage("At least two levels are needed."));
+  pcout << "Total number of available levels: " << n_levels(tree) << std::endl;
+
+  const unsigned int                     extraction_level = 2;
+  CellsAgglomerator<dim, decltype(tree)> agglomerator{tree,
+                                                      extraction_level + 1};
+  const auto agglomerates = agglomerator.extract_agglomerates();
+  agglomeration_handler =
+    std::make_unique<AgglomerationHandler<dim>>(cached_tria);
+  std::size_t agglo_index_fine = 0;
+  for (std::size_t i = 0; i < agglomerates.size(); ++i)
+    {
+      const auto &agglo = agglomerates[i]; // i-th agglomerate fine
+      for (const auto &el : agglo)
+        {
+          el->set_material_id(agglo_index_fine);
+        }
+      ++agglo_index_fine;
+    }
+
+  const unsigned int n_subdomains_fine = agglo_index_fine;
+  unsigned int       total_agglomerates_fine =
+    Utilities::MPI::sum(n_subdomains_fine, comm);
+  pcout << "Total fine agglomerates: " << total_agglomerates_fine << std::endl;
+
+  std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+    cells_per_subdomain_fine(n_subdomains_fine);
+  for (const auto &cell : tria_pft.active_cell_iterators())
+    if (cell->is_locally_owned())
+      cells_per_subdomain_fine[cell->material_id()].push_back(cell);
+
+  // For every subdomain, agglomerate elements together
+  for (std::size_t i = 0; i < cells_per_subdomain_fine.size(); ++i)
+    agglomeration_handler->define_agglomerate(cells_per_subdomain_fine[i]);
+
+  agglomeration_handler->initialize_fe_values(
+    QGauss<dim>(degree_finite_element + 1),
+    update_values | update_gradients | update_JxW_values |
+      update_quadrature_points,
+    QGauss<dim - 1>(degree_finite_element + 1),
+    update_JxW_values);
+  agglomeration_handler->distribute_agglomerated_dofs(fe_dg);
+
+  pcout << "Distributed DoFs" << std::endl;
+
+
+  // Check injection matrix
+  TrilinosWrappers::SparseMatrix embedding_matrix;
+  fill_interpolation_matrix(*agglomeration_handler, embedding_matrix);
+  pcout << "Injection matrix has size: (" << embedding_matrix.m() << ","
+        << embedding_matrix.n() << ")" << std::endl;
+
+  // Setup matrix-free object and operator.
+  AffineConstraints constraints;
+  constraints.close();
+
+  dof_handler.distribute_dofs(fe_dg);
+
+  typename MatrixFree<dim, double>::AdditionalData additional_data;
+  additional_data.tasks_parallel_scheme =
+    MatrixFree<dim, double>::AdditionalData::none;
+  additional_data.mapping_update_flags =
+    (update_gradients | update_JxW_values | update_quadrature_points);
+  std::shared_ptr<MatrixFree<dim, double>> system_mf_storage(
+    new MatrixFree<dim, double>());
+  system_mf_storage->reinit(mapping,
+                            dof_handler,
+                            constraints,
+                            QGauss<1>(fe_dg.degree + 1),
+                            additional_data);
+
+  LaplaceOperator<dim, degree_finite_element, double> system_matrix;
+  system_matrix.initialize(system_mf_storage);
+  system_matrix.evaluate_coefficient(Coefficient<dim>());
+
+  // Define transfer between levels.
+  std::vector<TrilinosWrappers::SparseMatrix *> transfers(1);
+  transfers[0] = &embedding_matrix;
+
+  MatrixFreeAMG<dim, double> mf_amg(system_matrix, transfers);
+  using VectorType = LinearAlgebra::distributed::Vector<double>;
+  MGLevelObject<LinearOperator<VectorType, VectorType>> mg_matrices(0, 2);
+  mf_amg.compute_level_matrices(mg_matrices);
+
+
+  //  Define dst, src for the fine space.
+  LinearAlgebra::distributed::Vector<double> fine_src;
+  fine_src.reinit(dof_handler.locally_owned_dofs(), comm);
+  LinearAlgebra::distributed::Vector<double> fine_dst;
+  fine_dst.reinit(dof_handler.locally_owned_dofs(), comm);
+
+  VectorTools::interpolate(mapping, dof_handler, func, fine_src);
+  system_matrix.vmult(fine_dst, fine_src);
+  const double test_operator_scalar_product = fine_src * fine_dst;
+  pcout << "Scalar product induced by fine operator: "
+        << test_operator_scalar_product << std::endl;
+
+
+  // Define dst, src for the coarse agglomerated space.
+  LinearAlgebra::distributed::Vector<double> src_coarse;
+  src_coarse.reinit(agglomeration_handler->agglo_dh.locally_owned_dofs(), comm);
+  LinearAlgebra::distributed::Vector<double> dst_coarse_op;
+  dst_coarse_op.reinit(agglomeration_handler->agglo_dh.locally_owned_dofs(),
+                       comm);
+  VectorTools::interpolate(*(agglomeration_handler->euler_mapping),
+                           agglomeration_handler->agglo_dh,
+                           func,
+                           src_coarse);
+  dst_coarse_op = mg_matrices[1] * src_coarse;
+  const double test_coarse_operator_scalar_product = src_coarse * dst_coarse_op;
+  pcout << "Scalar product induced by agglomerated operator: "
+        << test_coarse_operator_scalar_product << std::endl;
+
+#ifdef FALSE
+  pcout << "Size of resulting vector: " << dst_coarse_op.size() << std::endl;
+  for (const double x : dst_coarse_op)
+    pcout << x << std::endl;
+  pcout << "L2 norm: " << dst_coarse_op.l2_norm() << std::endl;
+  pcout << "L2 norm(fine): " << fine_dst.l2_norm() << std::endl;
+#endif
+}
+
+
+
+template <int dim>
+void
+TestMGMatrix<dim>::run()
+{
+  make_fine_grid(6); // 6 global refinements of unit cube
+  agglomerate_and_compute_level_matrices();
+  pcout << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  const MPI_Comm                   comm = MPI_COMM_WORLD;
+  static constexpr unsigned int    dim  = 2;
+
+
+  // number of agglomerates in each local subdomain
+  XFunction<dim>                   x;
+  XplusYFunction<dim>              xpy;
+  Functions::ConstantFunction<dim> constant(1.);
+  std::array<Function<dim> *, 3>   functions{{&constant, &x, &xpy}};
+
+  for (const Function<dim> *func : functions)
+    for (const GridType &grid_type : {GridType::grid_generator})
+      {
+        TestMGMatrix<dim> problem(grid_type,
+                                  degree_finite_element,
+                                  *func,
+                                  comm);
+        problem.run();
+      }
+}

--- a/test/polydeal/coarse_operator_from_matrix_free.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/test/polydeal/coarse_operator_from_matrix_free.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,27 @@
+Running with 3 MPI ranks.
+Grid type: Structured square
+Total number of available levels: 5
+Total fine agglomerates: 66
+Distributed DoFs
+Injection matrix has size: (16384,264)
+Scalar product induced by fine operator: 0
+Scalar product induced by agglomerated operator: 3.62691e-30
+
+Running with 3 MPI ranks.
+Grid type: Structured square
+Total number of available levels: 5
+Total fine agglomerates: 66
+Distributed DoFs
+Injection matrix has size: (16384,264)
+Scalar product induced by fine operator: 1
+Scalar product induced by agglomerated operator: 1
+
+Running with 3 MPI ranks.
+Grid type: Structured square
+Total number of available levels: 5
+Total fine agglomerates: 66
+Distributed DoFs
+Injection matrix has size: (16384,264)
+Scalar product induced by fine operator: 2
+Scalar product induced by agglomerated operator: 2
+

--- a/test/polydeal/coarse_operator_from_matrix_free.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/test/polydeal/coarse_operator_from_matrix_free.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -8,6 +8,15 @@ Scalar product induced by fine operator: 0
 Scalar product induced by agglomerated operator: 3.62691e-30
 
 Running with 3 MPI ranks.
+Grid type: Unstructured square
+Total number of available levels: 6
+Total fine agglomerates: 93
+Distributed DoFs
+Injection matrix has size: (93184,372)
+Scalar product induced by fine operator: 0
+Scalar product induced by agglomerated operator: 3.12216e-29
+
+Running with 3 MPI ranks.
 Grid type: Structured square
 Total number of available levels: 5
 Total fine agglomerates: 66
@@ -17,11 +26,29 @@ Scalar product induced by fine operator: 1
 Scalar product induced by agglomerated operator: 1
 
 Running with 3 MPI ranks.
+Grid type: Unstructured square
+Total number of available levels: 6
+Total fine agglomerates: 93
+Distributed DoFs
+Injection matrix has size: (93184,372)
+Scalar product induced by fine operator: 1
+Scalar product induced by agglomerated operator: 1
+
+Running with 3 MPI ranks.
 Grid type: Structured square
 Total number of available levels: 5
 Total fine agglomerates: 66
 Distributed DoFs
 Injection matrix has size: (16384,264)
+Scalar product induced by fine operator: 2
+Scalar product induced by agglomerated operator: 2
+
+Running with 3 MPI ranks.
+Grid type: Unstructured square
+Total number of available levels: 6
+Total fine agglomerates: 93
+Distributed DoFs
+Injection matrix has size: (93184,372)
 Scalar product induced by fine operator: 2
 Scalar product induced by agglomerated operator: 2
 


### PR DESCRIPTION
An implementation of a parallel transfer operator between possibly agglomerated levels is provided, named `MGTransferAgglomeration`. This class just takes:
- the intergrid transfers
- `DoFHandlers` for each level

and implements the interface required by `MGTransferBase`, providing prolongation and restriction methods across multigrid levels. Together with #109, it allows the usage of such transfer operator in a multigrid preconditioner.

The fact that the triangulation is always the same on each level implies that the `copy_to/from` levels can simply be performed by copying locally owned data. Tested locally on some unstructured meshes and with polynomial degrees up to $3$

Builds on top of #109, only relevant commit is [5b7f091](https://github.com/fdrmrc/Polydeal/pull/110/commits/5b7f09138eb69e259c164da98e6528e254c8d1cf).