### PR TITLE
Define MESH_DIR as preprocessor macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ ENDIF()
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 PROJECT(polydeal)
 
+# Define mesh directory path
+SET(MESH_DIR "${CMAKE_SOURCE_DIR}/meshes")
+MESSAGE(STATUS "Mesh directory: ${MESH_DIR}")
+
 # Enable testing and descent into tests/ subdirectory:
 ENABLE_TESTING()
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include)

--- a/examples/3D_piston.cc
+++ b/examples/3D_piston.cc
@@ -395,7 +395,8 @@ DiffusionReactionProblem<dim>::make_fine_grid()
 
   GridIn<dim> grid_in;
   grid_in.attach_triangulation(tria);
-  std::ifstream gmsh_file("../../meshes/piston_3.inp"); // piston mesh
+  std::ifstream gmsh_file(std::string(MESH_DIR) +
+                          "/piston_3.inp"); // piston mesh
   grid_in.read_abaqus(gmsh_file);
   // tria.refine_global(1);
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,8 +41,12 @@ FOREACH(_build_type ${_d2_build_types})
 
             add_executable( ${testname} ${testsourcefile} )
 
-            # Make sure YourLib is linked to each app
+            # Make sure the library is linked to each app
             target_link_libraries(${testname} ${_lib})
+            
+            # Define MESH_DIR for the executable
+            target_compile_definitions(${testname} PRIVATE MESH_DIR="${MESH_DIR}")
+            
             DEAL_II_SETUP_TARGET(${testname} ${_BUILD_TYPE})
             INSTALL(TARGETS ${testname})
             set(testname ${testname}${_p})

--- a/examples/agglo_amg.cc
+++ b/examples/agglo_amg.cc
@@ -1040,18 +1040,22 @@ TestMGMatrix<dim>::make_fine_grid(const unsigned int n_global_refinements)
       if constexpr (dim == 2)
         {
           std::ifstream gmsh_file(
-            "../../meshes/t3.msh"); // unstructured square [0,1]^2
+            std::string(MESH_DIR) +
+            "meshes/t3.msh"); // unstructured square [0,1]^2
           grid_in.read_msh(gmsh_file);
           tria.refine_global(n_global_refinements + 2);
         }
       else
         {
-          std::ifstream abaqus_file("../../meshes/piston_3.inp"); // piston
+          std::ifstream abaqus_file(std::string(MESH_DIR) +
+                                    "meshes/piston_3.inp"); // piston
           // mesh
           // std::ifstream abaqus_file(
-          //   "../../meshes/idealized_lv.msh"); // idealized mesh
+          //   std::string(MESH_DIR) + "meshes/idealized_lv.msh"); // idealized
+          //   mesh
           // std::ifstream abaqus_file(
-          // "../../meshes/realistic_lv.msh"); // idealized mesh
+          //   std::string(MESH_DIR) + "meshes/realistic_lv.msh"); // idealized
+          //   mesh
           grid_in.read_abaqus(abaqus_file);
           // grid_in.read_abaqus(abaqus_file);
           // tria.refine_global(n_global_refinements - 3);

--- a/examples/benchmarks_3D.cc
+++ b/examples/benchmarks_3D.cc
@@ -95,7 +95,8 @@ AgglomerationBenchmark<dim>::make_grid()
         {
           grid_in.attach_triangulation(tria);
           std::ifstream gmsh_file(
-            "../../meshes/t3.msh"); // unstructured square [0,1]^2
+            std::string(MESH_DIR) +
+            "/meshes/t3.msh"); // unstructured square [0,1]^2
           grid_in.read_msh(gmsh_file);
           tria.refine_global(5); // 4
         }
@@ -108,10 +109,12 @@ AgglomerationBenchmark<dim>::make_grid()
           // }
           grid_in.attach_triangulation(tria);
           std::ifstream mesh_file(
-            "../../meshes/gray_level_image1.vtk"); // liver mesh
+            std::string(MESH_DIR) +
+            "/meshes/gray_level_image1.vtk"); // liver mesh
           grid_in.read_vtk(mesh_file);
           // grid_in.read_ucd(mesh_file);
-          // "../../meshes/csf_brain_filled_centered_UCD.inp"); // brain mesh
+          // std::string(MESH_DIR) +
+          // "/meshes/csf_brain_filled_centered_UCD.inp"); // brain mesh
           // tria.refine_global(1);
         }
     }

--- a/examples/matrix_free_agglo.cc
+++ b/examples/matrix_free_agglo.cc
@@ -133,13 +133,15 @@ AgglomeratedMG<dim>::make_fine_grid(const unsigned int n_global_refinements)
       if constexpr (dim == 2)
         {
           std::ifstream gmsh_file(
-            "../../meshes/t3.msh"); // unstructured square [0,1]^2
+            std::string(MESH_DIR) +
+            "/meshes/t3.msh"); // unstructured square [0,1]^2
           grid_in.read_msh(gmsh_file);
           tria.refine_global(n_global_refinements + 2);
         }
       else
         {
-          std::ifstream abaqus_file("../../meshes/piston_3.inp"); // piston mesh
+          std::ifstream abaqus_file(std::string(MESH_DIR) +
+                                    "/meshes/piston_3.inp"); // piston mesh
           grid_in.read_abaqus(abaqus_file);
         }
     }

--- a/examples/monodomain_DG3D.cc
+++ b/examples/monodomain_DG3D.cc
@@ -2089,9 +2089,9 @@ MonodomainProblem<dim>::run()
     grid_in.attach_triangulation(tria_dummy);
     std::string mesh_path;
     if (param.test_case == "Idealized")
-      mesh_path = "../../meshes/idealized_lv.msh";
+      mesh_path = std::string(MESH_DIR) + "/idealized_lv.msh";
     else if (param.test_case == "Realistic")
-      mesh_path = "../../meshes/realistic_lv.msh";
+      mesh_path = std::string(MESH_DIR) + "/realistic_lv.msh";
     else
       AssertThrow(false, ExcMessage("No mesh selected!"));
     std::ifstream mesh_file(mesh_path);

--- a/examples/repairing.cc
+++ b/examples/repairing.cc
@@ -89,7 +89,8 @@ Test<dim>::make_grid()
     {
       grid_in.attach_triangulation(tria);
       std::cout << "########### Reading mesh file... ###########" << std::endl;
-      std::ifstream filename("../../meshes/ernie.msh"); // liver or brain domain
+      std::ifstream filename(std::string(MESH_DIR) +
+                             "/meshes/ernie.msh"); // liver or brain domain
       grid_in.read_msh(filename);
       std::cout << "########### Done ###########" << std::endl;
     }

--- a/examples/simplex_agglomerated_multigrid.cc
+++ b/examples/simplex_agglomerated_multigrid.cc
@@ -180,8 +180,9 @@ AgglomeratedMultigridSimplex<dim>::make_fine_grid(
       if constexpr (dim == 2)
         {
           std::ifstream gmsh_file(
-            "../../meshes/square_simplex_coarser.msh"); // unstructured square
-                                                        // made by triangles
+            std::string(MESH_DIR) +
+            "/meshes/square_simplex_coarser.msh"); // unstructured square
+                                                   // made by triangles
           grid_in.read_msh(gmsh_file);
           tria.refine_global(n_global_refinements + 2);
         }

--- a/test/polydeal/3DRtree.cc
+++ b/test/polydeal/3DRtree.cc
@@ -92,11 +92,10 @@ Poisson<dim>::make_grid()
   if (grid_type == GridType::unstructured)
     {
       grid_in.attach_triangulation(tria);
-      // std::ifstream gmsh_file("../../meshes/t2.msh"); // rectangular domain
-      // grid_in.read_msh(gmsh_file);
-      // tria.refine_global(4);
-      std::ifstream gmsh_file(
-        "../../meshes/piston_2.inp"); // rectangular domain
+      // std::ifstream gmsh_file(std::string(MESH_DIR) + "meshes/t2.msh"); //
+      // rectangular domain grid_in.read_msh(gmsh_file); tria.refine_global(4);
+      std::ifstream gmsh_file(std::string(MESH_DIR) +
+                              "/meshes/piston_2.inp"); // rectangular domain
       grid_in.read_abaqus(gmsh_file);
     }
   else
@@ -196,7 +195,7 @@ Poisson<dim>::setup_agglomeration()
       std::vector<typename Triangulation<dim>::active_cell_iterator>
         cells_to_be_agglomerated;
       // Get all the elements associated with the present subdomain_id
-      for (const auto element : cells_per_subdomain[i])
+      for (const auto &element : cells_per_subdomain[i])
         {
           idxs_to_be_agglomerated.push_back(element->active_cell_index());
         }

--- a/test/polydeal/CMakeLists.txt
+++ b/test/polydeal/CMakeLists.txt
@@ -22,6 +22,9 @@ FOREACH(_build_type ${_d2_build_types})
     SET(_lib "polydeal${_p}")
     MESSAGE("-- Configuring test for ${_lib}")
 
+    # Define MESH_DIR for tests
+    add_compile_definitions(MESH_DIR="${MESH_DIR}")
+
     SET(TEST_LIBRARIES ${_lib})
     DEAL_II_PICKUP_TESTS()
     set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/test/polydeal/extract_last_level.cc
+++ b/test/polydeal/extract_last_level.cc
@@ -82,7 +82,8 @@ TestExtractor<dim>::run()
         {
           grid_in.attach_triangulation(tria);
           std::ifstream gmsh_file(
-            "../../meshes/t3.msh"); // unstructured square [0,1]^2
+            std::string(MESH_DIR) +
+            "/meshes/t3.msh"); // unstructured square [0,1]^2
           grid_in.read_msh(gmsh_file);
           tria.refine_global(5); // 4
         }

--- a/test/polydeal/rtree_mesh.cc
+++ b/test/polydeal/rtree_mesh.cc
@@ -63,7 +63,7 @@ Poisson<dim>::make_grid()
   if (grid_type == GridTypes::unstructured)
     {
       grid_in.attach_triangulation(tria);
-      std::ifstream gmsh_file("../../meshes/t2.msh");
+      std::ifstream gmsh_file(std::string(MESH_DIR) + "/meshes/t2.msh");
       grid_in.read_msh(gmsh_file);
       tria.refine_global(4);
     }


### PR DESCRIPTION
This simplifies how we handle and read external meshes. ~Only commit 7e3be16740bb175a0e74bf9f961023a8e62ac183 is relevant. To be merged after #154.~