### PR TITLE
Allow DGP elements

### DIFF
--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -22,6 +22,8 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_dgp.h>
+#include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nothing.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>

--- a/include/poly_utils.h
+++ b/include/poly_utils.h
@@ -30,6 +30,7 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
+#include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_values.h>
 
 #include <deal.II/grid/grid_tools.h>

--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -204,16 +204,15 @@ void
 AgglomerationHandler<dim, spacedim>::distribute_agglomerated_dofs(
   const FiniteElement<dim> &fe_space)
 {
-  Assert((std::is_same_v<const FE_DGQ<dim> &, decltype(fe_space)> ||
-          std::is_same_v<const FE_DGP<dim> &, decltype(fe_space)>),
-         ExcNotImplemented(
-           "Currently, this interface supports only DGQ and DGP bases."));
   if (dynamic_cast<const FE_DGQ<dim> *>(&fe_space))
     fe = std::make_unique<FE_DGQ<dim>>(fe_space.degree);
   else if (dynamic_cast<const FE_DGP<dim> *>(&fe_space))
     fe = std::make_unique<FE_DGP<dim>>(fe_space.degree);
   else
-    AssertThrow(false, ExcInternalError());
+    AssertThrow(
+      false,
+      ExcNotImplemented(
+        "Currently, this interface supports only DGQ and DGP bases."));
 
 
   if (hybrid_mesh)

--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -11,8 +11,6 @@
 // -----------------------------------------------------------------------------
 
 
-#include <deal.II/fe/fe_dgp.h>
-#include <deal.II/fe/fe_dgq.h>
 
 #include <deal.II/lac/sparsity_tools.h>
 

--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -11,6 +11,9 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/fe/fe_dgp.h>
+#include <deal.II/fe/fe_dgq.h>
+
 #include <deal.II/lac/sparsity_tools.h>
 
 #include <agglomeration_handler.h>
@@ -194,6 +197,58 @@ AgglomerationHandler<dim, spacedim>::initialize_agglomeration_data(
 
   connect_to_tria_signals();
   n_agglomerations = 0;
+}
+
+
+
+template <int dim, int spacedim>
+void
+AgglomerationHandler<dim, spacedim>::distribute_agglomerated_dofs(
+  const FiniteElement<dim> &fe_space)
+{
+  Assert((std::is_same_v<const FE_DGQ<dim> &, decltype(fe_space)> ||
+          std::is_same_v<const FE_DGP<dim> &, decltype(fe_space)>),
+         ExcNotImplemented(
+           "Currently, this interface supports only DGQ and DGP bases."));
+  if (dynamic_cast<const FE_DGQ<dim> *>(&fe_space))
+    fe = std::make_unique<FE_DGQ<dim>>(fe_space.degree);
+  else if (dynamic_cast<const FE_DGP<dim> *>(&fe_space))
+    fe = std::make_unique<FE_DGP<dim>>(fe_space.degree);
+  else
+    AssertThrow(false, ExcInternalError());
+
+
+  if (hybrid_mesh)
+    {
+      // the mesh is composed by standard and agglomerate cells. initialize
+      // classes needed for standard cells in order to treat that finite
+      // element space as defined on a standard shape and not on the
+      // BoundingBox.
+      standard_scratch =
+        std::make_unique<ScratchData>(*mapping,
+                                      *fe,
+                                      QGauss<dim>(2 * fe_space.degree + 2),
+                                      internal_agglomeration_flags);
+    }
+
+
+  fe_collection.push_back(*fe);                         // master
+  fe_collection.push_back(FE_Nothing<dim, spacedim>()); // slave
+
+  initialize_hp_structure();
+
+  // in case the tria is distributed, communicate ghost information with
+  // neighboring ranks
+  const bool needs_ghost_info =
+    dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(&*tria) !=
+    nullptr;
+  if (needs_ghost_info)
+    setup_ghost_polytopes();
+
+  setup_connectivity_of_agglomeration();
+
+  if (needs_ghost_info)
+    exchange_interface_values();
 }
 
 


### PR DESCRIPTION
Related to #127. DGP elements are now supported. They turn out to be convenient under p-refinement. See the next example, where the polynomial degree increases for a given unstructured polytopal mesh.

![image](https://github.com/user-attachments/assets/afa39a51-513e-41c3-86ee-97fe53a9292e)