### PR TITLE
Fix deprecation warnings due to upstream updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,28 @@
-
 cmake_minimum_required(VERSION 3.13.4)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DAGGLO_DEBUG")
 
-FIND_PACKAGE(deal.II 9.5.0 QUIET
+FIND_PACKAGE(deal.II QUIET
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
 )
 
 IF(NOT ${deal.II_FOUND})
   MESSAGE(FATAL_ERROR "\n"
-    "*** Could not locate a (sufficiently recent) version of deal.II. ***\n\n"
+    "*** Could not locate deal.II. ***\n\n"
     "You may want to either pass a flag -DDEAL_II_DIR=/path/to/deal.II to cmake\n"
     "or set an environment variable \"DEAL_II_DIR\" that contains this path."
   )
+ENDIF()
+
+# Check the found version and ensure it meets our requirements
+MESSAGE(STATUS "Found deal.II version: ${deal.II_VERSION}")
+MESSAGE(STATUS "deal.II installation path: ${deal.II_DIR}")
+IF(${deal.II_VERSION} VERSION_LESS "9.7.0")
+  MESSAGE(FATAL_ERROR "\n"
+    "*** deal.II version ${deal.II_VERSION} found, but version 9.7.0 or newer is required. ***\n\n"
+    "Please update your deal.II installation to version 9.7.0 or newer."
+  )
+ELSE()
+  MESSAGE(STATUS "deal.II version ${deal.II_VERSION} meets the minimum requirement (>= 9.7.0)")
 ENDIF()
 
 DEAL_II_INITIALIZE_CACHED_VARIABLES()

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We require:
     -  **clang** version >= 15
     -  **icc** (Intel compiler) 2021.2
 - **openMPI** version  >= 4.0.3
-- **deal.II** version >= 9.6
+- **deal.II** version >= 9.7
 
 The library **polyDEAL** employs **deal.II** as main third-party library. As **deal.II** itself depends on other external libraries for many functionalities, we strongly suggest to download and install deal.II following the instructions available at https://www.dealii.org/download.html and https://www.dealii.org/developer/readme.html. The minimal set of other external libraries that we require are: **METIS**, **p4est**, **Trilinos**. All of them should be compiled against  MPI during the installation phase of deal.II. 
 

--- a/examples/agglo_amg.cc
+++ b/examples/agglo_amg.cc
@@ -892,7 +892,7 @@ fill_interpolation_matrix(
 
   if constexpr (std::is_same_v<MatrixType, TrilinosWrappers::SparseMatrix>)
     {
-      const MPI_Comm &communicator = tria.get_communicator();
+      const MPI_Comm &communicator = tria.get_mpi_communicator();
       SparsityTools::distribute_sparsity_pattern(dsp,
                                                  locally_owned_dofs,
                                                  communicator,

--- a/examples/monodomain_DG3D.cc
+++ b/examples/monodomain_DG3D.cc
@@ -365,7 +365,7 @@ fill_interpolation_matrix(
 
   if constexpr (std::is_same_v<MatrixType, TrilinosWrappers::SparseMatrix>)
     {
-      const MPI_Comm &communicator = tria.get_communicator();
+      const MPI_Comm &communicator = tria.get_mpi_communicator();
       SparsityTools::distribute_sparsity_pattern(dsp,
                                                  locally_owned_dofs,
                                                  communicator,

--- a/include/agglomeration_handler.h
+++ b/include/agglomeration_handler.h
@@ -13,8 +13,8 @@
 #define agglomeration_handler_h
 
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/quadrature.h>
-#include <deal.II/base/smartpointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/distributed/shared_tria.h>
@@ -807,9 +807,9 @@ private:
 
   ////////////////////////////////////////////////////////
 
-  SmartPointer<const Triangulation<dim, spacedim>> tria;
+  ObserverPointer<const Triangulation<dim, spacedim>> tria;
 
-  SmartPointer<const Mapping<dim, spacedim>> mapping;
+  ObserverPointer<const Mapping<dim, spacedim>> mapping;
 
   std::unique_ptr<GridTools::Cache<dim, spacedim>> cached_tria;
 

--- a/include/multigrid_amg.h
+++ b/include/multigrid_amg.h
@@ -479,7 +479,7 @@ namespace dealii
     /**
      * Sequence of transfer operators, stored as pointers to Trilinos matrices.
      */
-    MGLevelObject<SmartPointer<TrilinosWrappers::SparseMatrix>>
+    MGLevelObject<ObserverPointer<TrilinosWrappers::SparseMatrix>>
       transfer_matrices;
 
     /**

--- a/include/utils.h
+++ b/include/utils.h
@@ -145,7 +145,7 @@ namespace Utils
     if constexpr (is_trilinos_matrix)
       dsp.reinit(locally_owned_dofs_fine,
                  locally_owned_dofs_coarse,
-                 tria.get_communicator());
+                 tria.get_mpi_communicator());
     else
       dsp.reinit(fine_agglo_dh.n_dofs(),
                  coarse_agglo_dh.n_dofs(),

--- a/source/agglomeration_handler.cc
+++ b/source/agglomeration_handler.cc
@@ -23,7 +23,7 @@ AgglomerationHandler<dim, spacedim>::AgglomerationHandler(
   : cached_tria(std::make_unique<GridTools::Cache<dim, spacedim>>(
       cache_tria.get_triangulation(),
       cache_tria.get_mapping()))
-  , communicator(cache_tria.get_triangulation().get_communicator())
+  , communicator(cache_tria.get_triangulation().get_mpi_communicator())
 {
   Assert(dim == spacedim, ExcNotImplemented("Not available with codim > 0"));
   Assert(dim == 2 || dim == 3, ExcImpossibleInDim(1));

--- a/source/multigrid_amg.cc
+++ b/source/multigrid_amg.cc
@@ -123,7 +123,7 @@ namespace dealii
       {
         // std::cout << "level = " << level << std::endl;
         dst[level].reinit(dof_handlers[level]->locally_owned_dofs(),
-                          dof_handlers[level]->get_communicator());
+                          dof_handlers[level]->get_mpi_communicator());
       }
 
     if constexpr (std::is_same_v<VectorType, TrilinosWrappers::MPI::Vector>)


### PR DESCRIPTION
This PR fixes the following warnings due to deprecations upstream in deal.II (when using the latest master branch). 

* Replace `SmartPointer/Subscriptor` to `ObserverPointer/EnableObserverPointer`

* Replace `Triangluation/DoFHandler::get_communicator()` -> `Triangulation/DoFHandler::get_mpi_communicator()`

This requires the minimal deal.II version to be 9.7, hence the CMakeLists.txt has been updated accordingly.