### PR TITLE
Agglomerate using connected components 

### DIFF
--- a/examples/diffusion_reaction.cc
+++ b/examples/diffusion_reaction.cc
@@ -718,6 +718,8 @@ DiffusionReactionProblem<dim>::solve()
                                       interpolated_solution,
                                       completely_distributed_solution);
 
+  // Use other method to compute the error
+#ifdef FALSE
   Vector<double> cellwise_error(completely_distributed_solution.size());
   VectorTools::integrate_difference(ah->output_dh,
                                     interpolated_solution,
@@ -740,9 +742,19 @@ DiffusionReactionProblem<dim>::solve()
     VectorTools::compute_global_error(tria_pft,
                                       cellwise_error,
                                       VectorTools::NormType::H1_seminorm);
+#endif
 
-  pcout << "L2 error (exponential solution): " << error << std::endl;
-  pcout << "Semi H1 error (exponential solution): " << semiH1error << std::endl;
+  std::vector<double> global_errors;
+  PolyUtils::compute_global_error(*ah,
+                                  completely_distributed_solution,
+                                  Solution<dim>(),
+                                  {VectorTools::L2_norm,
+                                   VectorTools::H1_seminorm},
+                                  global_errors);
+
+  pcout << "L2 error (exponential solution): " << global_errors[0] << std::endl;
+  pcout << "Semi H1 error (exponential solution): " << global_errors[1]
+        << std::endl;
 }
 
 

--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -49,6 +49,7 @@
 
 #include <agglomeration_iterator.h>
 #include <agglomerator.h>
+#include <utils.h>
 
 #include <fstream>
 
@@ -282,6 +283,14 @@ public:
    */
   agglomeration_iterator
   define_agglomerate(const AgglomerationContainer &cells);
+
+  /**
+   * Same as above, but checking that every vector of cells is connected. If
+   * not, each connected component is agglomerated by calling the
+   * define_agglomerate() function defined above.
+   */
+  void
+  define_agglomerate_with_check(const AgglomerationContainer &cells);
 
   inline const Triangulation<dim, spacedim> &
   get_triangulation() const;

--- a/include/multigrid_amg.h
+++ b/include/multigrid_amg.h
@@ -19,6 +19,8 @@
 
 #include <deal.II/base/mg_level_object.h>
 
+#include <deal.II/fe/fe_dgq.h>
+
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include <deal.II/matrix_free/operators.h>

--- a/include/poly_utils.h
+++ b/include/poly_utils.h
@@ -41,6 +41,8 @@
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 
+#include <deal.II/numerics/vector_tools_common.h>
+
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/index/detail/rtree/utilities/print.hpp>
 #include <boost/geometry/index/rtree.hpp>
@@ -835,106 +837,75 @@ namespace dealii::PolyUtils
 
 
 
-  /**
-   * Given a vector @p src, typically the solution stemming after the
-   * agglomerate problem has been solved, this function interpolates @p src
-   * onto the finer grid and stores the result in vector @p dst.
-   *
-   * @note Supported parallel types are TrilinosWrappers::SparseMatrix and TrilinosWrappers::MPI::Vector
-   */
-  template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate_to_fine_grid(
-    const AgglomerationHandler<dim, spacedim> &agglomeration_handler,
-    VectorType                                &dst,
-    const VectorType                          &src)
+  namespace internal
   {
-    Assert((dim == spacedim), ExcNotImplemented());
-    Assert(
-      dst.size() == 0,
-      ExcMessage(
-        "The destination vector must the empt upon calling this function."));
+    /**
+     * Same as the public free function with the same name, but storing
+     * explicitly the interpolation matrix and performing interpolation through
+     * matrix-vector product.
+     */
+    template <int dim, int spacedim, typename VectorType>
+    void
+    interpolate_to_fine_grid(
+      const AgglomerationHandler<dim, spacedim> &agglomeration_handler,
+      VectorType                                &dst,
+      const VectorType                          &src)
+    {
+      Assert((dim == spacedim), ExcNotImplemented());
+      Assert(
+        dst.size() == 0,
+        ExcMessage(
+          "The destination vector must the empt upon calling this function."));
 
-    using NumberType = typename VectorType::value_type;
-    constexpr bool is_trilinos_vector =
-      std::is_same_v<VectorType, TrilinosWrappers::MPI::Vector>;
-    using MatrixType = std::conditional_t<is_trilinos_vector,
-                                          TrilinosWrappers::SparseMatrix,
-                                          SparseMatrix<NumberType>>;
+      using NumberType = typename VectorType::value_type;
+      constexpr bool is_trilinos_vector =
+        std::is_same_v<VectorType, TrilinosWrappers::MPI::Vector>;
+      using MatrixType = std::conditional_t<is_trilinos_vector,
+                                            TrilinosWrappers::SparseMatrix,
+                                            SparseMatrix<NumberType>>;
 
-    MatrixType interpolation_matrix;
+      MatrixType interpolation_matrix;
 
-    [[maybe_unused]]
-    typename std::conditional_t<!is_trilinos_vector, SparsityPattern, void *>
-      sp;
+      [[maybe_unused]]
+      typename std::conditional_t<!is_trilinos_vector, SparsityPattern, void *>
+        sp;
 
-    // Get some info from the handler
-    const DoFHandler<dim, spacedim> &agglo_dh = agglomeration_handler.agglo_dh;
+      // Get some info from the handler
+      const DoFHandler<dim, spacedim> &agglo_dh =
+        agglomeration_handler.agglo_dh;
 
-    DoFHandler<dim, spacedim> *output_dh =
-      const_cast<DoFHandler<dim, spacedim> *>(&agglomeration_handler.output_dh);
-    const FiniteElement<dim, spacedim> &fe = agglomeration_handler.get_fe();
-    const Triangulation<dim, spacedim> &tria =
-      agglomeration_handler.get_triangulation();
-    const auto &bboxes = agglomeration_handler.get_local_bboxes();
+      DoFHandler<dim, spacedim> *output_dh =
+        const_cast<DoFHandler<dim, spacedim> *>(
+          &agglomeration_handler.output_dh);
+      const FiniteElement<dim, spacedim> &fe = agglomeration_handler.get_fe();
+      const Triangulation<dim, spacedim> &tria =
+        agglomeration_handler.get_triangulation();
+      const auto &bboxes = agglomeration_handler.get_local_bboxes();
 
-    // Setup an auxiliary DoFHandler for output purposes
-    output_dh->reinit(tria);
-    output_dh->distribute_dofs(fe);
+      // Setup an auxiliary DoFHandler for output purposes
+      output_dh->reinit(tria);
+      output_dh->distribute_dofs(fe);
 
-    const IndexSet &locally_owned_dofs = output_dh->locally_owned_dofs();
-    const IndexSet  locally_relevant_dofs =
-      DoFTools::extract_locally_relevant_dofs(*output_dh);
+      const IndexSet &locally_owned_dofs = output_dh->locally_owned_dofs();
+      const IndexSet  locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(*output_dh);
 
-    const IndexSet &locally_owned_dofs_agglo = agglo_dh.locally_owned_dofs();
-
-
-    DynamicSparsityPattern dsp(output_dh->n_dofs(),
-                               agglo_dh.n_dofs(),
-                               locally_relevant_dofs);
-
-    std::vector<types::global_dof_index> agglo_dof_indices(fe.dofs_per_cell);
-    std::vector<types::global_dof_index> standard_dof_indices(fe.dofs_per_cell);
-    std::vector<types::global_dof_index> output_dof_indices(fe.dofs_per_cell);
-
-    Quadrature<dim>         quad(fe.get_unit_support_points());
-    FEValues<dim, spacedim> output_fe_values(fe,
-                                             quad,
-                                             update_quadrature_points);
-
-    for (const auto &cell : agglo_dh.active_cell_iterators())
-      if (cell->is_locally_owned())
-        {
-          if (agglomeration_handler.is_master_cell(cell))
-            {
-              auto slaves = agglomeration_handler.get_slaves_of_idx(
-                cell->active_cell_index());
-              slaves.emplace_back(cell);
-
-              cell->get_dof_indices(agglo_dof_indices);
-
-              for (const auto &slave : slaves)
-                {
-                  // addd master-slave relationship
-                  const auto slave_output =
-                    slave->as_dof_handler_iterator(*output_dh);
-                  slave_output->get_dof_indices(output_dof_indices);
-                  for (const auto row : output_dof_indices)
-                    dsp.add_entries(row,
-                                    agglo_dof_indices.begin(),
-                                    agglo_dof_indices.end());
-                }
-            }
-        }
+      const IndexSet &locally_owned_dofs_agglo = agglo_dh.locally_owned_dofs();
 
 
-    const auto assemble_interpolation_matrix = [&]() {
-      FullMatrix<NumberType>  local_matrix(fe.dofs_per_cell, fe.dofs_per_cell);
-      std::vector<Point<dim>> reference_q_points(fe.dofs_per_cell);
+      DynamicSparsityPattern dsp(output_dh->n_dofs(),
+                                 agglo_dh.n_dofs(),
+                                 locally_relevant_dofs);
 
-      // Dummy AffineConstraints, only needed for loc2glb
-      AffineConstraints<NumberType> c;
-      c.close();
+      std::vector<types::global_dof_index> agglo_dof_indices(fe.dofs_per_cell);
+      std::vector<types::global_dof_index> standard_dof_indices(
+        fe.dofs_per_cell);
+      std::vector<types::global_dof_index> output_dof_indices(fe.dofs_per_cell);
+
+      Quadrature<dim>         quad(fe.get_unit_support_points());
+      FEValues<dim, spacedim> output_fe_values(fe,
+                                               quad,
+                                               update_quadrature_points);
 
       for (const auto &cell : agglo_dh.active_cell_iterators())
         if (cell->is_locally_owned())
@@ -947,88 +918,249 @@ namespace dealii::PolyUtils
 
                 cell->get_dof_indices(agglo_dof_indices);
 
-                const types::global_cell_index polytope_index =
-                  agglomeration_handler.cell_to_polytope_index(cell);
-
-                // Get the box of this agglomerate.
-                const BoundingBox<dim> &box = bboxes[polytope_index];
-
                 for (const auto &slave : slaves)
                   {
-                    // add master-slave relationship
+                    // addd master-slave relationship
                     const auto slave_output =
                       slave->as_dof_handler_iterator(*output_dh);
-
                     slave_output->get_dof_indices(output_dof_indices);
-                    output_fe_values.reinit(slave_output);
-
-                    local_matrix = 0.;
-
-                    const auto &q_points =
-                      output_fe_values.get_quadrature_points();
-                    for (const auto i : output_fe_values.dof_indices())
-                      {
-                        const auto &p = box.real_to_unit(q_points[i]);
-                        for (const auto j : output_fe_values.dof_indices())
-                          {
-                            local_matrix(i, j) = fe.shape_value(j, p);
-                          }
-                      }
-                    c.distribute_local_to_global(local_matrix,
-                                                 output_dof_indices,
-                                                 agglo_dof_indices,
-                                                 interpolation_matrix);
+                    for (const auto row : output_dof_indices)
+                      dsp.add_entries(row,
+                                      agglo_dof_indices.begin(),
+                                      agglo_dof_indices.end());
                   }
               }
           }
-    };
 
 
-    if constexpr (std::is_same_v<MatrixType, TrilinosWrappers::SparseMatrix>)
+      const auto assemble_interpolation_matrix = [&]() {
+        FullMatrix<NumberType> local_matrix(fe.dofs_per_cell, fe.dofs_per_cell);
+        std::vector<Point<dim>> reference_q_points(fe.dofs_per_cell);
+
+        // Dummy AffineConstraints, only needed for loc2glb
+        AffineConstraints<NumberType> c;
+        c.close();
+
+        for (const auto &cell : agglo_dh.active_cell_iterators())
+          if (cell->is_locally_owned())
+            {
+              if (agglomeration_handler.is_master_cell(cell))
+                {
+                  auto slaves = agglomeration_handler.get_slaves_of_idx(
+                    cell->active_cell_index());
+                  slaves.emplace_back(cell);
+
+                  cell->get_dof_indices(agglo_dof_indices);
+
+                  const types::global_cell_index polytope_index =
+                    agglomeration_handler.cell_to_polytope_index(cell);
+
+                  // Get the box of this agglomerate.
+                  const BoundingBox<dim> &box = bboxes[polytope_index];
+
+                  for (const auto &slave : slaves)
+                    {
+                      // add master-slave relationship
+                      const auto slave_output =
+                        slave->as_dof_handler_iterator(*output_dh);
+
+                      slave_output->get_dof_indices(output_dof_indices);
+                      output_fe_values.reinit(slave_output);
+
+                      local_matrix = 0.;
+
+                      const auto &q_points =
+                        output_fe_values.get_quadrature_points();
+                      for (const auto i : output_fe_values.dof_indices())
+                        {
+                          const auto &p = box.real_to_unit(q_points[i]);
+                          for (const auto j : output_fe_values.dof_indices())
+                            {
+                              local_matrix(i, j) = fe.shape_value(j, p);
+                            }
+                        }
+                      c.distribute_local_to_global(local_matrix,
+                                                   output_dof_indices,
+                                                   agglo_dof_indices,
+                                                   interpolation_matrix);
+                    }
+                }
+            }
+      };
+
+
+      if constexpr (std::is_same_v<MatrixType, TrilinosWrappers::SparseMatrix>)
+        {
+          const MPI_Comm &communicator = tria.get_communicator();
+          SparsityTools::distribute_sparsity_pattern(dsp,
+                                                     locally_owned_dofs,
+                                                     communicator,
+                                                     locally_relevant_dofs);
+
+          interpolation_matrix.reinit(locally_owned_dofs,
+                                      locally_owned_dofs_agglo,
+                                      dsp,
+                                      communicator);
+          dst.reinit(locally_owned_dofs);
+          assemble_interpolation_matrix();
+        }
+      else if constexpr (std::is_same_v<MatrixType, SparseMatrix<NumberType>>)
+        {
+          sp.copy_from(dsp);
+          interpolation_matrix.reinit(sp);
+          dst.reinit(output_dh->n_dofs());
+          assemble_interpolation_matrix();
+        }
+      else
+        {
+          // PETSc, LA::d::v options not implemented.
+          (void)agglomeration_handler;
+          (void)dst;
+          (void)src;
+          AssertThrow(false, ExcNotImplemented());
+        }
+
+      // If tria is distributed
+      if (dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
+            &tria) != nullptr)
+        interpolation_matrix.compress(VectorOperation::add);
+
+      // Finally, perform the interpolation.
+      interpolation_matrix.vmult(dst, src);
+    }
+  } // namespace internal
+
+
+
+  /**
+   * Given a vector @p src, typically the solution stemming after the
+   * agglomerate problem has been solved, this function interpolates @p src
+   * onto the finer grid and stores the result in vector @p dst. The last
+   * argument @p on_the_fly does not build any interpolation matrix and allows
+   * computing the entries in @p dst in a matrix-free fashion.
+   *
+   * @note Supported parallel types are TrilinosWrappers::SparseMatrix and
+   * TrilinosWrappers::MPI::Vector.
+   */
+  template <int dim, int spacedim, typename VectorType>
+  void
+  interpolate_to_fine_grid(
+    const AgglomerationHandler<dim, spacedim> &agglomeration_handler,
+    VectorType                                &dst,
+    const VectorType                          &src,
+    const bool                                 on_the_fly = true)
+  {
+    Assert((dim == spacedim), ExcNotImplemented());
+    Assert(
+      dst.size() == 0,
+      ExcMessage(
+        "The destination vector must the empt upon calling this function."));
+
+    using NumberType = typename VectorType::value_type;
+    static constexpr bool is_trilinos_vector =
+      std::is_same_v<VectorType, TrilinosWrappers::MPI::Vector>;
+
+    static constexpr bool is_supported_vector =
+      std::is_same_v<VectorType, Vector<NumberType>> || is_trilinos_vector;
+    static_assert(is_supported_vector);
+
+    // First, check for an easy return
+    if (on_the_fly == false)
       {
-        const MPI_Comm &communicator = tria.get_communicator();
-        SparsityTools::distribute_sparsity_pattern(dsp,
-                                                   locally_owned_dofs,
-                                                   communicator,
-                                                   locally_relevant_dofs);
-
-        interpolation_matrix.reinit(locally_owned_dofs,
-                                    locally_owned_dofs_agglo,
-                                    dsp,
-                                    communicator);
-        dst.reinit(locally_owned_dofs);
-        assemble_interpolation_matrix();
-      }
-    else if constexpr (std::is_same_v<MatrixType, SparseMatrix<NumberType>>)
-      {
-        sp.copy_from(dsp);
-        interpolation_matrix.reinit(sp);
-        dst.reinit(output_dh->n_dofs());
-        assemble_interpolation_matrix();
+        return internal::interpolate_to_fine_grid(agglomeration_handler,
+                                                  dst,
+                                                  src);
       }
     else
       {
-        // PETSc, LA::d::v options not implemented.
-        (void)agglomeration_handler;
-        (void)dst;
-        (void)src;
-        AssertThrow(false, ExcNotImplemented());
+        // otherwise, do not create any matrix
+        const Triangulation<dim, spacedim> &tria =
+          agglomeration_handler.get_triangulation();
+        const FiniteElement<dim, spacedim> &original_fe =
+          agglomeration_handler.get_fe();
+
+        // We use DGQ nodal elements of the same degree as the ones in the
+        // agglomeration handler to generate the output also in the case in
+        // which different elements are used, such as DGP.
+
+        FE_DGQ<dim>      output_fe(original_fe.degree);
+        DoFHandler<dim> &output_dh =
+          const_cast<DoFHandler<dim> &>(agglomeration_handler.output_dh);
+
+        output_dh.reinit(tria);
+        output_dh.distribute_dofs(output_fe);
+
+        if constexpr (std::is_same_v<VectorType, TrilinosWrappers::MPI::Vector>)
+          {
+            const IndexSet &locally_owned_dofs = output_dh.locally_owned_dofs();
+            dst.reinit(locally_owned_dofs);
+          }
+        else if constexpr (std::is_same_v<VectorType, Vector<NumberType>>)
+          {
+            dst.reinit(output_dh.n_dofs());
+          }
+        else
+          {
+            // PETSc, LA::d::v options not implemented.
+            (void)agglomeration_handler;
+            (void)dst;
+            (void)src;
+            AssertThrow(false, ExcNotImplemented());
+          }
+
+
+
+        const unsigned int dofs_per_cell =
+          agglomeration_handler.n_dofs_per_cell();
+        const unsigned int output_dofs_per_cell = output_fe.n_dofs_per_cell();
+        Quadrature<dim>    quad(output_fe.get_unit_support_points());
+        FEValues<dim>      output_fe_values(output_fe,
+                                       quad,
+                                       update_quadrature_points);
+
+        std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+        std::vector<types::global_dof_index> local_dof_indices_output(
+          output_dofs_per_cell);
+
+        const auto &bboxes = agglomeration_handler.get_local_bboxes();
+        for (const auto &polytope : agglomeration_handler.polytope_iterators())
+          {
+            if (polytope->is_locally_owned())
+              {
+                polytope->get_dof_indices(local_dof_indices);
+                const BoundingBox<dim> &box = bboxes[polytope->index()];
+
+                const auto &deal_cells =
+                  polytope->get_agglomerate(); // fine deal.II cells
+                for (const auto &cell : deal_cells)
+                  {
+                    const auto slave_output = cell->as_dof_handler_iterator(
+                      agglomeration_handler.output_dh);
+                    slave_output->get_dof_indices(local_dof_indices_output);
+                    output_fe_values.reinit(slave_output);
+
+                    const auto &qpoints =
+                      output_fe_values.get_quadrature_points();
+
+                    for (unsigned int j = 0; j < output_dofs_per_cell; ++j)
+                      {
+                        const auto &ref_qpoint = box.real_to_unit(qpoints[j]);
+                        for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                          dst(local_dof_indices_output[j]) +=
+                            src(local_dof_indices[i]) *
+                            original_fe.shape_value(i, ref_qpoint);
+                      }
+                  }
+              }
+          }
       }
-
-    // If tria is distributed
-    if (dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
-          &tria) != nullptr)
-      interpolation_matrix.compress(VectorOperation::add);
-
-    // Finally, perform the interpolation.
-    interpolation_matrix.vmult(dst, src);
   }
 
 
 
   /**
-   * Construct the interpolation matrix from the DG space defined the polytopic
-   * elements
+   * Construct the interpolation matrix from the DG space defined the
+   * polytopic elements
    * defined in @p agglomeration_handler to the DG space defined on the DoFHandler associated
    * to standard shapes. The interpolation matrix is assumed to be
    * default-constructed and is filled inside this function.
@@ -1196,6 +1328,122 @@ namespace dealii::PolyUtils
     if (dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
           &tria) != nullptr)
       interpolation_matrix.compress(VectorOperation::add);
+  }
+
+
+
+  /**
+   * Similar to VectorTools::compute_global_error(), but customized for
+   * polytopic elements. Aside from the solution vector and a reference
+   * function, this function takes in addition a vector @p norms with types
+   * VectorTools::NormType to be computed and later stored in the last
+   * argument @p global_errors.
+   * In case of a parallel vector, the local errors are collected over each
+   * processor and later a classical reduction operation is performed.
+   */
+  template <int dim, typename Number, typename VectorType>
+  void
+  compute_global_error(const AgglomerationHandler<dim> &agglomeration_handler,
+                       const VectorType                &solution,
+                       const Function<dim, Number>     &exact_solution,
+                       const std::vector<VectorTools::NormType> &norms,
+                       std::vector<double>                      &global_errors)
+  {
+    Assert(solution.size() > 0,
+           ExcNotImplemented(
+             "Solution vector must be non-empty upon calling this function."));
+    Assert(std::any_of(norms.cbegin(),
+                       norms.cend(),
+                       [](VectorTools::NormType norm_type) {
+                         return (norm_type ==
+                                   VectorTools::NormType::H1_seminorm ||
+                                 norm_type == VectorTools::NormType::L2_norm);
+                       }),
+           ExcMessage("Norm type not supported"));
+    global_errors.resize(norms.size());
+    std::fill(global_errors.begin(), global_errors.end(), 0.);
+
+    // Vector storing errors local to the current processor.
+    std::vector<double> local_errors(norms.size());
+    std::fill(local_errors.begin(), local_errors.end(), 0.);
+
+    // Get some info from the handler
+    const unsigned int dofs_per_cell = agglomeration_handler.n_dofs_per_cell();
+
+    const bool compute_semi_H1 =
+      std::any_of(norms.cbegin(),
+                  norms.cend(),
+                  [](VectorTools::NormType norm_type) {
+                    return norm_type == VectorTools::NormType::H1_seminorm;
+                  });
+
+    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+    for (const auto &polytope : agglomeration_handler.polytope_iterators())
+      {
+        if (polytope->is_locally_owned())
+          {
+            const auto &agglo_values = agglomeration_handler.reinit(polytope);
+            polytope->get_dof_indices(local_dof_indices);
+
+            const auto         &q_points = agglo_values.get_quadrature_points();
+            const unsigned int  n_qpoints = q_points.size();
+            std::vector<double> analyical_sol_at_qpoints(n_qpoints);
+            exact_solution.value_list(q_points, analyical_sol_at_qpoints);
+            std::vector<Tensor<1, dim>> grad_analyical_sol_at_qpoints(
+              n_qpoints);
+
+            if (compute_semi_H1)
+              exact_solution.gradient_list(q_points,
+                                           grad_analyical_sol_at_qpoints);
+
+            for (unsigned int q_index : agglo_values.quadrature_point_indices())
+              {
+                double         solution_at_qpoint = 0.;
+                Tensor<1, dim> grad_solution_at_qpoint;
+                for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                  {
+                    solution_at_qpoint += solution(local_dof_indices[i]) *
+                                          agglo_values.shape_value(i, q_index);
+
+                    if (compute_semi_H1)
+                      grad_solution_at_qpoint +=
+                        solution(local_dof_indices[i]) *
+                        agglo_values.shape_grad(i, q_index);
+                  }
+                // L2
+                local_errors[0] += std::pow((analyical_sol_at_qpoints[q_index] -
+                                             solution_at_qpoint),
+                                            2) *
+                                   agglo_values.JxW(q_index);
+
+                // H1 seminorm
+                if (compute_semi_H1)
+                  for (unsigned int d = 0; d < dim; ++d)
+                    local_errors[1] +=
+                      std::pow((grad_analyical_sol_at_qpoints[q_index][d] -
+                                grad_solution_at_qpoint[d]),
+                               2) *
+                      agglo_values.JxW(q_index);
+              }
+          }
+      }
+
+    // Perform reduction and take sqrt of each error
+    global_errors[0] = Utilities::MPI::reduce<double>(
+      local_errors[0],
+      agglomeration_handler.get_triangulation().get_mpi_communicator(),
+      [](const double a, const double b) { return a + b; });
+
+    global_errors[0] = std::sqrt(global_errors[0]);
+
+    if (compute_semi_H1)
+      {
+        global_errors[1] = Utilities::MPI::reduce<double>(
+          local_errors[1],
+          agglomeration_handler.get_triangulation().get_mpi_communicator(),
+          [](const double a, const double b) { return a + b; });
+        global_errors[1] = std::sqrt(global_errors[1]);
+      }
   }
 
 

--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -106,6 +106,45 @@ AgglomerationHandler<dim, spacedim>::define_agglomerate(
 
 template <int dim, int spacedim>
 void
+AgglomerationHandler<dim, spacedim>::define_agglomerate_with_check(
+  const AgglomerationContainer &cells)
+{
+  Assert(cells.size() > 0, ExcMessage("No cells to be agglomerated."));
+
+  // Compute the graph associated to the agglomerate
+  Utils::Graph g;
+  Utils::create_graph_from_agglomerate<dim>(cells, g);
+
+  // The following vector will be filled with connected components
+  std::vector<std::vector<types::global_cell_index>> connected_components;
+  Utils::compute_connected_components(g, connected_components);
+
+  // Be verbose in debug mode
+#ifdef AGGLO_DEBUG
+  if (connected_components.size() > 1)
+    std::cout << "Disconnected elements. Connected components will be "
+                 "computed and agglomerated together."
+              << std::endl;
+#endif
+
+  // Get connected components and define one agglomerate for each one of them.
+  std::vector<typename Triangulation<dim>::active_cell_iterator> agglomerate;
+  for (const auto &comp : connected_components)
+    {
+      agglomerate.reserve(comp.size());
+      for (const types::global_cell_index local_idx : comp)
+        agglomerate.push_back(cells[local_idx]);
+
+      // Perform agglomeration
+      define_agglomerate(agglomerate);
+      agglomerate.clear();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+void
 AgglomerationHandler<dim, spacedim>::initialize_fe_values(
   const Quadrature<dim>     &cell_quadrature,
   const UpdateFlags         &flags,
@@ -547,8 +586,8 @@ AgglomerationHandler<dim, spacedim>::reinit(
 
   // First check if the polytope is made just by a single cell. If so, use
   // classical FEValues
-  if (polytope->n_background_cells() == 1)
-    return standard_scratch->reinit(deal_cell);
+  // if (polytope->n_background_cells() == 1)
+  //   return standard_scratch->reinit(deal_cell);
 
   const auto &agglo_cells = polytope->get_agglomerate();
 
@@ -972,9 +1011,13 @@ namespace dealii
                                                   &master_cell,
         const AgglomerationHandler<dim, spacedim> &handler)
       {
-        Assert(handler.master_slave_relationships
-                   [master_cell->global_active_cell_index()] == -1,
-               ExcMessage("The present cell is not a master one."));
+        Assert(
+          handler.master_slave_relationships[master_cell
+                                               ->global_active_cell_index()] ==
+            -1,
+          ExcMessage("The present cell with index " +
+                     std::to_string(master_cell->global_active_cell_index()) +
+                     "is not a master one."));
 
         const auto &agglomeration = handler.get_agglomerate(master_cell);
         const types::global_cell_index current_polytope_index =

--- a/source/multigrid_amg.cc
+++ b/source/multigrid_amg.cc
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/lac/trilinos_sparse_matrix.h>
 
-#include <agglomeration_handler.h>
 #include <multigrid_amg.h>
 
 namespace dealii

--- a/test/polydeal/disconnected_exact_solution.cc
+++ b/test/polydeal/disconnected_exact_solution.cc
@@ -1,0 +1,774 @@
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/reference_cell.h>
+
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <deal.II/numerics/vector_tools_integrate_difference.h>
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <agglomeration_handler.h>
+#include <poly_utils.h>
+
+#include <algorithm>
+#include <chrono>
+
+
+// Same as exact_solutions.cc, but splitting agglomerates that are not
+// connected. With reference the following triangulation, we agglomerate as
+// follows, obtaining 3 (disconnected) agglomerates:
+// {0,1,2,3,12,13,14,15}
+// {4, 5, 6, 7, 8, 9, 10}
+// {11}
+
+// x - - - - - - - - - - - - -x
+// |     |     |      |       |
+// |  10 |  11 |  14  |  15   |
+// |     |     |      |       |
+// | - - | - - - - - -| - - - |
+// |     |     |      |       |
+// |  8  | 9   |  12  |  13   |
+// | - - | - - - - - -| - - - |
+// |     |     |      |       |
+// |  2  |  3  |  6   |   7   |
+// | - - | - - - - - -| - - - |
+// |  0  |  1  |  4   |    5  |
+// |     |     |      |       |
+// x - - - - - - - - - - - - -x
+
+// This way, the number of finale agglomerates should be 5. In particular, they
+// are: {0,1,2,3} {12,13,14,15} {4, 5, 6, 7} {8, 9, 10} {11}
+
+static constexpr double TOL = 1e-14;
+
+enum class SolutionType
+{
+  LinearSolution,
+  QuadraticSolution
+};
+
+
+template <int dim>
+class LinearFunction : public Function<dim>
+{
+public:
+  LinearFunction(const std::vector<int> &coeffs)
+  {
+    Assert(coeffs.size() <= dim, ExcMessage("Wrong size!"));
+    coefficients.resize(coeffs.size());
+    for (size_t i = 0; i < coeffs.size(); i++)
+      coefficients[i] = coeffs[i];
+  }
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  std::vector<int> coefficients;
+};
+
+template <int dim>
+double
+LinearFunction<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  double value = 0.;
+  for (size_t i = 0; i < coefficients.size(); i++)
+    value += coefficients[i] * p[i];
+  return value;
+}
+
+
+
+template <int dim>
+void
+LinearFunction<dim>::value_list(const std::vector<Point<dim>> &points,
+                                std::vector<double>           &values,
+                                const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = value(points[i]);
+}
+
+
+template <int dim>
+class RightHandSide : public Function<dim>
+{
+public:
+  RightHandSide(const SolutionType &solution_type)
+    : Function<dim>()
+  {
+    sol_type = solution_type;
+  }
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  SolutionType sol_type;
+};
+
+
+template <int dim>
+void
+RightHandSide<dim>::value_list(const std::vector<Point<dim>> &points,
+                               std::vector<double>           &values,
+                               const unsigned int /*component*/) const
+{
+  (void)points;
+  if (sol_type == SolutionType::LinearSolution)
+    {
+      for (unsigned int i = 0; i < values.size(); ++i)
+        values[i] = 0.; //-4.; // ball, radial solution
+    }
+  else
+    {
+      for (unsigned int i = 0; i < values.size(); ++i)
+        values[i] = -4.; // quadratic solution
+    }
+}
+
+template <int dim>
+class SolutionLinear : public Function<dim>
+{
+public:
+  SolutionLinear()
+    : Function<dim>()
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  virtual Tensor<1, dim>
+  gradient(const Point<dim>  &p,
+           const unsigned int component = 0) const override;
+};
+
+template <int dim>
+double
+SolutionLinear<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  return p[0] + p[1] - 1; // linear
+}
+
+template <int dim>
+Tensor<1, dim>
+SolutionLinear<dim>::gradient(const Point<dim> &p, const unsigned int) const
+{
+  Assert(dim == 2, ExcMessage("This test only works in 2D."));
+  (void)p;
+  Tensor<1, dim> return_value;
+  return_value[0] = 1.;
+  return_value[1] = 1.;
+  return return_value;
+}
+
+
+template <int dim>
+void
+SolutionLinear<dim>::value_list(const std::vector<Point<dim>> &points,
+                                std::vector<double>           &values,
+                                const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+
+
+template <int dim>
+class SolutionQuadratic : public Function<dim>
+{
+public:
+  SolutionQuadratic()
+    : Function<dim>()
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  virtual Tensor<1, dim>
+  gradient(const Point<dim>  &p,
+           const unsigned int component = 0) const override;
+};
+
+template <int dim>
+double
+SolutionQuadratic<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  return p[0] * p[0] + p[1] * p[1] - 1;
+}
+
+template <int dim>
+Tensor<1, dim>
+SolutionQuadratic<dim>::gradient(const Point<dim> &p, const unsigned int) const
+{
+  Assert(dim == 2, ExcMessage("This test only works in 2D."));
+  (void)p;
+  Tensor<1, dim> return_value;
+  return_value[0] = 2 * p[0];
+  return_value[1] = 2 * p[1];
+  return return_value;
+}
+
+
+
+template <int dim>
+void
+SolutionQuadratic<dim>::value_list(const std::vector<Point<dim>> &points,
+                                   std::vector<double>           &values,
+                                   const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+
+
+template <int dim>
+class Poisson
+{
+private:
+  void
+  make_grid();
+  void
+  setup_agglomeration();
+  void
+  assemble_system();
+  void
+  solve();
+  void
+  output_results();
+
+
+  Triangulation<dim>                         tria;
+  MappingQ<dim>                              mapping;
+  FE_DGQ<dim>                               *dg_fe;
+  std::unique_ptr<AgglomerationHandler<dim>> ah;
+  // no hanging node in DG discretization, we define an AffineConstraints
+  // object
+  // so we can use the distribute_local_to_global() directly.
+  AffineConstraints<double>              constraints;
+  SparsityPattern                        sparsity;
+  DynamicSparsityPattern                 dsp;
+  SparseMatrix<double>                   system_matrix;
+  Vector<double>                         solution;
+  Vector<double>                         system_rhs;
+  std::unique_ptr<GridTools::Cache<dim>> cached_tria;
+  std::unique_ptr<const Function<dim>>   rhs_function;
+  Function<dim>                         *analytical_solution;
+
+public:
+  Poisson(const SolutionType &solution_type);
+  ~Poisson();
+
+  void
+  run();
+
+  double       penalty_constant = 10;
+  SolutionType sol_type;
+};
+
+
+
+template <int dim>
+Poisson<dim>::Poisson(const SolutionType &solution_type)
+  : mapping(1)
+  , sol_type(solution_type)
+{
+  if (sol_type == SolutionType::LinearSolution)
+    {
+      dg_fe               = new FE_DGQ<dim>{1};
+      analytical_solution = new SolutionLinear<dim>();
+    }
+  else
+    {
+      dg_fe               = new FE_DGQ<dim>{2};
+      analytical_solution = new SolutionQuadratic<dim>();
+    }
+}
+
+
+
+template <int dim>
+Poisson<dim>::~Poisson()
+{
+  delete dg_fe;
+  delete analytical_solution;
+}
+
+
+
+template <int dim>
+void
+Poisson<dim>::make_grid()
+{
+  GridIn<dim> grid_in;
+  GridGenerator::hyper_cube(tria, 0, 1);
+  tria.refine_global(2);
+  GridTools::distort_random(0.25, tria);
+
+  std::cout << "Size of tria: " << tria.n_active_cells() << std::endl;
+  cached_tria  = std::make_unique<GridTools::Cache<dim>>(tria, mapping);
+  rhs_function = std::make_unique<const RightHandSide<dim>>(sol_type);
+
+  constraints.close();
+}
+
+template <int dim>
+void
+Poisson<dim>::setup_agglomeration()
+{
+  ah = std::make_unique<AgglomerationHandler<dim>>(*cached_tria);
+
+  std::vector<types::global_cell_index> idxs_to_be_agglomerated = {
+    0, 1, 2, 3, 12, 13, 14, 15};
+
+  std::vector<typename Triangulation<2>::active_cell_iterator>
+    cells_to_be_agglomerated;
+  PolyUtils::collect_cells_for_agglomeration(tria,
+                                             idxs_to_be_agglomerated,
+                                             cells_to_be_agglomerated);
+
+  std::vector<types::global_cell_index> idxs_to_be_agglomerated2 = {
+    4, 5, 6, 7, 8, 9, 10};
+
+  std::vector<typename Triangulation<2>::active_cell_iterator>
+    cells_to_be_agglomerated2;
+  PolyUtils::collect_cells_for_agglomeration(tria,
+                                             idxs_to_be_agglomerated2,
+                                             cells_to_be_agglomerated2);
+
+  std::vector<types::global_cell_index> idxs_to_be_agglomerated3 = {11};
+
+  std::vector<typename Triangulation<2>::active_cell_iterator>
+    cells_to_be_agglomerated3;
+  PolyUtils::collect_cells_for_agglomeration(tria,
+                                             idxs_to_be_agglomerated3,
+                                             cells_to_be_agglomerated3);
+
+  // Agglomerate the cells just stored
+  ah->define_agglomerate_with_check(cells_to_be_agglomerated);
+  ah->define_agglomerate_with_check(cells_to_be_agglomerated2);
+  ah->define_agglomerate_with_check(cells_to_be_agglomerated3);
+
+  std::cout << "Number of generated agglomerates: " << ah->n_agglomerates()
+            << std::endl;
+  AssertThrow((ah->n_agglomerates() == 5),
+              ExcMessage("Wrong number of agglomerates."));
+
+  ah->distribute_agglomerated_dofs(*dg_fe);
+  ah->create_agglomeration_sparsity_pattern(dsp);
+  sparsity.copy_from(dsp);
+}
+
+
+
+template <int dim>
+void
+Poisson<dim>::assemble_system()
+{
+  system_matrix.reinit(sparsity);
+  solution.reinit(ah->n_dofs());
+  system_rhs.reinit(ah->n_dofs());
+
+  const unsigned int quadrature_degree      = 2 * dg_fe->degree + 1;
+  const unsigned int face_quadrature_degree = 2 * dg_fe->degree + 1;
+  ah->initialize_fe_values(QGauss<dim>(quadrature_degree),
+                           update_gradients | update_JxW_values |
+                             update_quadrature_points | update_JxW_values |
+                             update_values,
+                           QGauss<dim - 1>(face_quadrature_degree),
+                           update_gradients | update_JxW_values |
+                             update_normal_vectors | update_quadrature_points |
+                             update_JxW_values | update_values);
+
+  const unsigned int dofs_per_cell = ah->n_dofs_per_cell();
+
+  FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+  Vector<double>     cell_rhs(dofs_per_cell);
+
+  // Next, we define the four dofsxdofs matrices needed to assemble jumps and
+  // averages.
+  FullMatrix<double> M11(dofs_per_cell, dofs_per_cell);
+  FullMatrix<double> M12(dofs_per_cell, dofs_per_cell);
+  FullMatrix<double> M21(dofs_per_cell, dofs_per_cell);
+  FullMatrix<double> M22(dofs_per_cell, dofs_per_cell);
+
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+
+  LinearFunction<dim> linear_func{{1, 1}};
+  double              test_integral = 0.;
+  double              test_bdary    = 0.;
+  double              test_volume   = 0.;
+  for (const auto &polytope : ah->polytope_iterators())
+    {
+      // local_volume             = 0.;
+      cell_matrix              = 0;
+      cell_rhs                 = 0;
+      const auto &agglo_values = ah->reinit(polytope);
+
+      const auto &q_points = agglo_values.get_quadrature_points();
+
+      const unsigned int  n_qpoints = q_points.size();
+      std::vector<double> rhs(n_qpoints);
+      rhs_function->value_list(q_points, rhs);
+      std::vector<double> linear_values(n_qpoints);
+      linear_func.value_list(q_points, linear_values, 1);
+
+      for (unsigned int q_index : agglo_values.quadrature_point_indices())
+        {
+          for (unsigned int i = 0; i < dofs_per_cell; ++i)
+            {
+              for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                {
+                  cell_matrix(i, j) += agglo_values.shape_grad(i, q_index) *
+                                       agglo_values.shape_grad(j, q_index) *
+                                       agglo_values.JxW(q_index);
+                }
+              cell_rhs(i) += agglo_values.shape_value(i, q_index) *
+                             rhs[q_index] * agglo_values.JxW(q_index);
+            }
+          test_integral += linear_values[q_index] * agglo_values.JxW(q_index);
+          test_volume += agglo_values.JxW(q_index);
+        }
+
+      polytope->get_dof_indices(local_dof_indices);
+      constraints.distribute_local_to_global(
+        cell_matrix, cell_rhs, local_dof_indices, system_matrix, system_rhs);
+
+      // Face terms
+      const unsigned int n_faces = polytope->n_faces();
+      AssertThrow(n_faces > 0, ExcMessage("Invalid element!"));
+
+
+
+      // auto   polygon_boundary_vertices = ah->polytope_boundary(cell);
+      for (unsigned int f = 0; f < n_faces; ++f)
+        {
+          if (polytope->at_boundary(f))
+            {
+              const auto &fe_face = ah->reinit(polytope, f);
+
+              const unsigned int dofs_per_cell = fe_face.dofs_per_cell;
+              std::vector<types::global_dof_index> local_dof_indices_bdary_cell(
+                dofs_per_cell);
+
+              const auto &face_q_points = fe_face.get_quadrature_points();
+              std::vector<double> analytical_solution_values(
+                face_q_points.size());
+              analytical_solution->value_list(face_q_points,
+                                              analytical_solution_values,
+                                              1);
+
+              // Get normal vectors seen from each agglomeration.
+              const auto &normals = fe_face.get_normal_vectors();
+
+              const double penalty =
+                penalty_constant / std::fabs(polytope->diameter());
+
+              cell_matrix = 0.;
+              cell_rhs    = 0.;
+              for (unsigned int q_index : fe_face.quadrature_point_indices())
+                {
+                  for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                    {
+                      for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                        {
+                          cell_matrix(i, j) +=
+                            (-fe_face.shape_value(i, q_index) *
+                               fe_face.shape_grad(j, q_index) *
+                               normals[q_index] -
+                             fe_face.shape_grad(i, q_index) * normals[q_index] *
+                               fe_face.shape_value(j, q_index) +
+                             (penalty)*fe_face.shape_value(i, q_index) *
+                               fe_face.shape_value(j, q_index)) *
+                            fe_face.JxW(q_index);
+                        }
+                      cell_rhs(i) +=
+                        (penalty * analytical_solution_values[q_index] *
+                           fe_face.shape_value(i, q_index) -
+                         fe_face.shape_grad(i, q_index) * normals[q_index] *
+                           analytical_solution_values[q_index]) *
+                        fe_face.JxW(q_index);
+                    }
+
+                  test_bdary += fe_face.JxW(q_index);
+                }
+
+              // distribute DoFs
+              polytope->get_dof_indices(local_dof_indices_bdary_cell);
+              constraints.distribute_local_to_global(cell_matrix,
+                                                     cell_rhs,
+                                                     local_dof_indices,
+                                                     system_matrix,
+                                                     system_rhs);
+            }
+          else
+            {
+              const auto &neigh_polytope = polytope->neighbor(f);
+
+              // This is necessary to loop over internal faces only once.
+              if (polytope->index() < neigh_polytope->index())
+                {
+                  unsigned int nofn =
+                    polytope->neighbor_of_agglomerated_neighbor(f);
+
+                  const auto &fe_faces =
+                    ah->reinit_interface(polytope, neigh_polytope, f, nofn);
+
+                  const auto &fe_faces0 = fe_faces.first;
+                  const auto &fe_faces1 = fe_faces.second;
+
+#ifdef AGGLO_DEBUG
+                  const auto &points0 = fe_faces0.get_quadrature_points();
+                  const auto &points1 = fe_faces1.get_quadrature_points();
+                  for (size_t i = 0;
+                       i < fe_faces1.get_quadrature_points().size();
+                       ++i)
+                    {
+                      double d = (points0[i] - points1[i]).norm();
+                      Assert(d < 1e-15,
+                             ExcMessage(
+                               "Face qpoints at the interface do not match!"));
+                    }
+
+#endif
+
+                  std::vector<types::global_dof_index>
+                    local_dof_indices_neighbor(dofs_per_cell);
+
+                  M11 = 0.;
+                  M12 = 0.;
+                  M21 = 0.;
+                  M22 = 0.;
+
+                  const auto  &normals = fe_faces0.get_normal_vectors();
+                  const double penalty =
+                    penalty_constant / std::fabs(polytope->diameter());
+
+                  // M11
+                  for (unsigned int q_index :
+                       fe_faces0.quadrature_point_indices())
+                    {
+                      for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                        {
+                          for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                            {
+                              M11(i, j) +=
+                                (-0.5 * fe_faces0.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(j, q_index) -
+                                 0.5 * fe_faces0.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(i, q_index) +
+                                 (penalty)*fe_faces0.shape_value(i, q_index) *
+                                   fe_faces0.shape_value(j, q_index)) *
+                                fe_faces0.JxW(q_index);
+
+                              M12(i, j) +=
+                                (0.5 * fe_faces0.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(j, q_index) -
+                                 0.5 * fe_faces1.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(i, q_index) -
+                                 (penalty)*fe_faces0.shape_value(i, q_index) *
+                                   fe_faces1.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
+
+                              // A10
+                              M21(i, j) +=
+                                (-0.5 * fe_faces1.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(j, q_index) +
+                                 0.5 * fe_faces0.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(i, q_index) -
+                                 (penalty)*fe_faces1.shape_value(i, q_index) *
+                                   fe_faces0.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
+
+                              // A11
+                              M22(i, j) +=
+                                (0.5 * fe_faces1.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(j, q_index) +
+                                 0.5 * fe_faces1.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(i, q_index) +
+                                 (penalty)*fe_faces1.shape_value(i, q_index) *
+                                   fe_faces1.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
+                            }
+                        }
+                    }
+
+                  // distribute DoFs accordingly
+                  // Retrieve DoFs info from the cell iterator.
+                  neigh_polytope->get_dof_indices(local_dof_indices_neighbor);
+
+                  constraints.distribute_local_to_global(M11,
+                                                         local_dof_indices,
+                                                         system_matrix);
+                  constraints.distribute_local_to_global(
+                    M12,
+                    local_dof_indices,
+                    local_dof_indices_neighbor,
+                    system_matrix);
+                  constraints.distribute_local_to_global(
+                    M21,
+                    local_dof_indices_neighbor,
+                    local_dof_indices,
+                    system_matrix);
+                  constraints.distribute_local_to_global(
+                    M22, local_dof_indices_neighbor, system_matrix);
+                } // Loop only once trough internal faces
+            }
+        } // Loop over faces of current cell
+    }     // Loop over cells
+
+  AssertThrow(
+    std::fabs(test_integral - 1.) < TOL,
+    ExcMessage(
+      "Value for integral of linear function on this domain is not correct."));
+  AssertThrow(std::fabs(test_volume - 1.) < TOL,
+              ExcMessage("Value of measure of domain is not correct."));
+  AssertThrow(std::fabs(test_bdary - 4.) < TOL,
+              ExcMessage(
+                "Value for the measure of the boundary is not correct."));
+}
+
+void
+output_double_number(double input, const std::string &text)
+{
+  std::cout << text << input << std::endl;
+}
+
+template <int dim>
+void
+Poisson<dim>::solve()
+{
+  SparseDirectUMFPACK A_direct;
+  A_direct.initialize(system_matrix);
+  A_direct.vmult(solution, system_rhs);
+}
+
+
+
+template <int dim>
+void
+Poisson<dim>::output_results()
+{
+  // Compute errors.
+
+  // Prepare interpolation matrix onto the finer grid.
+  Vector<double> interpolated_solution;
+  PolyUtils::interpolate_to_fine_grid(*ah,
+                                      interpolated_solution,
+                                      solution,
+                                      true);
+
+  // L2 error
+  Vector<float> difference_per_cell(tria.n_active_cells());
+
+  VectorTools::integrate_difference(mapping,
+                                    ah->output_dh,
+                                    interpolated_solution,
+                                    *analytical_solution,
+                                    difference_per_cell,
+                                    QGauss<dim>(dg_fe->degree + 1),
+                                    VectorTools::L2_norm);
+
+  const double L2_error =
+    VectorTools::compute_global_error(tria,
+                                      difference_per_cell,
+                                      VectorTools::L2_norm);
+
+  // std::cout << "L2 error:" << L2_error << std::endl;
+  AssertThrow(L2_error < TOL,
+              ExcMessage("L2 error too large. It is " +
+                         std::to_string(L2_error)));
+
+
+
+  // H1 seminorm
+  Vector<float> difference_per_cell_H1_semi(tria.n_active_cells());
+
+  VectorTools::integrate_difference(mapping,
+                                    ah->output_dh,
+                                    interpolated_solution,
+                                    *analytical_solution,
+                                    difference_per_cell_H1_semi,
+                                    QGauss<dim>(dg_fe->degree + 1),
+                                    VectorTools::H1_seminorm);
+
+  const double H1_seminorm =
+    VectorTools::compute_global_error(tria,
+                                      difference_per_cell_H1_semi,
+                                      VectorTools::H1_seminorm);
+  AssertThrow(H1_seminorm < TOL, ExcMessage("H1 seminorm too large."));
+
+  // std::cout << "H1 seminorm:" << H1_seminorm << std::endl;
+}
+
+
+template <int dim>
+void
+Poisson<dim>::run()
+{
+  make_grid();
+  setup_agglomeration();
+  assemble_system();
+  solve();
+  output_results();
+}
+
+
+
+int
+main()
+{
+  deallog.depth_console(1);
+
+  try
+    {
+      Poisson<2> poisson_problem_linear_sol{SolutionType::LinearSolution};
+      poisson_problem_linear_sol.run();
+      std::cout << "Linear: OK" << std::endl;
+
+      Poisson<2> poisson_problem_quadratic_sol{SolutionType::QuadraticSolution};
+      poisson_problem_quadratic_sol.run();
+      std::cout << "Quadratic: OK" << std::endl;
+    }
+  catch (const std::exception &exc)
+    {
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+    }
+
+  return 0;
+}

--- a/test/polydeal/disconnected_exact_solution.output
+++ b/test/polydeal/disconnected_exact_solution.output
@@ -1,0 +1,6 @@
+Size of tria: 16
+Number of generated agglomerates: 5
+Linear: OK
+Size of tria: 16
+Number of generated agglomerates: 5
+Quadratic: OK

--- a/test/polydeal/exact_solutions_dgp.cc
+++ b/test/polydeal/exact_solutions_dgp.cc
@@ -1,0 +1,749 @@
+#include <deal.II/fe/fe_dgp.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/reference_cell.h>
+
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <deal.II/numerics/vector_tools_integrate_difference.h>
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <agglomeration_handler.h>
+#include <poly_utils.h>
+
+#include <algorithm>
+#include <chrono>
+
+
+// Same as exact_solutions.cc, but with a DGP space.
+
+static constexpr double TOL = 1e-14;
+
+enum class SolutionType
+{
+  LinearSolution,
+  QuadraticSolution
+};
+
+
+template <int dim>
+class LinearFunction : public Function<dim>
+{
+public:
+  LinearFunction(const std::vector<int> &coeffs)
+  {
+    Assert(coeffs.size() <= dim, ExcMessage("Wrong size!"));
+    coefficients.resize(coeffs.size());
+    for (size_t i = 0; i < coeffs.size(); i++)
+      coefficients[i] = coeffs[i];
+  }
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  std::vector<int> coefficients;
+};
+
+template <int dim>
+double
+LinearFunction<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  double value = 0.;
+  for (size_t i = 0; i < coefficients.size(); i++)
+    value += coefficients[i] * p[i];
+  return value;
+}
+
+
+
+template <int dim>
+void
+LinearFunction<dim>::value_list(const std::vector<Point<dim>> &points,
+                                std::vector<double>           &values,
+                                const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = value(points[i]);
+}
+
+
+template <int dim>
+class RightHandSide : public Function<dim>
+{
+public:
+  RightHandSide(const SolutionType &solution_type)
+    : Function<dim>()
+  {
+    sol_type = solution_type;
+  }
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  SolutionType sol_type;
+};
+
+
+template <int dim>
+void
+RightHandSide<dim>::value_list(const std::vector<Point<dim>> &points,
+                               std::vector<double>           &values,
+                               const unsigned int /*component*/) const
+{
+  (void)points;
+  if (sol_type == SolutionType::LinearSolution)
+    {
+      for (unsigned int i = 0; i < values.size(); ++i)
+        values[i] = 0.; //-4.; // ball, radial solution
+    }
+  else
+    {
+      for (unsigned int i = 0; i < values.size(); ++i)
+        values[i] = -4.; // quadratic solution
+    }
+}
+
+template <int dim>
+class SolutionLinear : public Function<dim>
+{
+public:
+  SolutionLinear()
+    : Function<dim>()
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  virtual Tensor<1, dim>
+  gradient(const Point<dim>  &p,
+           const unsigned int component = 0) const override;
+};
+
+template <int dim>
+double
+SolutionLinear<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  return p[0] + p[1] - 1; // linear
+}
+
+template <int dim>
+Tensor<1, dim>
+SolutionLinear<dim>::gradient(const Point<dim> &p, const unsigned int) const
+{
+  Assert(dim == 2, ExcMessage("This test only works in 2D."));
+  (void)p;
+  Tensor<1, dim> return_value;
+  return_value[0] = 1.;
+  return_value[1] = 1.;
+  return return_value;
+}
+
+
+template <int dim>
+void
+SolutionLinear<dim>::value_list(const std::vector<Point<dim>> &points,
+                                std::vector<double>           &values,
+                                const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+
+
+template <int dim>
+class SolutionQuadratic : public Function<dim>
+{
+public:
+  SolutionQuadratic()
+    : Function<dim>()
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  virtual Tensor<1, dim>
+  gradient(const Point<dim>  &p,
+           const unsigned int component = 0) const override;
+};
+
+template <int dim>
+double
+SolutionQuadratic<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  return p[0] * p[0] + p[1] * p[1] - 1;
+}
+
+template <int dim>
+Tensor<1, dim>
+SolutionQuadratic<dim>::gradient(const Point<dim> &p, const unsigned int) const
+{
+  Assert(dim == 2, ExcMessage("This test only works in 2D."));
+  (void)p;
+  Tensor<1, dim> return_value;
+  return_value[0] = 2 * p[0];
+  return_value[1] = 2 * p[1];
+  return return_value;
+}
+
+
+
+template <int dim>
+void
+SolutionQuadratic<dim>::value_list(const std::vector<Point<dim>> &points,
+                                   std::vector<double>           &values,
+                                   const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+
+
+template <int dim>
+class Poisson
+{
+private:
+  void
+  make_grid();
+  void
+  setup_agglomeration();
+  void
+  assemble_system();
+  void
+  solve();
+  void
+  output_results();
+
+
+  Triangulation<dim>                         tria;
+  MappingQ<dim>                              mapping;
+  FE_DGP<dim>                               *dg_fe;
+  std::unique_ptr<AgglomerationHandler<dim>> ah;
+  // no hanging node in DG discretization, we define an AffineConstraints
+  // object
+  // so we can use the distribute_local_to_global() directly.
+  AffineConstraints<double>              constraints;
+  SparsityPattern                        sparsity;
+  DynamicSparsityPattern                 dsp;
+  SparseMatrix<double>                   system_matrix;
+  Vector<double>                         solution;
+  Vector<double>                         system_rhs;
+  std::unique_ptr<GridTools::Cache<dim>> cached_tria;
+  std::unique_ptr<const Function<dim>>   rhs_function;
+  Function<dim>                         *analytical_solution;
+
+public:
+  Poisson(const SolutionType &solution_type);
+  ~Poisson();
+
+  void
+  run();
+
+  double       penalty_constant = 10;
+  SolutionType sol_type;
+};
+
+
+
+template <int dim>
+Poisson<dim>::Poisson(const SolutionType &solution_type)
+  : mapping(1)
+  , sol_type(solution_type)
+{
+  if (sol_type == SolutionType::LinearSolution)
+    {
+      dg_fe               = new FE_DGP<dim>{1};
+      analytical_solution = new SolutionLinear<dim>();
+    }
+  else
+    {
+      dg_fe               = new FE_DGP<dim>{2};
+      analytical_solution = new SolutionQuadratic<dim>();
+    }
+}
+
+
+
+template <int dim>
+Poisson<dim>::~Poisson()
+{
+  delete dg_fe;
+  delete analytical_solution;
+}
+
+
+
+template <int dim>
+void
+Poisson<dim>::make_grid()
+{
+  GridIn<dim> grid_in;
+  GridGenerator::hyper_cube(tria, 0, 1);
+  tria.refine_global(2);
+  GridTools::distort_random(0.25, tria);
+
+  std::cout << "Size of tria: " << tria.n_active_cells() << std::endl;
+  cached_tria  = std::make_unique<GridTools::Cache<dim>>(tria, mapping);
+  rhs_function = std::make_unique<const RightHandSide<dim>>(sol_type);
+
+  constraints.close();
+}
+
+template <int dim>
+void
+Poisson<dim>::setup_agglomeration()
+{
+  ah = std::make_unique<AgglomerationHandler<dim>>(*cached_tria);
+
+  std::vector<types::global_cell_index> idxs_to_be_agglomerated = {0, 1, 2, 3};
+
+  std::vector<typename Triangulation<2>::active_cell_iterator>
+    cells_to_be_agglomerated;
+  PolyUtils::collect_cells_for_agglomeration(tria,
+                                             idxs_to_be_agglomerated,
+                                             cells_to_be_agglomerated);
+
+  std::vector<types::global_cell_index> idxs_to_be_agglomerated2 = {4, 5, 6, 7};
+
+  std::vector<typename Triangulation<2>::active_cell_iterator>
+    cells_to_be_agglomerated2;
+  PolyUtils::collect_cells_for_agglomeration(tria,
+                                             idxs_to_be_agglomerated2,
+                                             cells_to_be_agglomerated2);
+
+  std::vector<types::global_cell_index> idxs_to_be_agglomerated3 = {8,
+                                                                    9,
+                                                                    10,
+                                                                    11};
+
+  std::vector<typename Triangulation<2>::active_cell_iterator>
+    cells_to_be_agglomerated3;
+  PolyUtils::collect_cells_for_agglomeration(tria,
+                                             idxs_to_be_agglomerated3,
+                                             cells_to_be_agglomerated3);
+
+  std::vector<types::global_cell_index> idxs_to_be_agglomerated4 = {12,
+                                                                    13,
+                                                                    14,
+                                                                    15};
+
+  std::vector<typename Triangulation<2>::active_cell_iterator>
+    cells_to_be_agglomerated4;
+  PolyUtils::collect_cells_for_agglomeration(tria,
+                                             idxs_to_be_agglomerated4,
+                                             cells_to_be_agglomerated4);
+
+  // Agglomerate the cells just stored
+  ah->define_agglomerate(cells_to_be_agglomerated);
+  ah->define_agglomerate(cells_to_be_agglomerated2);
+  ah->define_agglomerate(cells_to_be_agglomerated3);
+  ah->define_agglomerate(cells_to_be_agglomerated4);
+
+  ah->distribute_agglomerated_dofs(*dg_fe);
+  ah->create_agglomeration_sparsity_pattern(dsp);
+  sparsity.copy_from(dsp);
+}
+
+
+
+template <int dim>
+void
+Poisson<dim>::assemble_system()
+{
+  system_matrix.reinit(sparsity);
+  solution.reinit(ah->n_dofs());
+  system_rhs.reinit(ah->n_dofs());
+
+  const unsigned int quadrature_degree      = 2 * dg_fe->get_degree() + 1;
+  const unsigned int face_quadrature_degree = 2 * dg_fe->get_degree() + 1;
+  ah->initialize_fe_values(QGauss<dim>(quadrature_degree),
+                           update_gradients | update_JxW_values |
+                             update_quadrature_points | update_JxW_values |
+                             update_values,
+                           QGauss<dim - 1>(face_quadrature_degree));
+
+  const unsigned int dofs_per_cell = ah->n_dofs_per_cell();
+
+  FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+  Vector<double>     cell_rhs(dofs_per_cell);
+
+  // Next, we define the four dofsxdofs matrices needed to assemble jumps and
+  // averages.
+  FullMatrix<double> M11(dofs_per_cell, dofs_per_cell);
+  FullMatrix<double> M12(dofs_per_cell, dofs_per_cell);
+  FullMatrix<double> M21(dofs_per_cell, dofs_per_cell);
+  FullMatrix<double> M22(dofs_per_cell, dofs_per_cell);
+
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+
+  LinearFunction<dim> linear_func{{1, 1}};
+  double              test_integral = 0.;
+  double              test_bdary    = 0.;
+  double              test_volume   = 0.;
+  for (const auto &polytope : ah->polytope_iterators())
+    {
+      // local_volume             = 0.;
+      cell_matrix              = 0;
+      cell_rhs                 = 0;
+      const auto &agglo_values = ah->reinit(polytope);
+
+      const auto &q_points = agglo_values.get_quadrature_points();
+
+      const unsigned int  n_qpoints = q_points.size();
+      std::vector<double> rhs(n_qpoints);
+      rhs_function->value_list(q_points, rhs);
+      std::vector<double> linear_values(n_qpoints);
+      linear_func.value_list(q_points, linear_values, 1);
+
+      for (unsigned int q_index : agglo_values.quadrature_point_indices())
+        {
+          for (unsigned int i = 0; i < dofs_per_cell; ++i)
+            {
+              for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                {
+                  cell_matrix(i, j) += agglo_values.shape_grad(i, q_index) *
+                                       agglo_values.shape_grad(j, q_index) *
+                                       agglo_values.JxW(q_index);
+                }
+              cell_rhs(i) += agglo_values.shape_value(i, q_index) *
+                             rhs[q_index] * agglo_values.JxW(q_index);
+            }
+          test_integral += linear_values[q_index] * agglo_values.JxW(q_index);
+          test_volume += agglo_values.JxW(q_index);
+        }
+
+      polytope->get_dof_indices(local_dof_indices);
+      constraints.distribute_local_to_global(
+        cell_matrix, cell_rhs, local_dof_indices, system_matrix, system_rhs);
+
+      // Face terms
+      const unsigned int n_faces = polytope->n_faces();
+      AssertThrow(n_faces > 0, ExcMessage("Invalid element!"));
+
+
+
+      // auto   polygon_boundary_vertices = ah->polytope_boundary(cell);
+      for (unsigned int f = 0; f < n_faces; ++f)
+        {
+          if (polytope->at_boundary(f))
+            {
+              const auto &fe_face = ah->reinit(polytope, f);
+
+              const unsigned int dofs_per_cell = fe_face.dofs_per_cell;
+              std::vector<types::global_dof_index> local_dof_indices_bdary_cell(
+                dofs_per_cell);
+
+              const auto &face_q_points = fe_face.get_quadrature_points();
+              std::vector<double> analytical_solution_values(
+                face_q_points.size());
+              analytical_solution->value_list(face_q_points,
+                                              analytical_solution_values,
+                                              1);
+
+              // Get normal vectors seen from each agglomeration.
+              const auto &normals = fe_face.get_normal_vectors();
+
+              const double penalty =
+                penalty_constant / std::fabs(polytope->diameter());
+
+              cell_matrix = 0.;
+              cell_rhs    = 0.;
+              for (unsigned int q_index : fe_face.quadrature_point_indices())
+                {
+                  for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                    {
+                      for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                        {
+                          cell_matrix(i, j) +=
+                            (-fe_face.shape_value(i, q_index) *
+                               fe_face.shape_grad(j, q_index) *
+                               normals[q_index] -
+                             fe_face.shape_grad(i, q_index) * normals[q_index] *
+                               fe_face.shape_value(j, q_index) +
+                             (penalty)*fe_face.shape_value(i, q_index) *
+                               fe_face.shape_value(j, q_index)) *
+                            fe_face.JxW(q_index);
+                        }
+                      cell_rhs(i) +=
+                        (penalty * analytical_solution_values[q_index] *
+                           fe_face.shape_value(i, q_index) -
+                         fe_face.shape_grad(i, q_index) * normals[q_index] *
+                           analytical_solution_values[q_index]) *
+                        fe_face.JxW(q_index);
+                    }
+
+                  test_bdary += fe_face.JxW(q_index);
+                }
+
+              // distribute DoFs
+              polytope->get_dof_indices(local_dof_indices_bdary_cell);
+              constraints.distribute_local_to_global(cell_matrix,
+                                                     cell_rhs,
+                                                     local_dof_indices,
+                                                     system_matrix,
+                                                     system_rhs);
+            }
+          else
+            {
+              const auto &neigh_polytope = polytope->neighbor(f);
+
+              // This is necessary to loop over internal faces only once.
+              if (polytope->index() < neigh_polytope->index())
+                {
+                  unsigned int nofn =
+                    polytope->neighbor_of_agglomerated_neighbor(f);
+
+                  const auto &fe_faces =
+                    ah->reinit_interface(polytope, neigh_polytope, f, nofn);
+
+                  const auto &fe_faces0 = fe_faces.first;
+                  const auto &fe_faces1 = fe_faces.second;
+
+#ifdef AGGLO_DEBUG
+                  const auto &points0 = fe_faces0.get_quadrature_points();
+                  const auto &points1 = fe_faces1.get_quadrature_points();
+                  for (size_t i = 0;
+                       i < fe_faces1.get_quadrature_points().size();
+                       ++i)
+                    {
+                      double d = (points0[i] - points1[i]).norm();
+                      Assert(d < 1e-15,
+                             ExcMessage(
+                               "Face qpoints at the interface do not match!"));
+                    }
+
+#endif
+
+                  std::vector<types::global_dof_index>
+                    local_dof_indices_neighbor(dofs_per_cell);
+
+                  M11 = 0.;
+                  M12 = 0.;
+                  M21 = 0.;
+                  M22 = 0.;
+
+                  const auto  &normals = fe_faces0.get_normal_vectors();
+                  const double penalty =
+                    penalty_constant / std::fabs(polytope->diameter());
+
+                  // M11
+                  for (unsigned int q_index :
+                       fe_faces0.quadrature_point_indices())
+                    {
+                      for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                        {
+                          for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                            {
+                              M11(i, j) +=
+                                (-0.5 * fe_faces0.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(j, q_index) -
+                                 0.5 * fe_faces0.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(i, q_index) +
+                                 (penalty)*fe_faces0.shape_value(i, q_index) *
+                                   fe_faces0.shape_value(j, q_index)) *
+                                fe_faces0.JxW(q_index);
+
+                              M12(i, j) +=
+                                (0.5 * fe_faces0.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(j, q_index) -
+                                 0.5 * fe_faces1.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(i, q_index) -
+                                 (penalty)*fe_faces0.shape_value(i, q_index) *
+                                   fe_faces1.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
+
+                              // A10
+                              M21(i, j) +=
+                                (-0.5 * fe_faces1.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(j, q_index) +
+                                 0.5 * fe_faces0.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(i, q_index) -
+                                 (penalty)*fe_faces1.shape_value(i, q_index) *
+                                   fe_faces0.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
+
+                              // A11
+                              M22(i, j) +=
+                                (0.5 * fe_faces1.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(j, q_index) +
+                                 0.5 * fe_faces1.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(i, q_index) +
+                                 (penalty)*fe_faces1.shape_value(i, q_index) *
+                                   fe_faces1.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
+                            }
+                        }
+                    }
+
+                  // distribute DoFs accordingly
+                  // Retrieve DoFs info from the cell iterator.
+                  neigh_polytope->get_dof_indices(local_dof_indices_neighbor);
+
+                  constraints.distribute_local_to_global(M11,
+                                                         local_dof_indices,
+                                                         system_matrix);
+                  constraints.distribute_local_to_global(
+                    M12,
+                    local_dof_indices,
+                    local_dof_indices_neighbor,
+                    system_matrix);
+                  constraints.distribute_local_to_global(
+                    M21,
+                    local_dof_indices_neighbor,
+                    local_dof_indices,
+                    system_matrix);
+                  constraints.distribute_local_to_global(
+                    M22, local_dof_indices_neighbor, system_matrix);
+                } // Loop only once trough internal faces
+            }
+        } // Loop over faces of current cell
+    }     // Loop over cells
+
+  AssertThrow(
+    std::fabs(test_integral - 1.) < TOL,
+    ExcMessage(
+      "Value for integral of linear function on this domain is not correct."));
+  AssertThrow(std::fabs(test_volume - 1.) < TOL,
+              ExcMessage("Value of measure of domain is not correct."));
+  AssertThrow(std::fabs(test_bdary - 4.) < TOL,
+              ExcMessage(
+                "Value for the measure of the boundary is not correct."));
+}
+
+
+
+template <int dim>
+void
+Poisson<dim>::solve()
+{
+  SparseDirectUMFPACK A_direct;
+  A_direct.initialize(system_matrix);
+  A_direct.vmult(solution, system_rhs);
+}
+
+
+
+template <int dim>
+void
+Poisson<dim>::output_results()
+{
+  // Compute errors.
+
+  // Prepare interpolation matrix onto the finer grid.
+  Vector<double> interpolated_solution;
+  PolyUtils::interpolate_to_fine_grid(*ah, interpolated_solution, solution);
+
+  // L2 error
+  Vector<float> difference_per_cell(tria.n_active_cells());
+
+  VectorTools::integrate_difference(mapping,
+                                    ah->output_dh,
+                                    interpolated_solution,
+                                    *analytical_solution,
+                                    difference_per_cell,
+                                    QGauss<dim>(dg_fe->degree + 1),
+                                    VectorTools::L2_norm);
+
+  const double L2_error =
+    VectorTools::compute_global_error(tria,
+                                      difference_per_cell,
+                                      VectorTools::L2_norm);
+
+  // std::cout << "L2 error:" << L2_error << std::endl;
+  AssertThrow(L2_error < TOL, ExcMessage("L2 error too large."));
+
+
+
+  // H1 seminorm
+  Vector<float> difference_per_cell_H1_semi(tria.n_active_cells());
+
+  VectorTools::integrate_difference(mapping,
+                                    ah->output_dh,
+                                    interpolated_solution,
+                                    *analytical_solution,
+                                    difference_per_cell_H1_semi,
+                                    QGauss<dim>(dg_fe->degree + 1),
+                                    VectorTools::H1_seminorm);
+
+  const double H1_seminorm =
+    VectorTools::compute_global_error(tria,
+                                      difference_per_cell_H1_semi,
+                                      VectorTools::H1_seminorm);
+  AssertThrow(H1_seminorm < TOL, ExcMessage("H1 seminorm too large."));
+
+  // std::cout << "H1 seminorm:" << H1_seminorm << std::endl;
+}
+
+
+template <int dim>
+void
+Poisson<dim>::run()
+{
+  make_grid();
+  setup_agglomeration();
+  assemble_system();
+  solve();
+  output_results();
+}
+
+
+
+int
+main()
+{
+  deallog.depth_console(1);
+
+  try
+    {
+      Poisson<2> poisson_problem_linear_sol{SolutionType::LinearSolution};
+      poisson_problem_linear_sol.run();
+      std::cout << "Linear: OK" << std::endl;
+
+      Poisson<2> poisson_problem_quadratic_sol{SolutionType::QuadraticSolution};
+      poisson_problem_quadratic_sol.run();
+      std::cout << "Quadratic: OK" << std::endl;
+    }
+  catch (const std::exception &exc)
+    {
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+    }
+
+  return 0;
+}

--- a/test/polydeal/exact_solutions_dgp.output
+++ b/test/polydeal/exact_solutions_dgp.output
@@ -1,0 +1,4 @@
+Size of tria: 16
+Linear: OK
+Size of tria: 16
+Quadratic: OK

--- a/test/polydeal/fe_collection_agglomeration.cc
+++ b/test/polydeal/fe_collection_agglomeration.cc
@@ -111,10 +111,8 @@ test_hyper_cube(Triangulation<2> &tria)
         total_sum += weight;
     }
 
-
-
-  Assert(total_sum == GridTools::volume(tria, mapping),
-         ExcMessage("Integration did not succeed"));
+  AssertThrow(total_sum == GridTools::volume(tria, mapping),
+              ExcMessage("Integration did not succeed"));
   std::cout << "Ok" << std::endl;
 }
 
@@ -194,7 +192,7 @@ test_hyper_ball(Triangulation<2> &tria)
     }
 
   FE_DGQ<2> fe_dg(0);
-  ah.initialize_fe_values(QGauss<2>(2), update_JxW_values);
+  ah.initialize_fe_values(QGauss<2>(3), update_JxW_values);
   ah.distribute_agglomerated_dofs(fe_dg);
   double total_sum = 0.;
   for (const auto &polytope : ah.polytope_iterators())
@@ -204,8 +202,8 @@ test_hyper_ball(Triangulation<2> &tria)
         total_sum += weight;
     }
 
-  Assert(total_sum == GridTools::volume(tria, mapping),
-         ExcMessage("Integration did not succeed"));
+  AssertThrow((total_sum - GridTools::volume(tria, mapping) < 1e-13),
+              ExcMessage("Integration did not succeed."));
   std::cout << "Ok" << std::endl;
 }
 


### PR DESCRIPTION
To be merged after #129. This PR expands the interface to define agglomerates by checking if the input patch of cells is connected. If not, the connected components are computed using depth-first-search on the graph associated to the agglomerate and each one is agglomerated in the standard way. The relevant commit is aed376b15d2eabf52bc4d325b94108c17f820b5f

The following test explains the matter and has been added. Consider the following fine grid and flag for agglomeration the following cells:

$K_0 = \\{ 0,1,2,3,12,13,14,15\\}$
$K_1 = \\{4, 5, 6, 7, 8, 9, 10\\}$
$K_2 =\\{11\\}$
```

x - - - - - - - - - - - - -x
|     |     |      |       |
|  10 |  11 |  14  |  15   |
|     |     |      |       |
| - - | - - - - - -| - - - |
|     |     |      |       |
|  8  | 9   |  12  |  13   |
| - - | - - - - - -| - - - |
|     |     |      |       |
|  2  |  3  |  6   |   7   |
| - - | - - - - - -| - - - |
|  0  |  1  |  4   |    5  |
|     |     |      |       |
x - - - - - - - - - - - - -x
```


$K_0$ and $K_1$ are clearly disconnected. The new routine produces the following final set of agglomerates, by agglomerating the connected components separately.

$K_0 = \\{0,1,2,3\\}$
$K_1 = \\{4, 5, 6, 7\\}$
$K_2 = \\{11\\}$
$K_3 = \\{8, 9, 10\\}$
$K_4 = \\{12,13,14,15\\}$

The test simply checks that we can capture exactly on this new mesh some manufactured solutions which live in the test space.