### PR TITLE
Provide IndexSet to DynamicSparsityPattern

### DIFF
--- a/include/poly_utils.h
+++ b/include/poly_utils.h
@@ -559,7 +559,9 @@ namespace dealii::PolyUtils
     const IndexSet &locally_owned_dofs_agglo = agglo_dh.locally_owned_dofs();
 
 
-    DynamicSparsityPattern dsp(output_dh->n_dofs(), agglo_dh.n_dofs());
+    DynamicSparsityPattern dsp(output_dh->n_dofs(),
+                               agglo_dh.n_dofs(),
+                               output_dh->locally_owned_dofs());
 
     std::vector<types::global_dof_index> agglo_dof_indices(fe.dofs_per_cell);
     std::vector<types::global_dof_index> standard_dof_indices(fe.dofs_per_cell);


### PR DESCRIPTION
As noted upstream, without the index set the memory requirement in parallel is again O(n_dofs) instead of O(n_locally_owned_dofs).