### PR TITLE
hp::FECollection support + Oseen example

### DIFF
--- a/examples/PolyOseen.cc
+++ b/examples/PolyOseen.cc
@@ -773,8 +773,8 @@ namespace OseenNamespace
                     cell_matrix(i, j) +=
                       (viscosity_nu * scalar_product(grad_phi_u[i],
                                                      grad_phi_u[j]) // + ν ∇v:∇u
-                       - div_phi_u[i] * phi_p[j]                    // - ∇·v p
-                       + phi_p[i] * div_phi_u[j]                    // + ∇·u q
+                       - div_phi_u[i] * phi_p[j] // - ∇·v p
+                       + phi_p[i] * div_phi_u[j] // + ∇·u q
                        +
                        phi_u[i] * (grad_phi_u[j] * beta[q_index]) // + v· (β·∇)u
                        ) *
@@ -1008,14 +1008,16 @@ namespace OseenNamespace
                     double tau_neigh = (viscosity_nu) * (deg_v_neigh + 1) *
                                        (deg_v_neigh + dim) /
                                        std::fabs(neigh_polytope->diameter());
-                    double sigma_v = penalty_constant_v * std::max(tau_current, tau_neigh);
+                    double sigma_v =
+                      penalty_constant_v * std::max(tau_current, tau_neigh);
 
                     double zeta_current =
                       1. / (viscosity_nu / polytope->diameter() + beta_max);
                     double zeta_neigh =
                       1. /
                       (viscosity_nu / neigh_polytope->diameter() + beta_max);
-                    double sigma_p = penalty_constant_p * std::max(zeta_current, zeta_neigh);
+                    double sigma_p =
+                      penalty_constant_p * std::max(zeta_current, zeta_neigh);
 
                     for (unsigned int q_index = 0;
                          q_index < fe_faces0.n_quadrature_points;
@@ -1134,7 +1136,8 @@ namespace OseenNamespace
                                    (beta[q_index] * normals[q_index]) *
                                      jump_phi_v1[j] * downwind_phi_v0[i]) *
                                   fe_faces0.JxW(q_index);
-                                // Same structure as M11; only the basis functions differ.
+                                // Same structure as M11; only the basis
+                                // functions differ.
                                 //
                                 // Suffix '1' refers to neighbor cell basis
                                 // functions, while suffix '0' refers to current
@@ -1169,7 +1172,8 @@ namespace OseenNamespace
                                    (beta[q_index] * normals[q_index]) *
                                      jump_phi_v0[j] * downwind_phi_v1[i]) *
                                   fe_faces0.JxW(q_index);
-                                // Same structure as M11; only the basis functions differ.
+                                // Same structure as M11; only the basis
+                                // functions differ.
                                 //
                                 // Suffix '1' refers to neighbor cell basis
                                 // functions, while suffix '0' refers to current
@@ -1205,7 +1209,8 @@ namespace OseenNamespace
                                    (beta[q_index] * normals[q_index]) *
                                      jump_phi_v1[j] * downwind_phi_v1[i]) *
                                   fe_faces0.JxW(q_index);
-                                // Same structure as M11; only the basis functions differ.
+                                // Same structure as M11; only the basis
+                                // functions differ.
                                 //
                                 // Suffix '1' refers to neighbor cell basis
                                 // functions, while suffix '0' refers to current
@@ -1473,12 +1478,12 @@ main()
     {
       using namespace OseenNamespace;
 
-      ConvergenceTable convergence_table;
-      const unsigned int              deg_v_left  = 3;
-      const unsigned int              deg_p_left  = 2;
-      const unsigned int              deg_v_right = 2;
-      const unsigned int              deg_p_right = 1;
-      const double           Re          = 1.0;
+      ConvergenceTable   convergence_table;
+      const unsigned int deg_v_left  = 3;
+      const unsigned int deg_p_left  = 2;
+      const unsigned int deg_v_right = 2;
+      const unsigned int deg_p_right = 1;
+      const double       Re          = 1.0;
 
       for (unsigned int mesh_level = 2; mesh_level < 7; ++mesh_level)
         {

--- a/include/agglomeration_accessor.h
+++ b/include/agglomeration_accessor.h
@@ -188,7 +188,7 @@ public:
 
   /**
    * Sets the active finite element index.
-   * This function should be called when using hp::FECollection to specify 
+   * This function should be called when using hp::FECollection to specify
    * which finite element in the collection is assigned to the current polytope.
    */
   void
@@ -196,7 +196,7 @@ public:
 
   /**
    * Returns the index of the active finite element.
-   * When using hp::FECollection, this function retrieves the index 
+   * When using hp::FECollection, this function retrieves the index
    * of the finite element assigned to the current polytope.
    */
   types::fe_index
@@ -811,17 +811,22 @@ template <int dim, int spacedim>
 inline const FiniteElement<dim, spacedim> &
 AgglomerationAccessor<dim, spacedim>::get_fe() const
 {
-  typename DoFHandler<dim, spacedim>::active_cell_iterator master_cell_as_dof_handler_iterator = master_cell->as_dof_handler_iterator(handler->agglo_dh);
+  typename DoFHandler<dim, spacedim>::active_cell_iterator
+    master_cell_as_dof_handler_iterator =
+      master_cell->as_dof_handler_iterator(handler->agglo_dh);
   return master_cell_as_dof_handler_iterator->get_fe();
 }
 
 template <int dim, int spacedim>
 inline void
-AgglomerationAccessor<dim, spacedim>::set_active_fe_index(const types::fe_index index) const
+AgglomerationAccessor<dim, spacedim>::set_active_fe_index(
+  const types::fe_index index) const
 {
   Assert(!handler->is_slave_cell(master_cell),
          ExcMessage("The present function cannot be called for slave cells."));
-  typename DoFHandler<dim, spacedim>::active_cell_iterator master_cell_as_dof_handler_iterator = master_cell->as_dof_handler_iterator(handler->agglo_dh);
+  typename DoFHandler<dim, spacedim>::active_cell_iterator
+    master_cell_as_dof_handler_iterator =
+      master_cell->as_dof_handler_iterator(handler->agglo_dh);
   master_cell_as_dof_handler_iterator->set_active_fe_index(index);
 }
 
@@ -829,7 +834,9 @@ template <int dim, int spacedim>
 inline types::fe_index
 AgglomerationAccessor<dim, spacedim>::active_fe_index() const
 {
-  typename DoFHandler<dim, spacedim>::active_cell_iterator master_cell_as_dof_handler_iterator = master_cell->as_dof_handler_iterator(handler->agglo_dh);
+  typename DoFHandler<dim, spacedim>::active_cell_iterator
+    master_cell_as_dof_handler_iterator =
+      master_cell->as_dof_handler_iterator(handler->agglo_dh);
   return master_cell_as_dof_handler_iterator->active_fe_index();
 }
 

--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -251,7 +251,8 @@ public:
    * Overload for hp::FECollection.
    */
   void
-  distribute_agglomerated_dofs(const hp::FECollection<dim, spacedim> &fe_collection_in);
+  distribute_agglomerated_dofs(
+    const hp::FECollection<dim, spacedim> &fe_collection_in);
 
   /**
    *
@@ -270,10 +271,12 @@ public:
    */
   void
   initialize_fe_values(
-    const hp::QCollection<dim>     &cell_qcollection = hp::QCollection<dim>(QGauss<dim>(1)),
-    const UpdateFlags              &flags           = UpdateFlags::update_default,
-    const hp::QCollection<dim - 1> &face_qcollection = hp::QCollection<dim - 1>(QGauss<dim - 1>(1)),
-    const UpdateFlags              &face_flags      = UpdateFlags::update_default);
+    const hp::QCollection<dim> &cell_qcollection =
+      hp::QCollection<dim>(QGauss<dim>(1)),
+    const UpdateFlags              &flags = UpdateFlags::update_default,
+    const hp::QCollection<dim - 1> &face_qcollection =
+      hp::QCollection<dim - 1>(QGauss<dim - 1>(1)),
+    const UpdateFlags &face_flags = UpdateFlags::update_default);
 
   /**
    * Given a Triangulation with some agglomerated cells, create the sparsity
@@ -306,12 +309,13 @@ public:
    * The parameter @p fecollection_size provides the number of finite elements
    * in the collection, allowing Polydeal to insert an empty element for
    * slave cells internally.
-   * 
+   *
    * When @p fecollection_size equals 1, this function behaves identically to
    * define_agglomerate(const AgglomerationContainer &cells).
    */
   agglomeration_iterator
-  define_agglomerate(const AgglomerationContainer &cells, const unsigned int fecollection_size);
+  define_agglomerate(const AgglomerationContainer &cells,
+                     const unsigned int            fecollection_size);
 
   /**
    * Same as above, but checking that every vector of cells is connected. If
@@ -558,7 +562,8 @@ public:
   connect_hierarchy(const CellsAgglomerator<dim, RtreeType> &agglomerator);
 
   /**
-   * Return the finite element collection passed to distribute_agglomerated_dofs().
+   * Return the finite element collection passed to
+   * distribute_agglomerated_dofs().
    */
   inline const hp::FECollection<dim, spacedim> &
   get_fe_collection() const;

--- a/include/poly_utils.h
+++ b/include/poly_utils.h
@@ -1184,13 +1184,15 @@ namespace dealii::PolyUtils
               agglomeration_handler.get_fe();
 
             // We use DGQ (on tensor-product meshes) or DGP (on simplex meshes)
-            // nodal elements of the same degree as the ones in the agglomeration
-            // handler to interpolate the solution onto the finer grid.
+            // nodal elements of the same degree as the ones in the
+            // agglomeration handler to interpolate the solution onto the finer
+            // grid.
             std::unique_ptr<FiniteElement<dim>> output_fe;
             if (tria.all_reference_cells_are_hyper_cube())
               output_fe = std::make_unique<FE_DGQ<dim>>(original_fe.degree);
             else if (tria.all_reference_cells_are_simplex())
-              output_fe = std::make_unique<FE_SimplexDGP<dim>>(original_fe.degree);
+              output_fe =
+                std::make_unique<FE_SimplexDGP<dim>>(original_fe.degree);
             else
               AssertThrow(false, ExcNotImplemented());
 
@@ -1199,9 +1201,11 @@ namespace dealii::PolyUtils
             output_dh.reinit(tria);
             output_dh.distribute_dofs(*output_fe);
 
-            if constexpr (std::is_same_v<VectorType, TrilinosWrappers::MPI::Vector>)
+            if constexpr (std::is_same_v<VectorType,
+                                         TrilinosWrappers::MPI::Vector>)
               {
-                const IndexSet &locally_owned_dofs = output_dh.locally_owned_dofs();
+                const IndexSet &locally_owned_dofs =
+                  output_dh.locally_owned_dofs();
                 dst.reinit(locally_owned_dofs);
               }
             else if constexpr (std::is_same_v<VectorType, Vector<NumberType>>)
@@ -1221,19 +1225,22 @@ namespace dealii::PolyUtils
 
             const unsigned int dofs_per_cell =
               agglomeration_handler.n_dofs_per_cell();
-            const unsigned int output_dofs_per_cell = output_fe->n_dofs_per_cell();
-            Quadrature<dim>    quad(output_fe->get_unit_support_points());
-            FEValues<dim>      output_fe_values(mapping,
+            const unsigned int output_dofs_per_cell =
+              output_fe->n_dofs_per_cell();
+            Quadrature<dim> quad(output_fe->get_unit_support_points());
+            FEValues<dim>   output_fe_values(mapping,
                                            *output_fe,
                                            quad,
                                            update_quadrature_points);
 
-            std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+            std::vector<types::global_dof_index> local_dof_indices(
+              dofs_per_cell);
             std::vector<types::global_dof_index> local_dof_indices_output(
               output_dofs_per_cell);
 
             const auto &bboxes = agglomeration_handler.get_local_bboxes();
-            for (const auto &polytope : agglomeration_handler.polytope_iterators())
+            for (const auto &polytope :
+                 agglomeration_handler.polytope_iterators())
               {
                 if (polytope->is_locally_owned())
                   {
@@ -1254,7 +1261,8 @@ namespace dealii::PolyUtils
 
                         for (unsigned int j = 0; j < output_dofs_per_cell; ++j)
                           {
-                            const auto &ref_qpoint = box.real_to_unit(qpoints[j]);
+                            const auto &ref_qpoint =
+                              box.real_to_unit(qpoints[j]);
                             for (unsigned int i = 0; i < dofs_per_cell; ++i)
                               dst(local_dof_indices_output[j]) +=
                                 src(local_dof_indices[i]) *
@@ -1274,12 +1282,13 @@ namespace dealii::PolyUtils
               agglomeration_handler.get_fe_collection();
 
             // We use DGQ (on tensor-product meshes) or DGP (on simplex meshes)
-            // nodal elements of the same degree as the ones in the agglomeration
-            // handler to interpolate the solution onto the finer grid.
+            // nodal elements of the same degree as the ones in the
+            // agglomeration handler to interpolate the solution onto the finer
+            // grid.
             hp::FECollection<dim, spacedim> output_fe_collection;
 
-            Assert(original_fe_collection[0].n_components() >= 1, 
-              ExcMessage("Invalid FE: must have at least one component."));
+            Assert(original_fe_collection[0].n_components() >= 1,
+                   ExcMessage("Invalid FE: must have at least one component."));
             if (original_fe_collection[0].n_components() == 1)
               {
                 // Scalar case
@@ -1287,9 +1296,11 @@ namespace dealii::PolyUtils
                   {
                     std::unique_ptr<FiniteElement<dim>> output_fe;
                     if (tria.all_reference_cells_are_hyper_cube())
-                      output_fe = std::make_unique<FE_DGQ<dim>>(original_fe_collection[i].degree);
+                      output_fe = std::make_unique<FE_DGQ<dim>>(
+                        original_fe_collection[i].degree);
                     else if (tria.all_reference_cells_are_simplex())
-                      output_fe = std::make_unique<FE_SimplexDGP<dim>>(original_fe_collection[i].degree);
+                      output_fe = std::make_unique<FE_SimplexDGP<dim>>(
+                        original_fe_collection[i].degree);
                     else
                       AssertThrow(false, ExcNotImplemented());
                     output_fe_collection.push_back(*output_fe);
@@ -1300,49 +1311,65 @@ namespace dealii::PolyUtils
                 // System case
                 for (unsigned int i = 0; i < original_fe_collection.size(); ++i)
                   {
-                    std::vector<const FiniteElement<dim, spacedim>*> base_elements;
+                    std::vector<const FiniteElement<dim, spacedim> *>
+                                              base_elements;
                     std::vector<unsigned int> multiplicities;
-                    for (unsigned int b = 0; b < original_fe_collection[i].n_base_elements(); ++b)
+                    for (unsigned int b = 0;
+                         b < original_fe_collection[i].n_base_elements();
+                         ++b)
                       {
                         if (tria.all_reference_cells_are_hyper_cube())
-                          base_elements.push_back(new FE_DGQ<dim, spacedim>(original_fe_collection[i].base_element(b).degree));
+                          base_elements.push_back(new FE_DGQ<dim, spacedim>(
+                            original_fe_collection[i].base_element(b).degree));
                         else if (tria.all_reference_cells_are_simplex())
-                          base_elements.push_back(new FE_SimplexDGP<dim, spacedim>(original_fe_collection[i].base_element(b).degree));
+                          base_elements.push_back(new FE_SimplexDGP<dim,
+                                                                    spacedim>(
+                            original_fe_collection[i].base_element(b).degree));
                         else
                           AssertThrow(false, ExcNotImplemented());
-                        multiplicities.push_back(original_fe_collection[i].element_multiplicity(b));
+                        multiplicities.push_back(
+                          original_fe_collection[i].element_multiplicity(b));
                       }
 
-                    FESystem<dim, spacedim> output_fe_system(base_elements, multiplicities);
+                    FESystem<dim, spacedim> output_fe_system(base_elements,
+                                                             multiplicities);
                     for (const auto *ptr : base_elements)
                       delete ptr;
                     output_fe_collection.push_back(output_fe_system);
                   }
               }
-            
+
 
             DoFHandler<dim> &output_dh =
               const_cast<DoFHandler<dim> &>(agglomeration_handler.output_dh);
             output_dh.reinit(tria);
-            for (const auto &polytope : agglomeration_handler.polytope_iterators())
+            for (const auto &polytope :
+                 agglomeration_handler.polytope_iterators())
               {
                 if (polytope->is_locally_owned())
                   {
-                    const auto &deal_cells = polytope->get_agglomerate(); // fine deal.II cells
-                    const unsigned int active_fe_idx = polytope->active_fe_index();
+                    const auto &deal_cells =
+                      polytope->get_agglomerate(); // fine deal.II cells
+                    const unsigned int active_fe_idx =
+                      polytope->active_fe_index();
 
                     for (const auto &cell : deal_cells)
                       {
-                        const typename DoFHandler<dim>::active_cell_iterator slave_cell_dh_iterator = cell->as_dof_handler_iterator(output_dh);
-                        slave_cell_dh_iterator->set_active_fe_index(active_fe_idx);
+                        const typename DoFHandler<dim>::active_cell_iterator
+                          slave_cell_dh_iterator =
+                            cell->as_dof_handler_iterator(output_dh);
+                        slave_cell_dh_iterator->set_active_fe_index(
+                          active_fe_idx);
                       }
                   }
               }
             output_dh.distribute_dofs(output_fe_collection);
 
-            if constexpr (std::is_same_v<VectorType, TrilinosWrappers::MPI::Vector>)
+            if constexpr (std::is_same_v<VectorType,
+                                         TrilinosWrappers::MPI::Vector>)
               {
-                const IndexSet &locally_owned_dofs = output_dh.locally_owned_dofs();
+                const IndexSet &locally_owned_dofs =
+                  output_dh.locally_owned_dofs();
                 dst.reinit(locally_owned_dofs);
               }
             else if constexpr (std::is_same_v<VectorType, Vector<NumberType>>)
@@ -1359,20 +1386,28 @@ namespace dealii::PolyUtils
               }
 
             const auto &bboxes = agglomeration_handler.get_local_bboxes();
-            for (const auto &polytope : agglomeration_handler.polytope_iterators())
+            for (const auto &polytope :
+                 agglomeration_handler.polytope_iterators())
               {
                 if (polytope->is_locally_owned())
                   {
-                    const unsigned int active_fe_idx = polytope->active_fe_index();
-                    const unsigned int dofs_per_cell = polytope->get_fe().dofs_per_cell;
-                    const unsigned int output_dofs_per_cell = output_fe_collection[active_fe_idx].n_dofs_per_cell();
-                    Quadrature<dim>    quad(output_fe_collection[active_fe_idx].get_unit_support_points());
-                    FEValues<dim>      output_fe_values(mapping,
-                                                        output_fe_collection[active_fe_idx],
-                                                        quad,
-                                                        update_quadrature_points);
-                    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-                    std::vector<types::global_dof_index> local_dof_indices_output(output_dofs_per_cell);
+                    const unsigned int active_fe_idx =
+                      polytope->active_fe_index();
+                    const unsigned int dofs_per_cell =
+                      polytope->get_fe().dofs_per_cell;
+                    const unsigned int output_dofs_per_cell =
+                      output_fe_collection[active_fe_idx].n_dofs_per_cell();
+                    Quadrature<dim> quad(output_fe_collection[active_fe_idx]
+                                           .get_unit_support_points());
+                    FEValues<dim>   output_fe_values(
+                      mapping,
+                      output_fe_collection[active_fe_idx],
+                      quad,
+                      update_quadrature_points);
+                    std::vector<types::global_dof_index> local_dof_indices(
+                      dofs_per_cell);
+                    std::vector<types::global_dof_index>
+                      local_dof_indices_output(output_dofs_per_cell);
 
                     polytope->get_dof_indices(local_dof_indices);
                     const BoundingBox<dim> &box = bboxes[polytope->index()];
@@ -1391,12 +1426,18 @@ namespace dealii::PolyUtils
 
                         for (unsigned int j = 0; j < output_dofs_per_cell; ++j)
                           {
-                            const unsigned int component_idx_of_this_dof = slave_output->get_fe().system_to_component_index(j).first;
-                            const auto &ref_qpoint = box.real_to_unit(qpoints[j]);
+                            const unsigned int component_idx_of_this_dof =
+                              slave_output->get_fe()
+                                .system_to_component_index(j)
+                                .first;
+                            const auto &ref_qpoint =
+                              box.real_to_unit(qpoints[j]);
                             for (unsigned int i = 0; i < dofs_per_cell; ++i)
                               dst(local_dof_indices_output[j]) +=
                                 src(local_dof_indices[i]) *
-                                original_fe_collection[active_fe_idx].shape_value_component(i, ref_qpoint, component_idx_of_this_dof);
+                                original_fe_collection[active_fe_idx]
+                                  .shape_value_component(
+                                    i, ref_qpoint, component_idx_of_this_dof);
                           }
                       }
                   }

--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -106,7 +106,8 @@ AgglomerationHandler<dim, spacedim>::define_agglomerate(
 template <int dim, int spacedim>
 typename AgglomerationHandler<dim, spacedim>::agglomeration_iterator
 AgglomerationHandler<dim, spacedim>::define_agglomerate(
-  const AgglomerationContainer &cells, const unsigned int fecollection_size)
+  const AgglomerationContainer &cells,
+  const unsigned int            fecollection_size)
 {
   Assert(cells.size() > 0, ExcMessage("No cells to be agglomerated."));
 
@@ -123,7 +124,7 @@ AgglomerationHandler<dim, spacedim>::define_agglomerate(
 
   const typename DoFHandler<dim>::active_cell_iterator cell_dh =
     cells[0]->as_dof_handler_iterator(agglo_dh);
-    cell_dh->set_active_fe_index(CellAgglomerationType::master);
+  cell_dh->set_active_fe_index(CellAgglomerationType::master);
 
   // Store slave cells and save the relationship with the parent
   std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>
@@ -140,7 +141,8 @@ AgglomerationHandler<dim, spacedim>::define_agglomerate(
 
       const typename DoFHandler<dim>::active_cell_iterator cell =
         (*it)->as_dof_handler_iterator(agglo_dh);
-      cell->set_active_fe_index(fecollection_size); // slave cell (the last index)
+      cell->set_active_fe_index(
+        fecollection_size); // slave cell (the last index)
 
       // If we have a p::d::T, check that all cells are in the same subdomain.
       // If serial, just check that the subdomain_id is invalid.
@@ -237,29 +239,28 @@ template <int dim, int spacedim>
 void
 AgglomerationHandler<dim, spacedim>::initialize_fe_values(
   const hp::QCollection<dim>     &cell_qcollection,
-  const UpdateFlags         &flags,
+  const UpdateFlags              &flags,
   const hp::QCollection<dim - 1> &face_qcollection,
-  const UpdateFlags         &face_flags)
+  const UpdateFlags              &face_flags)
 {
-  agglomeration_quad_collection       = cell_qcollection;
-  agglomeration_flags      = flags;
-  agglomeration_face_quad_collection  = face_qcollection;
+  agglomeration_quad_collection      = cell_qcollection;
+  agglomeration_flags                = flags;
+  agglomeration_face_quad_collection = face_qcollection;
   agglomeration_face_flags = face_flags | internal_agglomeration_face_flags;
 
-  mapping_collection = hp::MappingCollection<dim>(*mapping);
+  mapping_collection  = hp::MappingCollection<dim>(*mapping);
   dummy_fe_collection = hp::FECollection<dim, spacedim>(dummy_fe);
-  hp_no_values =
-      std::make_unique<hp::FEValues<dim>>(mapping_collection,
-                                    dummy_fe_collection,
-                                    agglomeration_quad_collection,
-                                    update_quadrature_points |
-                                    update_JxW_values); // only for quadrature
+  hp_no_values        = std::make_unique<hp::FEValues<dim>>(
+    mapping_collection,
+    dummy_fe_collection,
+    agglomeration_quad_collection,
+    update_quadrature_points | update_JxW_values); // only for quadrature
 
   hp_no_face_values = std::make_unique<hp::FEFaceValues<dim>>(
-      mapping_collection,
-      dummy_fe_collection,
-      agglomeration_face_quad_collection,
-      update_quadrature_points | update_JxW_values |
+    mapping_collection,
+    dummy_fe_collection,
+    agglomeration_face_quad_collection,
+    update_quadrature_points | update_JxW_values |
       update_normal_vectors); // only for quadrature
 }
 
@@ -382,7 +383,7 @@ void
 AgglomerationHandler<dim, spacedim>::distribute_agglomerated_dofs(
   const hp::FECollection<dim, spacedim> &fe_collection_in)
 {
-  is_hp_collection  = true;
+  is_hp_collection = true;
 
   hp_fe_collection = std::make_unique<hp::FECollection<dim, spacedim>>(
     fe_collection_in); // copy the input collection
@@ -391,13 +392,12 @@ AgglomerationHandler<dim, spacedim>::distribute_agglomerated_dofs(
     bboxes,
     master2polygon); // construct bounding box mapping
 
-  
+
   if (hybrid_mesh)
     {
-      AssertThrow(
-      false,
-      ExcNotImplemented(
-        "Hybrid mesh is not implemented for hp::FECollection."));
+      AssertThrow(false,
+                  ExcNotImplemented(
+                    "Hybrid mesh is not implemented for hp::FECollection."));
     }
 
   for (unsigned int i = 0; i < fe_collection_in.size(); ++i)
@@ -434,16 +434,16 @@ AgglomerationHandler<dim, spacedim>::distribute_agglomerated_dofs(
       fe_collection.push_back(fe_collection_in[i]);
     }
 
-  Assert(fe_collection[0].n_components() >= 1, 
-    ExcMessage("Invalid FE: must have at least one component."));
+  Assert(fe_collection[0].n_components() >= 1,
+         ExcMessage("Invalid FE: must have at least one component."));
   if (fe_collection[0].n_components() == 1)
     {
       fe_collection.push_back(FE_Nothing<dim, spacedim>());
     }
   else if (fe_collection[0].n_components() > 1)
     {
-      std::vector<const FiniteElement<dim, spacedim>*> base_elements;
-      std::vector<unsigned int> multiplicities;
+      std::vector<const FiniteElement<dim, spacedim> *> base_elements;
+      std::vector<unsigned int>                         multiplicities;
       for (unsigned int b = 0; b < fe_collection[0].n_base_elements(); ++b)
         {
           base_elements.push_back(new FE_Nothing<dim, spacedim>());
@@ -637,8 +637,8 @@ AgglomerationHandler<dim, spacedim>::agglomerated_quadrature(
       for (const auto &dummy_cell : cells)
         {
           no_values->reinit(dummy_cell);
-          auto        q_points = no_values->get_quadrature_points(); // real qpoints
-          const auto &JxWs     = no_values->get_JxW_values();
+          auto q_points    = no_values->get_quadrature_points(); // real qpoints
+          const auto &JxWs = no_values->get_JxW_values();
 
           std::transform(q_points.begin(),
                          q_points.end(),
@@ -653,7 +653,8 @@ AgglomerationHandler<dim, spacedim>::agglomerated_quadrature(
   else
     {
       // Handle the hp::FECollection case
-      const auto &master_cell_as_dh_iterator = master_cell->as_dof_handler_iterator(agglo_dh);
+      const auto &master_cell_as_dh_iterator =
+        master_cell->as_dof_handler_iterator(agglo_dh);
       for (const auto &dummy_cell : cells)
         {
           // The following verbose call is necessary to handle cases where
@@ -670,9 +671,14 @@ AgglomerationHandler<dim, spacedim>::agglomerated_quadrature(
           // hp::FECollection have different sizes.
           // TODO: Refactor the architecture to better handle numerical
           // integration for hp::QCollection.
-          hp_no_values->reinit(dummy_cell, master_cell_as_dh_iterator->active_fe_index(), 0, 0);
-          auto        q_points = hp_no_values->get_present_fe_values().get_quadrature_points(); // real qpoints
-          const auto &JxWs     = hp_no_values->get_present_fe_values().get_JxW_values();
+          hp_no_values->reinit(dummy_cell,
+                               master_cell_as_dh_iterator->active_fe_index(),
+                               0,
+                               0);
+          auto q_points = hp_no_values->get_present_fe_values()
+                            .get_quadrature_points(); // real qpoints
+          const auto &JxWs =
+            hp_no_values->get_present_fe_values().get_JxW_values();
 
           std::transform(q_points.begin(),
                          q_points.end(),
@@ -934,7 +940,7 @@ AgglomerationHandler<dim, spacedim>::create_agglomeration_sparsity_pattern(
     agglo_dh, dsp, constraints, keep_constrained_dofs, subdomain_id);
 
 
-  if(!is_hp_collection)
+  if (!is_hp_collection)
     {
       // Original version: handle case without hp::FECollection
       const unsigned int dofs_per_cell = agglo_dh.get_fe(0).n_dofs_per_cell();
@@ -955,11 +961,12 @@ AgglomerationHandler<dim, spacedim>::create_agglomeration_sparsity_pattern(
                   if (neigh_polytope.state() == IteratorState::valid)
                     {
                       neigh_polytope->get_dof_indices(neighbor_dof_indices);
-                      constraints.add_entries_local_to_global(current_dof_indices,
-                                                              neighbor_dof_indices,
-                                                              dsp,
-                                                              keep_constrained_dofs,
-                                                              {});
+                      constraints.add_entries_local_to_global(
+                        current_dof_indices,
+                        neighbor_dof_indices,
+                        dsp,
+                        keep_constrained_dofs,
+                        {});
                     }
                 }
             }
@@ -975,8 +982,10 @@ AgglomerationHandler<dim, spacedim>::create_agglomeration_sparsity_pattern(
         {
           if (polytope->is_locally_owned())
             {
-              const unsigned int current_dofs_per_cell = polytope->get_fe().dofs_per_cell;
-              std::vector<types::global_dof_index> current_dof_indices(current_dofs_per_cell);
+              const unsigned int current_dofs_per_cell =
+                polytope->get_fe().dofs_per_cell;
+              std::vector<types::global_dof_index> current_dof_indices(
+                current_dofs_per_cell);
 
               const unsigned int n_current_faces = polytope->n_faces();
               polytope->get_dof_indices(current_dof_indices);
@@ -985,21 +994,24 @@ AgglomerationHandler<dim, spacedim>::create_agglomeration_sparsity_pattern(
                   const auto &neigh_polytope = polytope->neighbor(f);
                   if (neigh_polytope.state() == IteratorState::valid)
                     {
-                      const unsigned int neighbor_dofs_per_cell = neigh_polytope->get_fe().dofs_per_cell;
-                      std::vector<types::global_dof_index> neighbor_dof_indices(neighbor_dofs_per_cell);
+                      const unsigned int neighbor_dofs_per_cell =
+                        neigh_polytope->get_fe().dofs_per_cell;
+                      std::vector<types::global_dof_index> neighbor_dof_indices(
+                        neighbor_dofs_per_cell);
 
                       neigh_polytope->get_dof_indices(neighbor_dof_indices);
-                      constraints.add_entries_local_to_global(current_dof_indices,
-                                                              neighbor_dof_indices,
-                                                              dsp,
-                                                              keep_constrained_dofs,
-                                                              {});
+                      constraints.add_entries_local_to_global(
+                        current_dof_indices,
+                        neighbor_dof_indices,
+                        dsp,
+                        keep_constrained_dofs,
+                        {});
                     }
                 }
             }
         }
     }
-      
+
 
 
   if constexpr (std::is_same_v<SparsityPatternType,
@@ -1128,21 +1140,23 @@ namespace dealii
             final_weights.reserve(expected_qpoints);
             final_normals.reserve(expected_qpoints);
 
-            
+
             for (const auto &[deal_cell, local_face_idx] : common_face)
               {
                 handler.no_face_values->reinit(deal_cell, local_face_idx);
 
                 const auto &q_points =
                   handler.no_face_values->get_quadrature_points();
-                const auto &JxWs    = handler.no_face_values->get_JxW_values();
-                const auto &normals = handler.no_face_values->get_normal_vectors();
+                const auto &JxWs = handler.no_face_values->get_JxW_values();
+                const auto &normals =
+                  handler.no_face_values->get_normal_vectors();
 
                 const unsigned int n_qpoints_agglo = q_points.size();
 
                 for (unsigned int q = 0; q < n_qpoints_agglo; ++q)
                   {
-                    final_unit_q_points.push_back(bbox.real_to_unit(q_points[q]));
+                    final_unit_q_points.push_back(
+                      bbox.real_to_unit(q_points[q]));
                     final_weights.push_back(JxWs[q]);
                     final_normals.push_back(normals[q]);
                   }
@@ -1153,42 +1167,56 @@ namespace dealii
             // Handle the hp::FECollection case
             unsigned int higher_order_quad_index = cell->active_fe_index();
             if (neigh_polytope.state() == IteratorState::valid)
-              if (handler.agglomeration_face_quad_collection[cell->active_fe_index()].size() <
-                  handler.agglomeration_face_quad_collection[neigh_polytope->active_fe_index()].size())
+              if (handler
+                    .agglomeration_face_quad_collection[cell->active_fe_index()]
+                    .size() <
+                  handler
+                    .agglomeration_face_quad_collection[neigh_polytope
+                                                          ->active_fe_index()]
+                    .size())
                 higher_order_quad_index = neigh_polytope->active_fe_index();
 
             const unsigned int expected_qpoints =
-            common_face.size() * handler.agglomeration_face_quad_collection[higher_order_quad_index].size();
+              common_face.size() *
+              handler
+                .agglomeration_face_quad_collection[higher_order_quad_index]
+                .size();
             final_unit_q_points.reserve(expected_qpoints);
             final_weights.reserve(expected_qpoints);
             final_normals.reserve(expected_qpoints);
 
             for (const auto &[deal_cell, local_face_idx] : common_face)
               {
-                handler.hp_no_face_values->reinit(deal_cell, local_face_idx,
-                                                  higher_order_quad_index, 0, 0);
+                handler.hp_no_face_values->reinit(
+                  deal_cell, local_face_idx, higher_order_quad_index, 0, 0);
 
                 const auto &q_points =
-                  handler.hp_no_face_values->get_present_fe_values().get_quadrature_points();
-                const auto &JxWs    = handler.hp_no_face_values->get_present_fe_values().get_JxW_values();
-                const auto &normals = handler.hp_no_face_values->get_present_fe_values().get_normal_vectors();
-              
+                  handler.hp_no_face_values->get_present_fe_values()
+                    .get_quadrature_points();
+                const auto &JxWs =
+                  handler.hp_no_face_values->get_present_fe_values()
+                    .get_JxW_values();
+                const auto &normals =
+                  handler.hp_no_face_values->get_present_fe_values()
+                    .get_normal_vectors();
+
                 const unsigned int n_qpoints_agglo = q_points.size();
 
                 for (unsigned int q = 0; q < n_qpoints_agglo; ++q)
                   {
-                    final_unit_q_points.push_back(bbox.real_to_unit(q_points[q]));
+                    final_unit_q_points.push_back(
+                      bbox.real_to_unit(q_points[q]));
                     final_weights.push_back(JxWs[q]);
                     final_normals.push_back(normals[q]);
                   }
               }
           }
-        
+
 
         NonMatching::ImmersedSurfaceQuadrature<dim, spacedim> surface_quad(
           final_unit_q_points, final_weights, final_normals);
 
-        if(!handler.is_hp_collection)
+        if (!handler.is_hp_collection)
           {
             agglo_isv_ptr =
               std::make_unique<NonMatching::FEImmersedSurfaceValues<spacedim>>(


### PR DESCRIPTION
This pull request adds support for using **hp::FECollection** in Polydeal, along with a new example solving the Oseen problem on a mesh with curved interfaces. The example employs hp::FECollection finite elements, applying different element pairs in the left and right regions.