### PR TITLE
Compile with latest deal.II master

### DIFF
--- a/include/mapping_box.h
+++ b/include/mapping_box.h
@@ -93,8 +93,13 @@ public:
   virtual bool
   preserves_vertex_locations() const override;
 
+#if DEAL_II_VERSION_GTE(9, 8, 0)
+  virtual bool
+  is_compatible_with(const ReferenceCell<dim> &reference_cell) const override;
+#else
   virtual bool
   is_compatible_with(const ReferenceCell &reference_cell) const override;
+#endif
 
   /**
    * @name Mapping points between reference and real cells

--- a/source/mapping_box.cc
+++ b/source/mapping_box.cc
@@ -130,8 +130,13 @@ MappingBox<dim, spacedim>::preserves_vertex_locations() const
 
 template <int dim, int spacedim>
 bool
+#if DEAL_II_VERSION_GTE(9, 8, 0)
+MappingBox<dim, spacedim>::is_compatible_with(
+  const ReferenceCell<dim> &reference_cell) const
+#else
 MappingBox<dim, spacedim>::is_compatible_with(
   const ReferenceCell &reference_cell) const
+#endif
 {
   Assert(dim == reference_cell.get_dimension(),
          ExcMessage("The dimension of your mapping (" +


### PR DESCRIPTION
Fixes a new incompatibility introduced upstream: `ReferenceCell` requires now a template argument.