### PR TITLE
Fix reinit of distributed vector using right signature

### DIFF
--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -165,7 +165,8 @@ AgglomerationHandler<dim, spacedim>::initialize_agglomeration_data(
     {
       const std::weak_ptr<const Utilities::MPI::Partitioner> cells_partitioner =
         parallel_tria->global_active_cell_index_partitioner();
-      master_slave_relationships.reinit(cells_partitioner.lock(), communicator);
+      master_slave_relationships.reinit(
+        cells_partitioner.lock()->locally_owned_range(), communicator);
 
       const IndexSet &local_eulerian_index_set = euler_dh.locally_owned_dofs();
       euler_vector.reinit(local_eulerian_index_set, communicator);


### PR DESCRIPTION
The previous version of `LA::d::V::reinit()` (https://dealii.org/developer/doxygen/deal.II/classLinearAlgebra_1_1distributed_1_1Vector.html#a3e6c69e780f5c612a7e52b2cf87ac84b) for the master-slave-relationships (distributed) vector was taking a shared ptr and a communicator `comm_sm`.  This signature assumes that `comm_sm`  consists of processes on the same shared-memory domain.

In larger experiments with more compute nodes this rightfully throws with message:
```
MPI_ERR_RMA_SHARED:
    Memory cannot be shared".
```

Fixed by calling the overload with IndexSet and communicator (the IndexSet argument is retrieved from the partitioner).
