### PR TITLE
Replace `FE_DGP` with custom class avoiding assert

### DIFF
--- a/examples/poisson.cc
+++ b/examples/poisson.cc
@@ -26,6 +26,7 @@
 #include <deal.II/numerics/data_out.h>
 
 #include <agglomeration_handler.h>
+#include <fe_agglodgp.h>
 #include <poly_utils.h>
 
 #include <algorithm>

--- a/examples/poisson.cc
+++ b/examples/poisson.cc
@@ -409,7 +409,7 @@ private:
   Triangulation<dim> tria;
 #ifdef HEX
   MappingQ1<dim>   mapping;
-  FE_AGGLODGP<dim> dg_fe;
+  FE_AggloDGP<dim> dg_fe;
 #else
   MappingFE<dim>     mapping;
   FE_SimplexDGP<dim> dg_fe;

--- a/examples/poisson.cc
+++ b/examples/poisson.cc
@@ -11,7 +11,6 @@
 // -----------------------------------------------------------------------------
 
 
-#include <deal.II/fe/fe_dgp.h>
 #include <deal.II/fe/mapping_fe.h>
 
 #include <deal.II/grid/grid_generator.h>
@@ -409,8 +408,8 @@ private:
 
   Triangulation<dim> tria;
 #ifdef HEX
-  MappingQ1<dim> mapping;
-  FE_DGQ<dim>    dg_fe;
+  MappingQ1<dim>   mapping;
+  FE_AGGLODGP<dim> dg_fe;
 #else
   MappingFE<dim>     mapping;
   FE_SimplexDGP<dim> dg_fe;

--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -22,7 +22,6 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
-#include <deal.II/fe/fe_dgp.h>
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nothing.h>
 #include <deal.II/fe/fe_simplex_p.h>
@@ -50,6 +49,7 @@
 
 #include <agglomeration_iterator.h>
 #include <agglomerator.h>
+#include <fe_agglodgp.h>
 #include <mapping_box.h>
 #include <utils.h>
 

--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -22,6 +22,7 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_dgp.h>
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nothing.h>
 #include <deal.II/fe/fe_simplex_p.h>
@@ -49,7 +50,6 @@
 
 #include <agglomeration_iterator.h>
 #include <agglomerator.h>
-#include <fe_agglodgp.h>
 #include <mapping_box.h>
 #include <utils.h>
 
@@ -762,11 +762,7 @@ private:
 
   ObserverPointer<const Triangulation<dim, spacedim>> tria;
 
-<<<<<<< HEAD
   ObserverPointer<const Mapping<dim, spacedim>> mapping;
-=======
-  SmartPointer<const Mapping<dim, spacedim>> mapping;
->>>>>>> 49f3083 (Add new class MappingBox, implementing bbox mapping on general (hex or tet) cells)
 
   std::unique_ptr<GridTools::Cache<dim, spacedim>> cached_tria;
 

--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -762,7 +762,11 @@ private:
 
   ObserverPointer<const Triangulation<dim, spacedim>> tria;
 
+<<<<<<< HEAD
   ObserverPointer<const Mapping<dim, spacedim>> mapping;
+=======
+  SmartPointer<const Mapping<dim, spacedim>> mapping;
+>>>>>>> 49f3083 (Add new class MappingBox, implementing bbox mapping on general (hex or tet) cells)
 
   std::unique_ptr<GridTools::Cache<dim, spacedim>> cached_tria;
 

--- a/include/fe_agglodgp.h
+++ b/include/fe_agglodgp.h
@@ -1,0 +1,477 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2002 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#ifndef dealii_fe_agglodgp_h
+#define dealii_fe_agglodgp_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/polynomial_space.h>
+
+#include <deal.II/fe/fe_poly.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * @addtogroup fe
+ * @{
+ */
+
+/**
+ * Discontinuous finite elements based on Legendre polynomials.
+ *
+ * This finite element implements complete polynomial spaces, that is,
+ * dim-dimensional polynomials of degree p. For example, in 2d the element
+ * FE_AGGLODGP(1) would represent the span of the functions $\{1,\hat x,\hat
+ * y\}$, which is in contrast to the element FE_DGQ(1) that is formed by the
+ * span of
+ * $\{1,\hat x,\hat y,\hat x\hat y\}$. Since the DGP space has only three
+ * unknowns for each quadrilateral, it is immediately clear that this element
+ * can not be continuous.
+ *
+ * The basis functions used in this element for the space described above are
+ * chosen to form a Legendre basis on the unit square, i.e., in particular
+ * they are $L_2$-orthogonal and normalized on the reference cell (but not
+ * necessarily on the real cell). As a consequence, the first basis function
+ * of this element is always the function that is constant and equal to one,
+ * regardless of the polynomial degree of the element. In addition, as a
+ * result of the orthogonality of the basis functions, the @ref GlossMassMatrix "mass matrix" is
+ * diagonal if the grid cells are parallelograms. Note that this is in
+ * contrast to the FE_DGPMonomial class that actually uses the monomial basis
+ * listed above as basis functions, without transformation from reference to
+ * real cell.
+ *
+ * The shape functions are defined in the class PolynomialSpace. The
+ * polynomials used inside PolynomialSpace are Polynomials::Legendre up to
+ * degree <tt>p</tt> given in FE_AGGLODGP. For the ordering of the basis
+ * functions, refer to PolynomialSpace, remembering that the Legendre
+ * polynomials are ordered by ascending degree.
+ *
+ * @note This element is not defined by finding shape functions within the
+ * given function space that interpolate a particular set of points.
+ * Consequently, there are no support points to which a given function could
+ * be interpolated; finding a finite element function that approximates a
+ * given function is therefore only possible through projection, rather than
+ * interpolation. Secondly, the shape functions of this element do not jointly
+ * add up to one. As a consequence of this, adding or subtracting a constant
+ * value -- such as one would do to make a function have mean value zero --
+ * can not be done by simply subtracting the constant value from each degree
+ * of freedom. Rather, one needs to use the fact that the first basis function
+ * is constant equal to one and simply subtract the constant from the value of
+ * the degree of freedom corresponding to this first shape function on each
+ * cell.
+ *
+ *
+ * @note This class is only partially implemented for the codimension one case
+ * (<tt>spacedim != dim </tt>), since no passage of information between meshes
+ * of different refinement level is possible because the embedding and
+ * projection matrices are not computed in the class constructor.
+ *
+ * <h3>Transformation properties</h3>
+ *
+ * It is worth noting that under a (bi-, tri-)linear mapping, the space
+ * described by this element does not contain $P(k)$, even if we use a basis
+ * of polynomials of degree $k$. Consequently, for example, on meshes with
+ * non-affine cells, a linear function can not be exactly represented by
+ * elements of type FE_AGGLODGP(1) or FE_DGPMonomial(1).
+ *
+ * This can be understood by the following 2-d example: consider the cell with
+ * vertices at $(0,0),(1,0),(0,1),(s,s)$:
+ * @image html dgp_doesnt_contain_p.png
+ *
+ * For this cell, a bilinear transformation $F$ produces the relations $x=\hat
+ * x+\hat x\hat y$ and $y=\hat y+\hat x\hat y$ that correlate reference
+ * coordinates $\hat x,\hat y$ and coordinates in real space $x,y$. Under this
+ * mapping, the constant function is clearly mapped onto itself, but the two
+ * other shape functions of the $P_1$ space, namely $\phi_1(\hat x,\hat
+ * y)=\hat x$ and $\phi_2(\hat x,\hat y)=\hat y$ are mapped onto
+ * $\phi_1(x,y)=\frac{x-t}{t(s-1)},\phi_2(x,y)=t$ where
+ * $t=\frac{y}{s-x+sx+y-sy}$.
+ *
+ * For the simple case that $s=1$, i.e. if the real cell is the unit square,
+ * the expressions can be simplified to $t=y$ and
+ * $\phi_1(x,y)=x,\phi_2(x,y)=y$. However, for all other cases, the functions
+ * $\phi_1(x,y),\phi_2(x,y)$ are not linear any more, and neither is any
+ * linear combination of them. Consequently, the linear functions are not
+ * within the range of the mapped $P_1$ polynomials.
+ *
+ * <h3>Visualization of shape functions</h3> In 2d, the shape functions of
+ * this element look as follows.
+ *
+ * <h4>$P_0$ element</h4>
+ *
+ * <table> <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P1/P1_DGP_shape0000.png
+ * </td>
+ *
+ * <td align="center"> </td> </tr> <tr> <td align="center"> $P_0$ element,
+ * shape function 0 </td>
+ *
+ * <td align="center"></tr> </table>
+ *
+ * <h4>$P_1$ element</h4>
+ *
+ * <table> <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P1/P1_DGP_shape0000.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P1/P1_DGP_shape0001.png
+ * </td> </tr> <tr> <td align="center"> $P_1$ element, shape function 0 </td>
+ *
+ * <td align="center"> $P_1$ element, shape function 1 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P1/P1_DGP_shape0002.png
+ * </td>
+ *
+ * <td align="center"> </td> </tr> <tr> <td align="center"> $P_1$ element,
+ * shape function 2 </td>
+ *
+ * <td align="center"></td> </tr> </table>
+ *
+ *
+ * <h4>$P_2$ element</h4>
+ *
+ * <table> <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P2/P2_DGP_shape0000.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P2/P2_DGP_shape0001.png
+ * </td> </tr> <tr> <td align="center"> $P_2$ element, shape function 0 </td>
+ *
+ * <td align="center"> $P_2$ element, shape function 1 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P2/P2_DGP_shape0002.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P2/P2_DGP_shape0003.png
+ * </td> </tr> <tr> <td align="center"> $P_2$ element, shape function 2 </td>
+ *
+ * <td align="center"> $P_2$ element, shape function 3 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P2/P2_DGP_shape0004.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P2/P2_DGP_shape0005.png
+ * </td> </tr> <tr> <td align="center"> $P_2$ element, shape function 4 </td>
+ *
+ * <td align="center"> $P_2$ element, shape function 5 </td> </tr> </table>
+ *
+ *
+ * <h4>$P_3$ element</h4>
+ *
+ * <table> <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P3/P3_DGP_shape0000.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P3/P3_DGP_shape0001.png
+ * </td> </tr> <tr> <td align="center"> $P_3$ element, shape function 0 </td>
+ *
+ * <td align="center"> $P_3$ element, shape function 1 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P3/P3_DGP_shape0002.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P3/P3_DGP_shape0003.png
+ * </td> </tr> <tr> <td align="center"> $P_3$ element, shape function 2 </td>
+ *
+ * <td align="center"> $P_3$ element, shape function 3 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P3/P3_DGP_shape0004.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P3/P3_DGP_shape0005.png
+ * </td> </tr> <tr> <td align="center"> $P_3$ element, shape function 4 </td>
+ *
+ * <td align="center"> $P_3$ element, shape function 5 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P3/P3_DGP_shape0006.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P3/P3_DGP_shape0007.png
+ * </td> </tr> <tr> <td align="center"> $P_3$ element, shape function 6 </td>
+ *
+ * <td align="center"> $P_3$ element, shape function 7 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P3/P3_DGP_shape0008.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P3/P3_DGP_shape0009.png
+ * </td> </tr> <tr> <td align="center"> $P_3$ element, shape function 8 </td>
+ *
+ * <td align="center"> $P_3$ element, shape function 9 </td> </tr> </table>
+ *
+ *
+ * <h4>$P_4$ element</h4> <table> <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0000.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0001.png
+ * </td> </tr> <tr> <td align="center"> $P_4$ element, shape function 0 </td>
+ *
+ * <td align="center"> $P_4$ element, shape function 1 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0002.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0003.png
+ * </td> </tr> <tr> <td align="center"> $P_4$ element, shape function 2 </td>
+ *
+ * <td align="center"> $P_4$ element, shape function 3 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0004.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0005.png
+ * </td> </tr> <tr> <td align="center"> $P_4$ element, shape function 4 </td>
+ *
+ * <td align="center"> $P_4$ element, shape function 5 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0006.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0007.png
+ * </td> </tr> <tr> <td align="center"> $P_4$ element, shape function 6 </td>
+ *
+ * <td align="center"> $P_4$ element, shape function 7 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0008.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0009.png
+ * </td> </tr> <tr> <td align="center"> $P_4$ element, shape function 8 </td>
+ *
+ * <td align="center"> $P_4$ element, shape function 9 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0010.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0011.png
+ * </td> </tr> <tr> <td align="center"> $P_4$ element, shape function 10 </td>
+ *
+ * <td align="center"> $P_4$ element, shape function 11 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0012.png
+ * </td>
+ *
+ * <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0013.png
+ * </td> </tr> <tr> <td align="center"> $P_4$ element, shape function 12 </td>
+ *
+ * <td align="center"> $P_4$ element, shape function 13 </td> </tr>
+ *
+ * <tr> <td align="center">
+ * @image html http://www.dealii.org/images/shape-functions/DGP/P4/P4_DGP_shape0014.png
+ * </td>
+ *
+ * <td align="center"> </td> </tr> <tr> <td align="center"> $P_4$ element,
+ * shape function 14 </td>
+ *
+ * <td align="center"></td> </tr> </table>
+ */
+template <int dim, int spacedim = dim>
+class FE_AGGLODGP : public FE_Poly<dim, spacedim>
+{
+public:
+  /**
+   * Constructor for tensor product polynomials of degree @p p.
+   */
+  FE_AGGLODGP(const unsigned int p);
+
+  /**
+   * Return a string that uniquely identifies a finite element. This class
+   * returns <tt>FE_AGGLODGP<dim>(degree)</tt>, with @p dim and @p degree replaced
+   * by appropriate values.
+   */
+  virtual std::string
+  get_name() const override;
+
+  /**
+   * @name Functions to support hp
+   * @{
+   */
+
+  /**
+   * If, on a vertex, several finite elements are active, the hp-code first
+   * assigns the degrees of freedom of each of these FEs different global
+   * indices. It then calls this function to find out which of them should get
+   * identical values, and consequently can receive the same global DoF index.
+   * This function therefore returns a list of identities between DoFs of the
+   * present finite element object with the DoFs of @p fe_other, which is a
+   * reference to a finite element object representing one of the other finite
+   * elements active on this particular vertex. The function computes which of
+   * the degrees of freedom of the two finite element objects are equivalent,
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
+   *
+   * This being a discontinuous element, the set of such constraints is of
+   * course empty.
+   */
+  virtual std::vector<std::pair<unsigned int, unsigned int>>
+  hp_vertex_dof_identities(
+    const FiniteElement<dim, spacedim> &fe_other) const override;
+
+  /**
+   * Same as hp_vertex_dof_indices(), except that the function treats degrees
+   * of freedom on lines.
+   *
+   * This being a discontinuous element, the set of such constraints is of
+   * course empty.
+   */
+  virtual std::vector<std::pair<unsigned int, unsigned int>>
+  hp_line_dof_identities(
+    const FiniteElement<dim, spacedim> &fe_other) const override;
+
+  /**
+   * Same as hp_vertex_dof_indices(), except that the function treats degrees
+   * of freedom on quads.
+   *
+   * This being a discontinuous element, the set of such constraints is of
+   * course empty.
+   */
+  virtual std::vector<std::pair<unsigned int, unsigned int>>
+  hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
+                         const unsigned int face_no = 0) const override;
+
+  /**
+   * Return whether this element implements its hanging node constraints in
+   * the new way, which has to be used to make elements "hp-compatible".
+   *
+   * For the FE_AGGLODGP class the result is always true (independent of the
+   * degree of the element), as it has no hanging nodes (being a discontinuous
+   * element).
+   */
+  virtual bool
+  hp_constraints_are_implemented() const override;
+
+  /**
+   * @copydoc FiniteElement::compare_for_domination()
+   */
+  virtual FiniteElementDomination::Domination
+  compare_for_domination(const FiniteElement<dim, spacedim> &fe_other,
+                         const unsigned int codim = 0) const override final;
+
+  /**
+   * @}
+   */
+
+  /**
+   * Return the matrix interpolating from a face of one element to the face
+   * of the neighboring element. The size of the matrix is then
+   * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
+   *
+   * Derived elements will have to implement this function. They may only
+   * provide interpolation matrices for certain source finite elements, for
+   * example those from the same family. If they don't implement interpolation
+   * from a given element, then they must throw an exception of type
+   * FiniteElement<dim,spacedim>::ExcInterpolationNotImplemented.
+   */
+  virtual void
+  get_face_interpolation_matrix(const FiniteElement<dim, spacedim> &source,
+                                FullMatrix<double>                 &matrix,
+                                const unsigned int face_no = 0) const override;
+
+  /**
+   * Return the matrix interpolating from a face of one element to the face
+   * of the neighboring element. The size of the matrix is then
+   * <tt>source.dofs_per_face</tt> times <tt>this->dofs_per_face</tt>.
+   *
+   * Derived elements will have to implement this function. They may only
+   * provide interpolation matrices for certain source finite elements, for
+   * example those from the same family. If they don't implement interpolation
+   * from a given element, then they must throw an exception of type
+   * FiniteElement<dim,spacedim>::ExcInterpolationNotImplemented.
+   */
+  virtual void
+  get_subface_interpolation_matrix(
+    const FiniteElement<dim, spacedim> &source,
+    const unsigned int                  subface,
+    FullMatrix<double>                 &matrix,
+    const unsigned int                  face_no = 0) const override;
+
+  /**
+   * This function returns @p true, if the shape function @p shape_index has
+   * non-zero function values somewhere on the face @p face_index.
+   */
+  virtual bool
+  has_support_on_face(const unsigned int shape_index,
+                      const unsigned int face_index) const override;
+
+  /**
+   * Determine an estimate for the memory consumption (in bytes) of this
+   * object.
+   *
+   * This function is made virtual, since finite element objects are usually
+   * accessed through pointers to their base class, rather than the class
+   * itself.
+   */
+  virtual std::size_t
+  memory_consumption() const override;
+
+
+  /**
+   * Return a list of constant modes of the element. For this element, the
+   * first entry is true, all other are false.
+   */
+  virtual std::pair<Table<2, bool>, std::vector<unsigned int>>
+  get_constant_modes() const override;
+
+  virtual std::unique_ptr<FiniteElement<dim, spacedim>>
+  clone() const override;
+
+private:
+  /**
+   * Only for internal use. Its full name is @p get_dofs_per_object_vector
+   * function and it creates the @p dofs_per_object vector that is needed
+   * within the constructor to be passed to the constructor of @p
+   * FiniteElementData.
+   */
+  static std::vector<unsigned int>
+  get_dpo_vector(const unsigned int degree);
+};
+
+/** @} */
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/fe_agglodgp.h
+++ b/include/fe_agglodgp.h
@@ -33,7 +33,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * This finite element implements complete polynomial spaces, that is,
  * dim-dimensional polynomials of degree p. For example, in 2d the element
- * FE_AGGLODGP(1) would represent the span of the functions $\{1,\hat x,\hat
+ * FE_AggloDGP(1) would represent the span of the functions $\{1,\hat x,\hat
  * y\}$, which is in contrast to the element FE_DGQ(1) that is formed by the
  * span of
  * $\{1,\hat x,\hat y,\hat x\hat y\}$. Since the DGP space has only three
@@ -54,7 +54,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * The shape functions are defined in the class PolynomialSpace. The
  * polynomials used inside PolynomialSpace are Polynomials::Legendre up to
- * degree <tt>p</tt> given in FE_AGGLODGP. For the ordering of the basis
+ * degree <tt>p</tt> given in FE_AggloDGP. For the ordering of the basis
  * functions, refer to PolynomialSpace, remembering that the Legendre
  * polynomials are ordered by ascending degree.
  *
@@ -84,7 +84,7 @@ DEAL_II_NAMESPACE_OPEN
  * described by this element does not contain $P(k)$, even if we use a basis
  * of polynomials of degree $k$. Consequently, for example, on meshes with
  * non-affine cells, a linear function can not be exactly represented by
- * elements of type FE_AGGLODGP(1) or FE_DGPMonomial(1).
+ * elements of type FE_AggloDGP(1) or FE_DGPMonomial(1).
  *
  * This can be understood by the following 2-d example: consider the cell with
  * vertices at $(0,0),(1,0),(0,1),(s,s)$:
@@ -308,17 +308,17 @@ DEAL_II_NAMESPACE_OPEN
  * <td align="center"></td> </tr> </table>
  */
 template <int dim, int spacedim = dim>
-class FE_AGGLODGP : public FE_Poly<dim, spacedim>
+class FE_AggloDGP : public FE_Poly<dim, spacedim>
 {
 public:
   /**
    * Constructor for tensor product polynomials of degree @p p.
    */
-  FE_AGGLODGP(const unsigned int p);
+  FE_AggloDGP(const unsigned int p);
 
   /**
    * Return a string that uniquely identifies a finite element. This class
-   * returns <tt>FE_AGGLODGP<dim>(degree)</tt>, with @p dim and @p degree replaced
+   * returns <tt>FE_AggloDGP<dim>(degree)</tt>, with @p dim and @p degree replaced
    * by appropriate values.
    */
   virtual std::string
@@ -377,7 +377,7 @@ public:
    * Return whether this element implements its hanging node constraints in
    * the new way, which has to be used to make elements "hp-compatible".
    *
-   * For the FE_AGGLODGP class the result is always true (independent of the
+   * For the FE_AggloDGP class the result is always true (independent of the
    * degree of the element), as it has no hanging nodes (being a discontinuous
    * element).
    */

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -3,7 +3,7 @@ SET(_d2_build_types "Release;Debug")
 SET(Release_postfix "")
 SET(Debug_postfix ".g")
 
-set(_files agglomeration_handler.cc multigrid_amg.cc mapping_box.cc)
+set(_files agglomeration_handler.cc multigrid_amg.cc mapping_box.cc fe_agglodgp.cc)
 
 FOREACH(_build_type ${_d2_build_types})
   # Postfix to use everywhere

--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -232,8 +232,8 @@ AgglomerationHandler<dim, spacedim>::distribute_agglomerated_dofs(
 {
   if (dynamic_cast<const FE_DGQ<dim> *>(&fe_space))
     fe = std::make_unique<FE_DGQ<dim>>(fe_space.degree);
-  else if (dynamic_cast<const FE_AGGLODGP<dim> *>(&fe_space))
-    fe = std::make_unique<FE_AGGLODGP<dim>>(fe_space.degree);
+  else if (dynamic_cast<const FE_AggloDGP<dim> *>(&fe_space))
+    fe = std::make_unique<FE_AggloDGP<dim>>(fe_space.degree);
   else if (dynamic_cast<const FE_SimplexDGP<dim> *>(&fe_space))
     fe = std::make_unique<FE_SimplexDGP<dim>>(fe_space.degree);
   else

--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -232,8 +232,8 @@ AgglomerationHandler<dim, spacedim>::distribute_agglomerated_dofs(
 {
   if (dynamic_cast<const FE_DGQ<dim> *>(&fe_space))
     fe = std::make_unique<FE_DGQ<dim>>(fe_space.degree);
-  else if (dynamic_cast<const FE_DGP<dim> *>(&fe_space))
-    fe = std::make_unique<FE_DGP<dim>>(fe_space.degree);
+  else if (dynamic_cast<const FE_AGGLODGP<dim> *>(&fe_space))
+    fe = std::make_unique<FE_AGGLODGP<dim>>(fe_space.degree);
   else if (dynamic_cast<const FE_SimplexDGP<dim> *>(&fe_space))
     fe = std::make_unique<FE_SimplexDGP<dim>>(fe_space.degree);
   else

--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -15,6 +15,7 @@
 #include <deal.II/lac/sparsity_tools.h>
 
 #include <agglomeration_handler.h>
+#include <fe_agglodgp.h>
 
 template <int dim, int spacedim>
 AgglomerationHandler<dim, spacedim>::AgglomerationHandler(
@@ -148,22 +149,26 @@ AgglomerationHandler<dim, spacedim>::initialize_fe_values(
   const Quadrature<dim>     &cell_quadrature,
   const UpdateFlags         &flags,
   const Quadrature<dim - 1> &face_quadrature,
-  const UpdateFlags         &face_flags) agglomeration_quad = cell_quadrature;
-agglomeration_face_flags = face_flags | internal_agglomeration_face_flags;
+  const UpdateFlags         &face_flags)
+{
+  agglomeration_quad       = cell_quadrature;
+  agglomeration_flags      = flags;
+  agglomeration_face_quad  = face_quadrature;
+  agglomeration_face_flags = face_flags | internal_agglomeration_face_flags;
 
 
-no_values =
-  std::make_unique<FEValues<dim>>(*mapping,
-                                  dummy_fe,
-                                  agglomeration_quad,
-                                  update_quadrature_points |
-                                    update_JxW_values); // only for quadrature
-no_face_values = std::make_unique<FEFaceValues<dim>>(
-  *mapping,
-  dummy_fe,
-  agglomeration_face_quad,
-  update_quadrature_points | update_JxW_values |
-    update_normal_vectors); // only for quadrature
+  no_values =
+    std::make_unique<FEValues<dim>>(*mapping,
+                                    dummy_fe,
+                                    agglomeration_quad,
+                                    update_quadrature_points |
+                                      update_JxW_values); // only for quadrature
+  no_face_values = std::make_unique<FEFaceValues<dim>>(
+    *mapping,
+    dummy_fe,
+    agglomeration_face_quad,
+    update_quadrature_points | update_JxW_values |
+      update_normal_vectors); // only for quadrature
 }
 
 

--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -148,26 +148,22 @@ AgglomerationHandler<dim, spacedim>::initialize_fe_values(
   const Quadrature<dim>     &cell_quadrature,
   const UpdateFlags         &flags,
   const Quadrature<dim - 1> &face_quadrature,
-  const UpdateFlags         &face_flags)
-{
-  agglomeration_quad       = cell_quadrature;
-  agglomeration_flags      = flags;
-  agglomeration_face_quad  = face_quadrature;
-  agglomeration_face_flags = face_flags | internal_agglomeration_face_flags;
+  const UpdateFlags         &face_flags) agglomeration_quad = cell_quadrature;
+agglomeration_face_flags = face_flags | internal_agglomeration_face_flags;
 
 
-  no_values =
-    std::make_unique<FEValues<dim>>(*mapping,
-                                    dummy_fe,
-                                    agglomeration_quad,
-                                    update_quadrature_points |
-                                      update_JxW_values); // only for quadrature
-  no_face_values = std::make_unique<FEFaceValues<dim>>(
-    *mapping,
-    dummy_fe,
-    agglomeration_face_quad,
-    update_quadrature_points | update_JxW_values |
-      update_normal_vectors); // only for quadrature
+no_values =
+  std::make_unique<FEValues<dim>>(*mapping,
+                                  dummy_fe,
+                                  agglomeration_quad,
+                                  update_quadrature_points |
+                                    update_JxW_values); // only for quadrature
+no_face_values = std::make_unique<FEFaceValues<dim>>(
+  *mapping,
+  dummy_fe,
+  agglomeration_face_quad,
+  update_quadrature_points | update_JxW_values |
+    update_normal_vectors); // only for quadrature
 }
 
 

--- a/source/fe_agglodgp.cc
+++ b/source/fe_agglodgp.cc
@@ -25,7 +25,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
-FE_AGGLODGP<dim, spacedim>::FE_AGGLODGP(const unsigned int degree)
+FE_AggloDGP<dim, spacedim>::FE_AggloDGP(const unsigned int degree)
   : FE_Poly<dim, spacedim>(
       PolynomialSpace<dim>(
         Polynomials::Legendre::generate_complete_basis(degree)),
@@ -57,14 +57,14 @@ FE_AGGLODGP<dim, spacedim>::FE_AGGLODGP(const unsigned int degree)
 
 template <int dim, int spacedim>
 std::string
-FE_AGGLODGP<dim, spacedim>::get_name() const
+FE_AggloDGP<dim, spacedim>::get_name() const
 {
   // note that the FETools::get_fe_by_name function depends on the
   // particular format of the string this function returns, so they have to be
   // kept in sync
 
   std::ostringstream namebuf;
-  namebuf << "FE_AGGLODGP<" << Utilities::dim_string(dim, spacedim) << ">("
+  namebuf << "FE_AggloDGP<" << Utilities::dim_string(dim, spacedim) << ">("
           << this->degree << ")";
 
   return namebuf.str();
@@ -74,9 +74,9 @@ FE_AGGLODGP<dim, spacedim>::get_name() const
 
 template <int dim, int spacedim>
 std::unique_ptr<FiniteElement<dim, spacedim>>
-FE_AGGLODGP<dim, spacedim>::clone() const
+FE_AggloDGP<dim, spacedim>::clone() const
 {
-  return std::make_unique<FE_AGGLODGP<dim, spacedim>>(*this);
+  return std::make_unique<FE_AggloDGP<dim, spacedim>>(*this);
 }
 
 
@@ -88,7 +88,7 @@ FE_AGGLODGP<dim, spacedim>::clone() const
 
 template <int dim, int spacedim>
 std::vector<unsigned int>
-FE_AGGLODGP<dim, spacedim>::get_dpo_vector(const unsigned int deg)
+FE_AggloDGP<dim, spacedim>::get_dpo_vector(const unsigned int deg)
 {
   std::vector<unsigned int> dpo(dim + 1, 0U);
   dpo[dim] = deg + 1;
@@ -104,7 +104,7 @@ FE_AGGLODGP<dim, spacedim>::get_dpo_vector(const unsigned int deg)
 
 template <int dim, int spacedim>
 void
-FE_AGGLODGP<dim, spacedim>::get_face_interpolation_matrix(
+FE_AggloDGP<dim, spacedim>::get_face_interpolation_matrix(
   const FiniteElement<dim, spacedim> &x_source_fe,
   FullMatrix<double>                 &interpolation_matrix,
   const unsigned int) const
@@ -115,8 +115,8 @@ FE_AGGLODGP<dim, spacedim>::get_face_interpolation_matrix(
   // need to do here.
   (void)interpolation_matrix;
   using FE    = FiniteElement<dim, spacedim>;
-  using FEDGP = FE_AGGLODGP<dim, spacedim>;
-  AssertThrow((x_source_fe.get_name().find("FE_AGGLODGP<") == 0) ||
+  using FEDGP = FE_AggloDGP<dim, spacedim>;
+  AssertThrow((x_source_fe.get_name().find("FE_AggloDGP<") == 0) ||
                 (dynamic_cast<const FEDGP *>(&x_source_fe) != nullptr),
               typename FE::ExcInterpolationNotImplemented());
 
@@ -130,7 +130,7 @@ FE_AGGLODGP<dim, spacedim>::get_face_interpolation_matrix(
 
 template <int dim, int spacedim>
 void
-FE_AGGLODGP<dim, spacedim>::get_subface_interpolation_matrix(
+FE_AggloDGP<dim, spacedim>::get_subface_interpolation_matrix(
   const FiniteElement<dim, spacedim> &x_source_fe,
   const unsigned int,
   FullMatrix<double> &interpolation_matrix,
@@ -142,8 +142,8 @@ FE_AGGLODGP<dim, spacedim>::get_subface_interpolation_matrix(
   // need to do here.
   (void)interpolation_matrix;
   using FE    = FiniteElement<dim, spacedim>;
-  using FEDGP = FE_AGGLODGP<dim, spacedim>;
-  AssertThrow((x_source_fe.get_name().find("FE_AGGLODGP<") == 0) ||
+  using FEDGP = FE_AggloDGP<dim, spacedim>;
+  AssertThrow((x_source_fe.get_name().find("FE_AggloDGP<") == 0) ||
                 (dynamic_cast<const FEDGP *>(&x_source_fe) != nullptr),
               typename FE::ExcInterpolationNotImplemented());
 
@@ -157,7 +157,7 @@ FE_AGGLODGP<dim, spacedim>::get_subface_interpolation_matrix(
 
 template <int dim, int spacedim>
 bool
-FE_AGGLODGP<dim, spacedim>::hp_constraints_are_implemented() const
+FE_AggloDGP<dim, spacedim>::hp_constraints_are_implemented() const
 {
   return true;
 }
@@ -166,7 +166,7 @@ FE_AGGLODGP<dim, spacedim>::hp_constraints_are_implemented() const
 
 template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
-FE_AGGLODGP<dim, spacedim>::hp_vertex_dof_identities(
+FE_AggloDGP<dim, spacedim>::hp_vertex_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other) const
 {
   (void)fe_other;
@@ -177,11 +177,11 @@ FE_AGGLODGP<dim, spacedim>::hp_vertex_dof_identities(
 
 template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
-FE_AGGLODGP<dim, spacedim>::hp_line_dof_identities(
+FE_AggloDGP<dim, spacedim>::hp_line_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other) const
 {
   // there are no such constraints for DGP elements at all
-  if (dynamic_cast<const FE_AGGLODGP<dim, spacedim> *>(&fe_other) != nullptr)
+  if (dynamic_cast<const FE_AggloDGP<dim, spacedim> *>(&fe_other) != nullptr)
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
@@ -194,12 +194,12 @@ FE_AGGLODGP<dim, spacedim>::hp_line_dof_identities(
 
 template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
-FE_AGGLODGP<dim, spacedim>::hp_quad_dof_identities(
+FE_AggloDGP<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
   const unsigned int) const
 {
   // there are no such constraints for DGP elements at all
-  if (dynamic_cast<const FE_AGGLODGP<dim, spacedim> *>(&fe_other) != nullptr)
+  if (dynamic_cast<const FE_AggloDGP<dim, spacedim> *>(&fe_other) != nullptr)
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
@@ -212,7 +212,7 @@ FE_AGGLODGP<dim, spacedim>::hp_quad_dof_identities(
 
 template <int dim, int spacedim>
 FiniteElementDomination::Domination
-FE_AGGLODGP<dim, spacedim>::compare_for_domination(
+FE_AggloDGP<dim, spacedim>::compare_for_domination(
   const FiniteElement<dim, spacedim> &fe_other,
   const unsigned int                  codim) const
 {
@@ -228,8 +228,8 @@ FE_AGGLODGP<dim, spacedim>::compare_for_domination(
 
   // cell domination
   // ---------------
-  if (const FE_AGGLODGP<dim, spacedim> *fe_dgp_other =
-        dynamic_cast<const FE_AGGLODGP<dim, spacedim> *>(&fe_other))
+  if (const FE_AggloDGP<dim, spacedim> *fe_dgp_other =
+        dynamic_cast<const FE_AggloDGP<dim, spacedim> *>(&fe_other))
     {
       if (this->degree < fe_dgp_other->degree)
         return FiniteElementDomination::this_element_dominates;
@@ -258,7 +258,7 @@ FE_AGGLODGP<dim, spacedim>::compare_for_domination(
 
 template <int dim, int spacedim>
 bool
-FE_AGGLODGP<dim, spacedim>::has_support_on_face(const unsigned int,
+FE_AggloDGP<dim, spacedim>::has_support_on_face(const unsigned int,
                                                 const unsigned int) const
 {
   // all shape functions have support on all faces
@@ -269,7 +269,7 @@ FE_AGGLODGP<dim, spacedim>::has_support_on_face(const unsigned int,
 
 template <int dim, int spacedim>
 std::pair<Table<2, bool>, std::vector<unsigned int>>
-FE_AGGLODGP<dim, spacedim>::get_constant_modes() const
+FE_AggloDGP<dim, spacedim>::get_constant_modes() const
 {
   Table<2, bool> constant_modes(1, this->n_dofs_per_cell());
   constant_modes(0, 0) = true;
@@ -281,7 +281,7 @@ FE_AGGLODGP<dim, spacedim>::get_constant_modes() const
 
 template <int dim, int spacedim>
 std::size_t
-FE_AGGLODGP<dim, spacedim>::memory_consumption() const
+FE_AggloDGP<dim, spacedim>::memory_consumption() const
 {
   DEAL_II_NOT_IMPLEMENTED();
   return 0;
@@ -290,9 +290,9 @@ FE_AGGLODGP<dim, spacedim>::memory_consumption() const
 
 
 // explicit instantiations
-template class FE_AGGLODGP<1>;
-template class FE_AGGLODGP<2>;
-template class FE_AGGLODGP<3>;
+template class FE_AggloDGP<1>;
+template class FE_AggloDGP<2>;
+template class FE_AggloDGP<3>;
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/fe_agglodgp.cc
+++ b/source/fe_agglodgp.cc
@@ -1,0 +1,298 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2002 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_tools.h>
+
+#include <fe_agglodgp.h>
+
+#include <memory>
+#include <sstream>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+template <int dim, int spacedim>
+FE_AGGLODGP<dim, spacedim>::FE_AGGLODGP(const unsigned int degree)
+  : FE_Poly<dim, spacedim>(
+      PolynomialSpace<dim>(
+        Polynomials::Legendre::generate_complete_basis(degree)),
+      FiniteElementData<dim>(get_dpo_vector(degree),
+                             1,
+                             degree,
+                             FiniteElementData<dim>::L2),
+      std::vector<bool>(
+        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree)
+          .n_dofs_per_cell(),
+        true),
+      std::vector<ComponentMask>(
+        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree)
+          .n_dofs_per_cell(),
+        ComponentMask(std::vector<bool>(1, true))))
+{
+  // Reinit the vectors of restriction and prolongation matrices to the right
+  // sizes
+  this->reinit_restriction_and_prolongation_matrices();
+  // Fill prolongation matrices with embedding operators
+  if (dim == spacedim)
+    {
+      FETools::compute_embedding_matrices(*this, this->prolongation);
+      // Fill restriction matrices with L2-projection
+      FETools::compute_projection_matrices(*this, this->restriction);
+    }
+}
+
+
+template <int dim, int spacedim>
+std::string
+FE_AGGLODGP<dim, spacedim>::get_name() const
+{
+  // note that the FETools::get_fe_by_name function depends on the
+  // particular format of the string this function returns, so they have to be
+  // kept in sync
+
+  std::ostringstream namebuf;
+  namebuf << "FE_AGGLODGP<" << Utilities::dim_string(dim, spacedim) << ">("
+          << this->degree << ")";
+
+  return namebuf.str();
+}
+
+
+
+template <int dim, int spacedim>
+std::unique_ptr<FiniteElement<dim, spacedim>>
+FE_AGGLODGP<dim, spacedim>::clone() const
+{
+  return std::make_unique<FE_AGGLODGP<dim, spacedim>>(*this);
+}
+
+
+
+//---------------------------------------------------------------------------
+// Auxiliary functions
+//---------------------------------------------------------------------------
+
+
+template <int dim, int spacedim>
+std::vector<unsigned int>
+FE_AGGLODGP<dim, spacedim>::get_dpo_vector(const unsigned int deg)
+{
+  std::vector<unsigned int> dpo(dim + 1, 0U);
+  dpo[dim] = deg + 1;
+  for (unsigned int i = 1; i < dim; ++i)
+    {
+      dpo[dim] *= deg + 1 + i;
+      dpo[dim] /= i + 1;
+    }
+  return dpo;
+}
+
+
+
+template <int dim, int spacedim>
+void
+FE_AGGLODGP<dim, spacedim>::get_face_interpolation_matrix(
+  const FiniteElement<dim, spacedim> &x_source_fe,
+  FullMatrix<double>                 &interpolation_matrix,
+  const unsigned int) const
+{
+  // this is only implemented, if the source FE is also a DGP element. in that
+  // case, both elements have no dofs on their faces and the face
+  // interpolation matrix is necessarily empty -- i.e. there isn't much we
+  // need to do here.
+  (void)interpolation_matrix;
+  using FE    = FiniteElement<dim, spacedim>;
+  using FEDGP = FE_AGGLODGP<dim, spacedim>;
+  AssertThrow((x_source_fe.get_name().find("FE_AGGLODGP<") == 0) ||
+                (dynamic_cast<const FEDGP *>(&x_source_fe) != nullptr),
+              typename FE::ExcInterpolationNotImplemented());
+
+  Assert(interpolation_matrix.m() == 0,
+         ExcDimensionMismatch(interpolation_matrix.m(), 0));
+  Assert(interpolation_matrix.n() == 0,
+         ExcDimensionMismatch(interpolation_matrix.n(), 0));
+}
+
+
+
+template <int dim, int spacedim>
+void
+FE_AGGLODGP<dim, spacedim>::get_subface_interpolation_matrix(
+  const FiniteElement<dim, spacedim> &x_source_fe,
+  const unsigned int,
+  FullMatrix<double> &interpolation_matrix,
+  const unsigned int) const
+{
+  // this is only implemented, if the source FE is also a DGP element. in that
+  // case, both elements have no dofs on their faces and the face
+  // interpolation matrix is necessarily empty -- i.e. there isn't much we
+  // need to do here.
+  (void)interpolation_matrix;
+  using FE    = FiniteElement<dim, spacedim>;
+  using FEDGP = FE_AGGLODGP<dim, spacedim>;
+  AssertThrow((x_source_fe.get_name().find("FE_AGGLODGP<") == 0) ||
+                (dynamic_cast<const FEDGP *>(&x_source_fe) != nullptr),
+              typename FE::ExcInterpolationNotImplemented());
+
+  Assert(interpolation_matrix.m() == 0,
+         ExcDimensionMismatch(interpolation_matrix.m(), 0));
+  Assert(interpolation_matrix.n() == 0,
+         ExcDimensionMismatch(interpolation_matrix.n(), 0));
+}
+
+
+
+template <int dim, int spacedim>
+bool
+FE_AGGLODGP<dim, spacedim>::hp_constraints_are_implemented() const
+{
+  return true;
+}
+
+
+
+template <int dim, int spacedim>
+std::vector<std::pair<unsigned int, unsigned int>>
+FE_AGGLODGP<dim, spacedim>::hp_vertex_dof_identities(
+  const FiniteElement<dim, spacedim> &fe_other) const
+{
+  (void)fe_other;
+  return std::vector<std::pair<unsigned int, unsigned int>>();
+}
+
+
+
+template <int dim, int spacedim>
+std::vector<std::pair<unsigned int, unsigned int>>
+FE_AGGLODGP<dim, spacedim>::hp_line_dof_identities(
+  const FiniteElement<dim, spacedim> &fe_other) const
+{
+  // there are no such constraints for DGP elements at all
+  if (dynamic_cast<const FE_AGGLODGP<dim, spacedim> *>(&fe_other) != nullptr)
+    return std::vector<std::pair<unsigned int, unsigned int>>();
+  else
+    {
+      DEAL_II_NOT_IMPLEMENTED();
+      return std::vector<std::pair<unsigned int, unsigned int>>();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+std::vector<std::pair<unsigned int, unsigned int>>
+FE_AGGLODGP<dim, spacedim>::hp_quad_dof_identities(
+  const FiniteElement<dim, spacedim> &fe_other,
+  const unsigned int) const
+{
+  // there are no such constraints for DGP elements at all
+  if (dynamic_cast<const FE_AGGLODGP<dim, spacedim> *>(&fe_other) != nullptr)
+    return std::vector<std::pair<unsigned int, unsigned int>>();
+  else
+    {
+      DEAL_II_NOT_IMPLEMENTED();
+      return std::vector<std::pair<unsigned int, unsigned int>>();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+FiniteElementDomination::Domination
+FE_AGGLODGP<dim, spacedim>::compare_for_domination(
+  const FiniteElement<dim, spacedim> &fe_other,
+  const unsigned int                  codim) const
+{
+  Assert(codim <= dim, ExcImpossibleInDim(dim));
+
+  // vertex/line/face domination
+  // ---------------------------
+  if (codim > 0)
+    // this is a discontinuous element, so by definition there will
+    // be no constraints wherever this element comes together with
+    // any other kind of element
+    return FiniteElementDomination::no_requirements;
+
+  // cell domination
+  // ---------------
+  if (const FE_AGGLODGP<dim, spacedim> *fe_dgp_other =
+        dynamic_cast<const FE_AGGLODGP<dim, spacedim> *>(&fe_other))
+    {
+      if (this->degree < fe_dgp_other->degree)
+        return FiniteElementDomination::this_element_dominates;
+      else if (this->degree == fe_dgp_other->degree)
+        return FiniteElementDomination::either_element_can_dominate;
+      else
+        return FiniteElementDomination::other_element_dominates;
+    }
+  else if (const FE_Nothing<dim> *fe_nothing =
+             dynamic_cast<const FE_Nothing<dim> *>(&fe_other))
+    {
+      if (fe_nothing->is_dominating())
+        return FiniteElementDomination::other_element_dominates;
+      else
+        // the FE_Nothing has no degrees of freedom and it is typically used
+        // in a context where we don't require any continuity along the
+        // interface
+        return FiniteElementDomination::no_requirements;
+    }
+
+  DEAL_II_NOT_IMPLEMENTED();
+  return FiniteElementDomination::neither_element_dominates;
+}
+
+
+
+template <int dim, int spacedim>
+bool
+FE_AGGLODGP<dim, spacedim>::has_support_on_face(const unsigned int,
+                                                const unsigned int) const
+{
+  // all shape functions have support on all faces
+  return true;
+}
+
+
+
+template <int dim, int spacedim>
+std::pair<Table<2, bool>, std::vector<unsigned int>>
+FE_AGGLODGP<dim, spacedim>::get_constant_modes() const
+{
+  Table<2, bool> constant_modes(1, this->n_dofs_per_cell());
+  constant_modes(0, 0) = true;
+  return std::pair<Table<2, bool>, std::vector<unsigned int>>(
+    constant_modes, std::vector<unsigned int>(1, 0));
+}
+
+
+
+template <int dim, int spacedim>
+std::size_t
+FE_AGGLODGP<dim, spacedim>::memory_consumption() const
+{
+  DEAL_II_NOT_IMPLEMENTED();
+  return 0;
+}
+
+
+
+// explicit instantiations
+template class FE_AGGLODGP<1>;
+template class FE_AGGLODGP<2>;
+template class FE_AGGLODGP<3>;
+
+
+DEAL_II_NAMESPACE_CLOSE

--- a/test/polydeal/exact_solutions_dgp.cc
+++ b/test/polydeal/exact_solutions_dgp.cc
@@ -240,7 +240,7 @@ private:
 
   Triangulation<dim>                         tria;
   MappingQ<dim>                              mapping;
-  FE_AGGLODGP<dim>                          *dg_fe;
+  FE_AggloDGP<dim>                          *dg_fe;
   std::unique_ptr<AgglomerationHandler<dim>> ah;
   // no hanging node in DG discretization, we define an AffineConstraints
   // object
@@ -275,12 +275,12 @@ Poisson<dim>::Poisson(const SolutionType &solution_type)
 {
   if (sol_type == SolutionType::LinearSolution)
     {
-      dg_fe               = new FE_AGGLODGP<dim>{1};
+      dg_fe               = new FE_AggloDGP<dim>{1};
       analytical_solution = new SolutionLinear<dim>();
     }
   else
     {
-      dg_fe               = new FE_AGGLODGP<dim>{2};
+      dg_fe               = new FE_AggloDGP<dim>{2};
       analytical_solution = new SolutionQuadratic<dim>();
     }
 }

--- a/test/polydeal/exact_solutions_dgp.cc
+++ b/test/polydeal/exact_solutions_dgp.cc
@@ -1,5 +1,3 @@
-#include <deal.II/fe/fe_dgp.h>
-
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_out.h>
@@ -16,6 +14,7 @@
 #include <deal.II/numerics/vector_tools_interpolate.h>
 
 #include <agglomeration_handler.h>
+#include <fe_agglodgp.h>
 #include <poly_utils.h>
 
 #include <algorithm>
@@ -241,7 +240,7 @@ private:
 
   Triangulation<dim>                         tria;
   MappingQ<dim>                              mapping;
-  FE_DGP<dim>                               *dg_fe;
+  FE_AGGLODGP<dim>                          *dg_fe;
   std::unique_ptr<AgglomerationHandler<dim>> ah;
   // no hanging node in DG discretization, we define an AffineConstraints
   // object
@@ -276,12 +275,12 @@ Poisson<dim>::Poisson(const SolutionType &solution_type)
 {
   if (sol_type == SolutionType::LinearSolution)
     {
-      dg_fe               = new FE_DGP<dim>{1};
+      dg_fe               = new FE_AGGLODGP<dim>{1};
       analytical_solution = new SolutionLinear<dim>();
     }
   else
     {
-      dg_fe               = new FE_DGP<dim>{2};
+      dg_fe               = new FE_AGGLODGP<dim>{2};
       analytical_solution = new SolutionQuadratic<dim>();
     }
 }


### PR DESCRIPTION
A new class which consists of a copy of `FE_DGP` in which this assert is not triggered.

```C++
template <int dim, int spacedim>
std::vector<std::pair<unsigned int, unsigned int>>
FE_DGP<dim, spacedim>::hp_vertex_dof_identities(
  const FiniteElement<dim, spacedim> &fe_other) const
{
  // there are no such constraints for DGP elements at all
  if (dynamic_cast<const FE_DGP<dim, spacedim> *>(&fe_other) != nullptr)
    return std::vector<std::pair<unsigned int, unsigned int>>();
  else
    {
      DEAL_II_NOT_IMPLEMENTED();
      return std::vector<std::pair<unsigned int, unsigned int>>();
    }
}
```
(see https://github.com/dealii/dealii/blob/2170eda0660b33e988d89a5816279387702db0dd/source/fe/fe_dgp.cc#L183-L197)

In the `FE_DGQ` case we never hit this because deal.II simply decides not to throw and returns an empty vector. The replacement I proposed in this PR does the same.
