### PR TITLE
Continuous agglo build transfer matrix implementation

### DIFF
--- a/examples/continuous_agglo_amg.cc
+++ b/examples/continuous_agglo_amg.cc
@@ -72,6 +72,14 @@ using namespace dealii;
 #include "multigrid_amg.h"
 #include "utils.h"
 
+#ifndef DEAL_II_WITH_MUMPS
+namespace dealii
+{
+  class SparseDirectMUMPS
+  {};
+} // namespace dealii
+#endif
+
 namespace Utils
 {
 

--- a/examples/continuous_agglo_amg.cc
+++ b/examples/continuous_agglo_amg.cc
@@ -458,8 +458,9 @@ public:
   unsigned int n_ref_cycles        = 1;
   bool         keep_ratio_constant = false; // try to keep H/h fixed
   bool         do_cells_agglo      = true; // test also cell-based agglomeration
-  bool         do_points_agglo = true; // test also point-based agglomeration
-  bool         do_trilinos_amg = true;
+  bool         do_points_agglo   = true; // test also point-based agglomeration
+  bool         do_trilinos_amg   = true;
+  bool         skip_leaves_level = true;
 
   mutable ParameterAcceptorProxy<ReductionControl> outer_solver_control;
 };
@@ -504,6 +505,7 @@ ProblemParameters<dim>::ProblemParameters()
     add_parameter("Do point agglomeration", do_points_agglo);
     add_parameter("Do cell agglomeration", do_cells_agglo);
     add_parameter("Do Trilinos AMG", do_trilinos_amg);
+    add_parameter("Skip leaves level", skip_leaves_level);
   }
   leave_subsection();
 
@@ -888,7 +890,7 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::solve_with_point_agglo_amg()
                                                         rtree_M_points>(
       original_dof_handler,
       mapping,
-      true,
+      parameters.skip_leaves_level,
       injection_matrices,
       injection_sparsity_patterns,
       mg_levels,
@@ -1081,7 +1083,7 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::solve_with_cell_agglo_amg()
                                                         rtree_M_cells>(
       original_dof_handler,
       mapping,
-      true,
+      parameters.skip_leaves_level,
       injection_matrices,
       injection_sparsity_patterns,
       mg_levels,
@@ -1320,6 +1322,9 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::run()
                 << (parameters.keep_ratio_constant ? "true" : "false")
                 << std::endl;
       std::cout << "Number of refinements: " << parameters.n_refinements
+                << std::endl;
+      std::cout << "Skip leaves level: "
+                << (parameters.skip_leaves_level ? "true" : "false")
                 << std::endl;
       std::cout << std::string(80, '=') << std::endl;
     }

--- a/examples/continuous_agglo_amg.cc
+++ b/examples/continuous_agglo_amg.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/parsed_function.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/fully_distributed_tria.h>
@@ -25,6 +26,7 @@
 #include <deal.II/dofs/dof_tools.h>
 
 #include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_fe.h>
 #include <deal.II/fe/mapping_q1.h>
@@ -71,6 +73,9 @@ using namespace dealii;
 #include "continuous_agglo_utils.h"
 #include "multigrid_amg.h"
 #include "utils.h"
+
+// Uncomment if you want to use simplexes
+// #define SIMPLEX TRUE
 
 #ifndef DEAL_II_WITH_MUMPS
 namespace dealii
@@ -542,19 +547,24 @@ private:
   solve_with_trilinos_amg();
 
   const ProblemParameters<dim>                       &parameters;
-  MappingQ1<dim>                                      mapping;
   MPI_Comm                                            comm;
   unsigned int                                        my_rank;
   unsigned int                                        n_mpi_processes;
   parallel::fullydistributed::Triangulation<dim, dim> distributed_tria;
-  FE_Q<dim>                                           fe_q;
-  AffineConstraints<double>                           constraints;
-  TrilinosWrappers::SparsityPattern                   sparsity;
-  TrilinosWrappers::SparseMatrix                      system_matrix;
-  LinearAlgebra::distributed::Vector<double>          locally_relevant_solution;
-  LinearAlgebra::distributed::Vector<double>          system_rhs;
-  std::unique_ptr<const Function<dim>>                rhs_function;
-  std::unique_ptr<const Function<dim>>                analytical_solution;
+#ifdef SIMPLEX
+  MappingFE<dim>   mapping;
+  FE_SimplexP<dim> fe_q;
+#else
+  MappingQ1<dim> mapping;
+  FE_Q<dim>      fe_q;
+#endif
+  AffineConstraints<double>                  constraints;
+  TrilinosWrappers::SparsityPattern          sparsity;
+  TrilinosWrappers::SparseMatrix             system_matrix;
+  LinearAlgebra::distributed::Vector<double> locally_relevant_solution;
+  LinearAlgebra::distributed::Vector<double> system_rhs;
+  std::unique_ptr<const Function<dim>>       rhs_function;
+  std::unique_ptr<const Function<dim>>       analytical_solution;
 
 
   static constexpr unsigned int rtree_M_points = 2 * rtree_m_points;
@@ -565,15 +575,12 @@ public:
   void
   run();
 
-  std::string grid_type;
-  std::string partitioner_type;
-  std::string solution_type;
-  // std::string  output_info_filename;
+  std::string  grid_type;
+  std::string  partitioner_type;
+  std::string  solution_type;
   unsigned int mg_levels;
 
-  DoFHandler<dim> original_dof_handler;
-  // std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
-  // std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
+  DoFHandler<dim>  original_dof_handler;
   ReductionControl solver_control;
 };
 
@@ -581,25 +588,20 @@ template <int dim, unsigned int rtree_m_points, unsigned int rtree_m_cells>
 Poisson<dim, rtree_m_points, rtree_m_cells>::Poisson(
   const ProblemParameters<dim> &problem_parameters)
   : parameters(problem_parameters)
-  , mapping()
   , comm(MPI_COMM_WORLD)
   , my_rank(Utilities::MPI::this_mpi_process(comm))
   , n_mpi_processes(Utilities::MPI::n_mpi_processes(comm))
   , distributed_tria(comm)
+#ifdef SIMPLEX
+  , mapping(FE_SimplexP<dim>{1})
+#else
+  , mapping()
+#endif
   , fe_q(parameters.fe_degree)
   , grid_type(parameters.grid_type)
   , partitioner_type(parameters.partitioner_type)
   , solution_type(parameters.solution_type)
   , mg_levels(parameters.mg_levels)
-  // , output_info_filename(
-  //     parameters.output_directory + "/output_info_" +
-  //     sanitize_for_filename(parameters.grid_type) + "_p" +
-  //     std::to_string(parameters.fe_degree) + "_cp" +
-  //     std::to_string(parameters.coarse_fe_degree) + "_ref" +
-  //     (parameters.keep_ratio_constant ? "_fixed_ratio" : "_variable_ratio") +
-  //     (parameters.do_points_agglo ? "_point_agglo" : "") +
-  //     (parameters.do_cells_agglo ? "_cell_agglo" : "") +
-  //     std::to_string(parameters.n_refinements) + ".txt")
   , original_dof_handler(distributed_tria)
   , solver_control(parameters.outer_solver_control)
 {
@@ -645,7 +647,14 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::make_grid()
       if constexpr (dim == 2)
         {
           grid_in.attach_triangulation(tria);
+#ifdef SIMPLEX
+          std::ifstream gmsh_file(
+            "../../meshes/square_simplex_coarser.msh"); // unstructured
+                                                        // square made by
+                                                        // triangles
+#else
           std::ifstream gmsh_file("../../meshes/t3.msh"); // unstructured square
+#endif
           grid_in.read_msh(gmsh_file);
           tria.refine_global(parameters.n_refinements);
           GridTools::partition_triangulation(n_mpi_processes, tria);
@@ -656,16 +665,20 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::make_grid()
       else if constexpr (dim == 3)
         {
           grid_in.attach_triangulation(tria);
+#ifdef SIMPLEX
+          std::ifstream filename(
+            "../../meshes/gray_level_image1.vtk"); // liver or brain domain
+          grid_in.read_vtk(filename);
+          GridTools::scale(1e-2, tria);
+          tria.set_all_manifold_ids(numbers::flat_manifold_id);
+          tria.refine_global(parameters.n_refinements);
+#else
           if (parameters.use_piston)
             {
               std::ifstream filename(
                 "../../meshes/piston_3.inp"); // piston mesh
               grid_in.read_abaqus(filename);
               tria.refine_global(parameters.n_refinements);
-              GridTools::partition_triangulation(n_mpi_processes, tria);
-              auto description = TriangulationDescription::Utilities::
-                create_description_from_triangulation(tria, comm);
-              distributed_tria.create_triangulation(description);
             }
           else if (parameters.use_real_lv_mesh)
             {
@@ -673,10 +686,6 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::make_grid()
               grid_in.read_msh(filename);
               tria.refine_global(parameters.n_refinements);
               GridTools::scale(1e-2, tria);
-              GridTools::partition_triangulation(n_mpi_processes, tria);
-              auto description = TriangulationDescription::Utilities::
-                create_description_from_triangulation(tria, comm);
-              distributed_tria.create_triangulation(description);
             }
           else
             {
@@ -684,31 +693,31 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::make_grid()
               grid_in.read_msh(filename);
               tria.refine_global(parameters.n_refinements);
               GridTools::scale(1e-2, tria);
-              GridTools::partition_triangulation(n_mpi_processes, tria);
-              auto description = TriangulationDescription::Utilities::
-                create_description_from_triangulation(tria, comm);
-              distributed_tria.create_triangulation(description);
             }
+#endif
+          GridTools::partition_triangulation(n_mpi_processes, tria);
+          auto description = TriangulationDescription::Utilities::
+            create_description_from_triangulation(tria, comm);
+          distributed_tria.create_triangulation(description);
 
+#ifdef SIMPLEX
+#else
           AssertThrow(tria.all_reference_cells_are_hyper_cube(),
                       ExcMessage("Mixed mesh. Bailing out"));
+#endif
         }
     }
   else
-    {
-      // Grids generated through using GridGenerator
-      if constexpr (dim == 2)
-        GridGenerator::hyper_cube(tria, 0., 1.);
-      // GridGenerator::hyper_ball(tria, Point<dim>(), 1.);
-      else if constexpr (dim == 3)
-        GridGenerator::hyper_cube(tria, 0., 1.);
-      // GridGenerator::eccentric_hyper_shell(tria,
-      //                                      Point<dim>(1., 1., 1.),
-      //                                      Point<dim>(0.7, 0.7, 0.7),
-      //                                      0.2,
-      //                                      1.,
-      //                                      12 /*cells along circumference*/);
+    { // Grids generated through using GridGenerator
+#ifdef SIMPLEX
+      Triangulation<dim> tria_hex;
+      GridGenerator::hyper_cube(tria_hex, 0., 1.);
+      tria_hex.refine_global(parameters.n_refinements);
+      GridGenerator::convert_hypercube_to_simplex_mesh(tria_hex, tria);
+#else
+      GridGenerator::hyper_cube(tria, 0., 1.);
       tria.refine_global(parameters.n_refinements);
+#endif
       GridTools::partition_triangulation(n_mpi_processes, tria);
       auto description = TriangulationDescription::Utilities::
         create_description_from_triangulation(tria, comm);
@@ -754,6 +763,12 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::assemble_system()
 
   if (grid_type == "unstructured" && dim == 3)
     {
+#ifdef SIMPLEX
+      VectorTools::interpolate_boundary_values(original_dof_handler,
+                                               types::boundary_id(0),
+                                               *analytical_solution,
+                                               constraints);
+#else
       if (parameters.use_piston)
         {
           VectorTools::interpolate_boundary_values(original_dof_handler,
@@ -784,29 +799,33 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::assemble_system()
                                                    *analytical_solution,
                                                    constraints);
         }
+#endif
     }
   else
     {
+#ifdef SIMPLEX
+      if (grid_type == "unstructured")
+        {
+          for (unsigned int i = 0; i < 4; ++i)
+            VectorTools::interpolate_boundary_values(original_dof_handler,
+                                                     types::boundary_id(i),
+                                                     *analytical_solution,
+                                                     constraints);
+        }
+      else
+        VectorTools::interpolate_boundary_values(original_dof_handler,
+                                                 types::boundary_id(0),
+                                                 *analytical_solution,
+                                                 constraints);
+#else
       VectorTools::interpolate_boundary_values(original_dof_handler,
                                                types::boundary_id(0),
                                                *analytical_solution,
                                                constraints);
+#endif
     }
 
   constraints.close();
-
-  // DynamicSparsityPattern dsp(locally_relevant_dofs);
-
-  // DoFTools::make_sparsity_pattern(original_dof_handler,
-  //                                 dsp,
-  //                                 constraints,
-  //                                 false);
-  // SparsityTools::distribute_sparsity_pattern(dsp,
-  //                                            locally_owned_dofs,
-  //                                            comm,
-  //                                            locally_relevant_dofs);
-
-  // system_matrix.reinit(locally_owned_dofs, locally_owned_dofs, dsp, comm);
 
   TrilinosWrappers::SparsityPattern sparsity_pattern(locally_owned_dofs, comm);
   DoFTools::make_sparsity_pattern(original_dof_handler,
@@ -816,8 +835,12 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::assemble_system()
   sparsity_pattern.compress();
   system_matrix.reinit(sparsity_pattern);
 
+#ifdef SIMPLEX
+  const QGaussSimplex<dim> quadrature_formula(fe_q.get_degree() + 1);
+#else
   const QGauss<dim> quadrature_formula(fe_q.get_degree() + 1);
-  FEValues<dim>     fe_values(mapping,
+#endif
+  FEValues<dim> fe_values(mapping,
                           fe_q,
                           quadrature_formula,
                           update_values | update_gradients |
@@ -905,6 +928,15 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::solve_with_point_agglo_amg()
       coarse_space_degrees,
       triangulations,
       support_dof_handlers);
+
+  if (my_rank == 0)
+    {
+      std::cout << "H/h ratio for point agglomeration: "
+                << GridTools::maximal_cell_diameter(*triangulations[0],
+                                                    mapping) /
+                     GridTools::maximal_cell_diameter(distributed_tria, mapping)
+                << std::endl;
+    }
 
   AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
     injection_matrices);
@@ -1048,7 +1080,11 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::solve_with_point_agglo_amg()
                                     locally_relevant_solution,
                                     *analytical_solution,
                                     error_per_cell,
+#ifdef SIMPLEX
+                                    QGaussSimplex<dim>(fe_q.get_degree() + 2),
+#else
                                     QGauss<dim>(fe_q.get_degree() + 2),
+#endif
                                     VectorTools::L2_norm);
 
   double l2_error =
@@ -1098,6 +1134,16 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::solve_with_cell_agglo_amg()
       coarse_space_degrees,
       triangulations,
       support_dof_handlers);
+
+  if (my_rank == 0)
+    {
+      std::cout << "H/h ratio for cell agglomeration: "
+                << GridTools::maximal_cell_diameter(*triangulations[0],
+                                                    mapping) /
+                     GridTools::maximal_cell_diameter(distributed_tria, mapping)
+                << std::endl;
+    }
+
 
   AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
     injection_matrices);
@@ -1241,7 +1287,11 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::solve_with_cell_agglo_amg()
                                     locally_relevant_solution,
                                     *analytical_solution,
                                     error_per_cell,
+#ifdef SIMPLEX
+                                    QGaussSimplex<dim>(fe_q.get_degree() + 2),
+#else
                                     QGauss<dim>(fe_q.get_degree() + 2),
+#endif
                                     VectorTools::L2_norm);
 
   double l2_error =
@@ -1300,7 +1350,11 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::solve_with_trilinos_amg()
                                     locally_relevant_solution,
                                     *analytical_solution,
                                     error_per_cell,
+#ifdef SIMPLEX
+                                    QGaussSimplex<dim>(fe_q.get_degree() + 2),
+#else
                                     QGauss<dim>(fe_q.get_degree() + 2),
+#endif
                                     VectorTools::L2_norm);
 
   double l2_error =
@@ -1334,6 +1388,12 @@ Poisson<dim, rtree_m_points, rtree_m_cells>::run()
       std::cout << "Skip leaves level: "
                 << (parameters.skip_leaves_level ? "true" : "false")
                 << std::endl;
+      std::cout << "Use simplex mesh: "
+#ifdef SIMPLEX
+                << "true" << std::endl;
+#else
+                << "false" << std::endl;
+#endif
       std::cout << std::string(80, '=') << std::endl;
     }
   make_grid();
@@ -1367,7 +1427,7 @@ main(int argc, char *argv[])
   if (dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     dealii::deallog.depth_console(10);
 
-  static constexpr unsigned int dim = 3;
+  static constexpr unsigned int dim = 2;
   ProblemParameters<dim>        parameters;
   std::string                   parameter_file;
   static constexpr unsigned int rtree_m_points = 4;

--- a/examples/continuous_agglo_amg.cc
+++ b/examples/continuous_agglo_amg.cc
@@ -1,0 +1,1380 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright ( ) XXXX - YYYY by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/parameter_acceptor.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/parsed_function.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_fe.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/multigrid/mg_coarse.h>
+#include <deal.II/multigrid/mg_matrix.h>
+#include <deal.II/multigrid/mg_smoother.h>
+#include <deal.II/multigrid/mg_tools.h>
+#include <deal.II/multigrid/multigrid.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/matrix_tools.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/vector_tools_integrate_difference.h>
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using namespace dealii;
+
+#include "continuous_agglo_utils.h"
+#include "multigrid_amg.h"
+#include "utils.h"
+
+namespace Utils
+{
+
+  template <typename MatrixType, typename VectorType, typename DirectSolverType>
+  class MGCoarseDirectMUMPS : public MGCoarseGridBase<VectorType>
+  {
+  public:
+    MGCoarseDirectMUMPS()
+    {}
+
+    void
+    initialize(const MatrixType &matrix)
+    {
+#ifdef DEAL_II_WITH_MUMPS
+      coarse_matrix = &matrix;
+      direct_solver = std::make_unique<SparseDirectMUMPS>(
+        typename SparseDirectMUMPS::AdditionalData(),
+        matrix.get_mpi_communicator());
+      direct_solver->initialize(*coarse_matrix);
+
+#else
+      DEAL_II_NOT_IMPLEMENTED();
+#endif
+    }
+
+    virtual void
+    operator()([[maybe_unused]] const unsigned int level,
+               VectorType                         &dst,
+               const VectorType                   &src) const override
+    {
+#ifdef DEAL_II_WITH_MUMPS
+      direct_solver->vmult(dst, src);
+#else
+      DEAL_II_NOT_IMPLEMENTED();
+#endif
+    }
+
+    const MatrixType                 *coarse_matrix;
+    std::unique_ptr<DirectSolverType> direct_solver;
+  };
+
+} // namespace Utils
+
+template <int dim>
+class RightHandSide : public Function<dim>
+{
+public:
+  RightHandSide(const std::string &sol_type = "linear")
+    : Function<dim>()
+  {
+    solution_type = sol_type;
+  }
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+private:
+  std::string solution_type;
+};
+
+
+
+template <int dim>
+void
+RightHandSide<dim>::value_list(const std::vector<Point<dim>> &points,
+                               std::vector<double>           &values,
+                               const unsigned int /*component*/) const
+{
+  if (solution_type == "linear")
+    {
+      for (unsigned int i = 0; i < values.size(); ++i)
+        values[i] = 0.; // Laplacian of linear function
+    }
+  else if (solution_type == "quadratic")
+    {
+      for (unsigned int i = 0; i < values.size(); ++i)
+        values[i] = -2.0 * dim; // -Δ(Σ x_d^2 - 1) = -2*dim
+    }
+  else if (solution_type == "product")
+    {
+      for (unsigned int i = 0; i < values.size(); ++i)
+        values[i] = -2. * points[i][0] * (points[i][0] - 1.) -
+                    2. * points[i][1] * (points[i][1] - 1.);
+    }
+  else if (solution_type == "product_sine")
+    {
+      // 2pi^2*sin(pi*x)*sin(pi*y)
+      if constexpr (dim == 2)
+        for (unsigned int i = 0; i < values.size(); ++i)
+          values[i] = 2. * numbers::PI * numbers::PI *
+                      std::sin(numbers::PI * points[i][0]) *
+                      std::sin(numbers::PI * points[i][1]);
+      else if constexpr (dim == 3)
+        for (unsigned int i = 0; i < values.size(); ++i)
+          values[i] = 3. * numbers::PI * numbers::PI *
+                      std::sin(numbers::PI * points[i][0]) *
+                      std::sin(numbers::PI * points[i][1]) *
+                      std::sin(numbers::PI * points[i][2]);
+      else
+        DEAL_II_NOT_IMPLEMENTED();
+    }
+  else
+    {
+      Assert(false, ExcNotImplemented());
+    }
+}
+
+
+
+template <int dim>
+class SolutionLinear : public Function<dim>
+{
+public:
+  SolutionLinear()
+    : Function<dim>()
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  virtual Tensor<1, dim>
+  gradient(const Point<dim>  &p,
+           const unsigned int component = 0) const override;
+};
+
+template <int dim>
+double
+SolutionLinear<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  double sum = 0;
+  for (unsigned int d = 0; d < dim; ++d)
+    sum += p[d];
+
+  return sum - 1; // p[0]+p[1]+p[2]-1
+}
+
+template <int dim>
+Tensor<1, dim>
+SolutionLinear<dim>::gradient(const Point<dim> &p, const unsigned int) const
+{
+  (void)p;
+  Tensor<1, dim> return_value;
+  for (unsigned int d = 0; d < dim; ++d)
+    return_value[d] = 0.;
+  return return_value;
+}
+
+
+template <int dim>
+void
+SolutionLinear<dim>::value_list(const std::vector<Point<dim>> &points,
+                                std::vector<double>           &values,
+                                const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+
+
+template <int dim>
+class SolutionQuadratic : public Function<dim>
+{
+public:
+  SolutionQuadratic()
+    : Function<dim>()
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  virtual Tensor<1, dim>
+  gradient(const Point<dim>  &p,
+           const unsigned int component = 0) const override;
+};
+
+template <int dim>
+double
+SolutionQuadratic<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  double s = 0.;
+  for (unsigned int d = 0; d < dim; ++d)
+    s += p[d] * p[d];
+  return s - 1.;
+}
+
+template <int dim>
+Tensor<1, dim>
+SolutionQuadratic<dim>::gradient(const Point<dim> &p, const unsigned int) const
+{
+  Tensor<1, dim> return_value;
+  for (unsigned int d = 0; d < dim; ++d)
+    return_value[d] = 2. * p[d];
+  return return_value;
+}
+
+
+template <int dim>
+void
+SolutionQuadratic<dim>::value_list(const std::vector<Point<dim>> &points,
+                                   std::vector<double>           &values,
+                                   const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+
+
+template <int dim>
+class SolutionProduct : public Function<dim>
+{
+public:
+  SolutionProduct()
+    : Function<dim>()
+  {
+    Assert(dim == 2, ExcNotImplemented());
+  }
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  virtual Tensor<1, dim>
+  gradient(const Point<dim>  &p,
+           const unsigned int component = 0) const override;
+
+  virtual void
+  gradient_list(const std::vector<Point<dim>> &points,
+                std::vector<Tensor<1, dim>>   &gradients,
+                const unsigned int /*component*/) const override;
+};
+
+template <int dim>
+double
+SolutionProduct<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  return p[0] * (p[0] - 1.) * p[1] * (p[1] - 1.); // square
+}
+
+template <int dim>
+Tensor<1, dim>
+SolutionProduct<dim>::gradient(const Point<dim> &p, const unsigned int) const
+{
+  Tensor<1, dim> return_value;
+  return_value[0] = (-1 + 2 * p[0]) * (-1 + p[1]) * p[1];
+  return_value[1] = (-1 + 2 * p[1]) * (-1 + p[0]) * p[0];
+  return return_value;
+}
+
+
+template <int dim>
+void
+SolutionProduct<dim>::value_list(const std::vector<Point<dim>> &points,
+                                 std::vector<double>           &values,
+                                 const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+
+
+template <int dim>
+void
+SolutionProduct<dim>::gradient_list(const std::vector<Point<dim>> &points,
+                                    std::vector<Tensor<1, dim>>   &gradients,
+                                    const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < gradients.size(); ++i)
+    gradients[i] = this->gradient(points[i]);
+}
+
+
+
+template <int dim>
+class SolutionProductSine : public Function<dim>
+{
+public:
+  SolutionProductSine()
+    : Function<dim>()
+  {
+    static_assert(dim > 1, "Dimension must be greater than 1");
+  }
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  virtual void
+  value_list(const std::vector<Point<dim>> &points,
+             std::vector<double>           &values,
+             const unsigned int /*component*/) const override;
+
+  virtual Tensor<1, dim>
+  gradient(const Point<dim>  &p,
+           const unsigned int component = 0) const override;
+};
+
+template <int dim>
+double
+SolutionProductSine<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  return dim == 2 ?
+           std::sin(numbers::PI * p[0]) * std::sin(numbers::PI * p[1]) :
+           std::sin(numbers::PI * p[0]) * std::sin(numbers::PI * p[1]) *
+             std::sin(numbers::PI * p[2]);
+}
+
+template <int dim>
+Tensor<1, dim>
+SolutionProductSine<dim>::gradient(const Point<dim> &p,
+                                   const unsigned int) const
+{
+  Tensor<1, dim> return_value;
+  if constexpr (dim == 2)
+    {
+      return_value[0] = numbers::PI * std::cos(numbers::PI * p[0]) *
+                        std::sin(numbers::PI * p[1]);
+      return_value[1] = numbers::PI * std::cos(numbers::PI * p[1]) *
+                        std::sin(numbers::PI * p[0]);
+    }
+  else if constexpr (dim == 3)
+    {
+      return_value[0] = numbers::PI * std::cos(numbers::PI * p[0]) *
+                        std::sin(numbers::PI * p[1]) *
+                        std::sin(numbers::PI * p[2]);
+      return_value[1] = numbers::PI * std::cos(numbers::PI * p[1]) *
+                        std::sin(numbers::PI * p[0]) *
+                        std::sin(numbers::PI * p[2]);
+      return_value[2] = numbers::PI * std::cos(numbers::PI * p[2]) *
+                        std::sin(numbers::PI * p[0]) *
+                        std::sin(numbers::PI * p[1]);
+    }
+  else
+    DEAL_II_NOT_IMPLEMENTED();
+
+  return return_value;
+}
+
+
+template <int dim>
+void
+SolutionProductSine<dim>::value_list(const std::vector<Point<dim>> &points,
+                                     std::vector<double>           &values,
+                                     const unsigned int /*component*/) const
+{
+  for (unsigned int i = 0; i < values.size(); ++i)
+    values[i] = this->value(points[i]);
+}
+
+template <int dim>
+class ProblemParameters : public ParameterAcceptor
+{
+public:
+  ProblemParameters();
+
+  std::string  output_directory    = ".";
+  unsigned int mg_levels           = 2;
+  unsigned int smoother_steps      = 1;
+  bool         use_piston          = false;
+  bool         use_real_lv_mesh    = false;
+  unsigned int fe_degree           = 1;
+  unsigned int coarse_fe_degree    = 1;
+  std::string  grid_type           = "unstructured";
+  std::string  partitioner_type    = "rtree";
+  std::string  solution_type       = "linear";
+  unsigned int n_refinements       = 1;
+  unsigned int n_ref_cycles        = 1;
+  bool         keep_ratio_constant = false; // try to keep H/h fixed
+  bool         do_cells_agglo      = true; // test also cell-based agglomeration
+  bool         do_points_agglo = true; // test also point-based agglomeration
+  bool         do_trilinos_amg = true;
+
+  mutable ParameterAcceptorProxy<ReductionControl> outer_solver_control;
+};
+
+template <int dim>
+ProblemParameters<dim>::ProblemParameters()
+  : ParameterAcceptor("R-tree based MG/")
+  , outer_solver_control("Reduction control")
+
+{
+  add_parameter("Finite element degree", fe_degree);
+  add_parameter("Output directory", output_directory);
+  add_parameter("Solution type", solution_type);
+  add_parameter("Coarse Finite element degree", coarse_fe_degree);
+
+
+
+  enter_subsection("Grid generation");
+  {
+    add_parameter(
+      "Grid type",
+      grid_type,
+      "Type of grid to use. Options are 'grid_generator' and 'unstructured'.");
+    add_parameter(
+      "Number of initial refinements",
+      n_refinements,
+      "Number of global refinements to perform on the initial mesh.");
+    add_parameter("Number of refinements cycles",
+                  n_ref_cycles,
+                  "Number of cycles to perform.");
+    add_parameter("Use piston mesh", use_piston);
+    add_parameter("Use real lv mesh", use_real_lv_mesh);
+  }
+  leave_subsection();
+
+  enter_subsection("R3MG");
+  {
+    add_parameter("Partitioner type", partitioner_type);
+    add_parameter("MG Levels", mg_levels);
+    add_parameter("Smoother steps", smoother_steps);
+    add_parameter("Keep ratio constant", keep_ratio_constant);
+    add_parameter("Do point agglomeration", do_points_agglo);
+    add_parameter("Do cell agglomeration", do_cells_agglo);
+    add_parameter("Do Trilinos AMG", do_trilinos_amg);
+  }
+  leave_subsection();
+
+  outer_solver_control.declare_parameters_call_back.connect([]() -> void {
+    ParameterAcceptor::prm.set("Max steps", "100");
+    ParameterAcceptor::prm.set("Tolerance", "1.e-9");
+    ParameterAcceptor::prm.set("Reduction", "1.e-6");
+    ParameterAcceptor::prm.set("Log history", "true");
+    ParameterAcceptor::prm.set("Log result", "true");
+  });
+}
+
+template <int dim, unsigned int rtree_m_points, unsigned int rtree_m_cells>
+class Poisson
+{
+private:
+  void
+  make_grid();
+  void
+  assemble_system();
+  void
+  solve_with_point_agglo_amg();
+  void
+  solve_with_cell_agglo_amg();
+  void
+  solve_with_trilinos_amg();
+
+  const ProblemParameters<dim>                       &parameters;
+  MappingQ1<dim>                                      mapping;
+  MPI_Comm                                            comm;
+  unsigned int                                        my_rank;
+  unsigned int                                        n_mpi_processes;
+  parallel::fullydistributed::Triangulation<dim, dim> distributed_tria;
+  FE_Q<dim>                                           fe_q;
+  AffineConstraints<double>                           constraints;
+  TrilinosWrappers::SparsityPattern                   sparsity;
+  TrilinosWrappers::SparseMatrix                      system_matrix;
+  LinearAlgebra::distributed::Vector<double>          locally_relevant_solution;
+  LinearAlgebra::distributed::Vector<double>          system_rhs;
+  std::unique_ptr<const Function<dim>>                rhs_function;
+  std::unique_ptr<const Function<dim>>                analytical_solution;
+
+
+  static constexpr unsigned int rtree_M_points = 2 * rtree_m_points;
+  static constexpr unsigned int rtree_M_cells  = 2 * rtree_m_cells;
+
+public:
+  Poisson(const ProblemParameters<dim> &);
+  void
+  run();
+
+  std::string grid_type;
+  std::string partitioner_type;
+  std::string solution_type;
+  // std::string  output_info_filename;
+  unsigned int mg_levels;
+
+  DoFHandler<dim> original_dof_handler;
+  // std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
+  // std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
+  ReductionControl solver_control;
+};
+
+template <int dim, unsigned int rtree_m_points, unsigned int rtree_m_cells>
+Poisson<dim, rtree_m_points, rtree_m_cells>::Poisson(
+  const ProblemParameters<dim> &problem_parameters)
+  : parameters(problem_parameters)
+  , mapping()
+  , comm(MPI_COMM_WORLD)
+  , my_rank(Utilities::MPI::this_mpi_process(comm))
+  , n_mpi_processes(Utilities::MPI::n_mpi_processes(comm))
+  , distributed_tria(comm)
+  , fe_q(parameters.fe_degree)
+  , grid_type(parameters.grid_type)
+  , partitioner_type(parameters.partitioner_type)
+  , solution_type(parameters.solution_type)
+  , mg_levels(parameters.mg_levels)
+  // , output_info_filename(
+  //     parameters.output_directory + "/output_info_" +
+  //     sanitize_for_filename(parameters.grid_type) + "_p" +
+  //     std::to_string(parameters.fe_degree) + "_cp" +
+  //     std::to_string(parameters.coarse_fe_degree) + "_ref" +
+  //     (parameters.keep_ratio_constant ? "_fixed_ratio" : "_variable_ratio") +
+  //     (parameters.do_points_agglo ? "_point_agglo" : "") +
+  //     (parameters.do_cells_agglo ? "_cell_agglo" : "") +
+  //     std::to_string(parameters.n_refinements) + ".txt")
+  , original_dof_handler(distributed_tria)
+  , solver_control(parameters.outer_solver_control)
+{
+  bool is_valid_m = false;
+  if constexpr (dim == 3)
+    is_valid_m = rtree_m_points >= 4 ? true : false;
+  else if constexpr (dim == 2)
+    is_valid_m = rtree_m_points >= 2 ? true : false;
+  else
+    DEAL_II_NOT_IMPLEMENTED();
+
+  AssertThrow(
+    is_valid_m,
+    ExcMessage(
+      "Invalid m for R-tree partitioning. Adjust parameter m accordingly to the dimension."));
+
+  if (solution_type == "linear")
+    analytical_solution = std::make_unique<SolutionLinear<dim>>();
+  else if (solution_type == "quadratic")
+    analytical_solution = std::make_unique<SolutionQuadratic<dim>>();
+  else if (solution_type == "product")
+    analytical_solution = std::make_unique<SolutionProduct<dim>>();
+  else if (solution_type == "product_sine")
+    analytical_solution = std::make_unique<SolutionProductSine<dim>>();
+
+  rhs_function = std::make_unique<const RightHandSide<dim>>(solution_type);
+  constraints.close();
+
+  solver_control.log_history(parameters.outer_solver_control.log_history() &&
+                             (my_rank == 0));
+  solver_control.log_result(parameters.outer_solver_control.log_result() &&
+                            (my_rank == 0));
+}
+
+template <int dim, unsigned int rtree_m_points, unsigned int rtree_m_cells>
+void
+Poisson<dim, rtree_m_points, rtree_m_cells>::make_grid()
+{
+  GridIn<dim>        grid_in;
+  Triangulation<dim> tria;
+  if (grid_type == "unstructured")
+    {
+      if constexpr (dim == 2)
+        {
+          grid_in.attach_triangulation(tria);
+          std::ifstream gmsh_file("../../meshes/t3.msh"); // unstructured square
+          grid_in.read_msh(gmsh_file);
+          tria.refine_global(parameters.n_refinements);
+          GridTools::partition_triangulation(n_mpi_processes, tria);
+          auto description = TriangulationDescription::Utilities::
+            create_description_from_triangulation(tria, comm);
+          distributed_tria.create_triangulation(description);
+        }
+      else if constexpr (dim == 3)
+        {
+          grid_in.attach_triangulation(tria);
+          if (parameters.use_piston)
+            {
+              std::ifstream filename(
+                "../../meshes/piston_3.inp"); // piston mesh
+              grid_in.read_abaqus(filename);
+              tria.refine_global(parameters.n_refinements);
+              GridTools::partition_triangulation(n_mpi_processes, tria);
+              auto description = TriangulationDescription::Utilities::
+                create_description_from_triangulation(tria, comm);
+              distributed_tria.create_triangulation(description);
+            }
+          else if (parameters.use_real_lv_mesh)
+            {
+              std::ifstream filename("../../meshes/realistic_lv.msh");
+              grid_in.read_msh(filename);
+              tria.refine_global(parameters.n_refinements);
+              GridTools::scale(1e-2, tria);
+              GridTools::partition_triangulation(n_mpi_processes, tria);
+              auto description = TriangulationDescription::Utilities::
+                create_description_from_triangulation(tria, comm);
+              distributed_tria.create_triangulation(description);
+            }
+          else
+            {
+              std::ifstream filename("../../meshes/idealized_lv.msh");
+              grid_in.read_msh(filename);
+              tria.refine_global(parameters.n_refinements);
+              GridTools::scale(1e-2, tria);
+              GridTools::partition_triangulation(n_mpi_processes, tria);
+              auto description = TriangulationDescription::Utilities::
+                create_description_from_triangulation(tria, comm);
+              distributed_tria.create_triangulation(description);
+            }
+
+          AssertThrow(tria.all_reference_cells_are_hyper_cube(),
+                      ExcMessage("Mixed mesh. Bailing out"));
+        }
+    }
+  else
+    {
+      // Grids generated through using GridGenerator
+      if constexpr (dim == 2)
+        GridGenerator::hyper_cube(tria, 0., 1.);
+      // GridGenerator::hyper_ball(tria, Point<dim>(), 1.);
+      else if constexpr (dim == 3)
+        GridGenerator::hyper_cube(tria, 0., 1.);
+      // GridGenerator::eccentric_hyper_shell(tria,
+      //                                      Point<dim>(1., 1., 1.),
+      //                                      Point<dim>(0.7, 0.7, 0.7),
+      //                                      0.2,
+      //                                      1.,
+      //                                      12 /*cells along circumference*/);
+      tria.refine_global(parameters.n_refinements);
+      GridTools::partition_triangulation(n_mpi_processes, tria);
+      auto description = TriangulationDescription::Utilities::
+        create_description_from_triangulation(tria, comm);
+      distributed_tria.create_triangulation(description);
+    }
+
+  if (partitioner_type != "rtree")
+    {
+      // TODO: maybe add more partitioning?
+      Assert(
+        false,
+        ExcMessage(
+          "This test is meant to be run with R-tree partitioning only for now."));
+    }
+}
+
+template <int dim, unsigned int rtree_m_points, unsigned int rtree_m_cells>
+void
+Poisson<dim, rtree_m_points, rtree_m_cells>::assemble_system()
+{
+  original_dof_handler.distribute_dofs(fe_q);
+
+  if (my_rank == 0)
+    {
+      std::cout << "Assembling system..." << std::endl;
+      std::cout << "Number of active cells: "
+                << distributed_tria.n_global_active_cells() << std::endl;
+      std::cout << "Number of degrees of freedom: "
+                << original_dof_handler.n_dofs() << std::endl;
+    }
+
+  const IndexSet locally_owned_dofs = original_dof_handler.locally_owned_dofs();
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(original_dof_handler);
+
+  constraints.clear();
+  constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
+
+  system_rhs.reinit(locally_owned_dofs, locally_relevant_dofs, comm);
+  locally_relevant_solution.reinit(locally_owned_dofs,
+                                   locally_relevant_dofs,
+                                   comm);
+
+  if (grid_type == "unstructured" && dim == 3)
+    {
+      if (parameters.use_piston)
+        {
+          VectorTools::interpolate_boundary_values(original_dof_handler,
+                                                   types::boundary_id(0),
+                                                   *analytical_solution,
+                                                   constraints);
+          VectorTools::interpolate_boundary_values(original_dof_handler,
+                                                   types::boundary_id(1),
+                                                   *analytical_solution,
+                                                   constraints);
+          VectorTools::interpolate_boundary_values(original_dof_handler,
+                                                   types::boundary_id(2),
+                                                   *analytical_solution,
+                                                   constraints);
+        }
+      else
+        {
+          VectorTools::interpolate_boundary_values(original_dof_handler,
+                                                   types::boundary_id(10),
+                                                   *analytical_solution,
+                                                   constraints);
+          VectorTools::interpolate_boundary_values(original_dof_handler,
+                                                   types::boundary_id(20),
+                                                   *analytical_solution,
+                                                   constraints);
+          VectorTools::interpolate_boundary_values(original_dof_handler,
+                                                   types::boundary_id(50),
+                                                   *analytical_solution,
+                                                   constraints);
+        }
+    }
+  else
+    {
+      VectorTools::interpolate_boundary_values(original_dof_handler,
+                                               types::boundary_id(0),
+                                               *analytical_solution,
+                                               constraints);
+    }
+
+  constraints.close();
+
+  // DynamicSparsityPattern dsp(locally_relevant_dofs);
+
+  // DoFTools::make_sparsity_pattern(original_dof_handler,
+  //                                 dsp,
+  //                                 constraints,
+  //                                 false);
+  // SparsityTools::distribute_sparsity_pattern(dsp,
+  //                                            locally_owned_dofs,
+  //                                            comm,
+  //                                            locally_relevant_dofs);
+
+  // system_matrix.reinit(locally_owned_dofs, locally_owned_dofs, dsp, comm);
+
+  TrilinosWrappers::SparsityPattern sparsity_pattern(locally_owned_dofs, comm);
+  DoFTools::make_sparsity_pattern(original_dof_handler,
+                                  sparsity_pattern,
+                                  constraints,
+                                  false);
+  sparsity_pattern.compress();
+  system_matrix.reinit(sparsity_pattern);
+
+  const QGauss<dim> quadrature_formula(fe_q.get_degree() + 1);
+  FEValues<dim>     fe_values(mapping,
+                          fe_q,
+                          quadrature_formula,
+                          update_values | update_gradients |
+                            update_quadrature_points | update_JxW_values);
+
+  const unsigned int dofs_per_cell = fe_q.n_dofs_per_cell();
+  const unsigned int n_q_points    = quadrature_formula.size();
+
+  FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+  Vector<double>     cell_rhs(dofs_per_cell);
+
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+  for (const auto &cell : original_dof_handler.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        fe_values.reinit(cell);
+
+        cell_matrix = 0.;
+        cell_rhs    = 0.;
+        std::vector<double> rhs_values(n_q_points);
+        rhs_function->value_list(fe_values.get_quadrature_points(), rhs_values);
+
+        for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+          {
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              {
+                for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                  cell_matrix(i, j) += fe_values.shape_grad(i, q_point) *
+                                       fe_values.shape_grad(j, q_point) *
+                                       fe_values.JxW(q_point);
+
+                cell_rhs(i) += rhs_values[q_point] *
+                               fe_values.shape_value(i, q_point) *
+                               fe_values.JxW(q_point);
+              }
+          }
+
+        cell->get_dof_indices(local_dof_indices);
+        constraints.distribute_local_to_global(
+          cell_matrix, cell_rhs, local_dof_indices, system_matrix, system_rhs);
+      }
+
+  system_matrix.compress(VectorOperation::add);
+  system_rhs.compress(VectorOperation::add);
+}
+
+template <int dim, unsigned int rtree_m_points, unsigned int rtree_m_cells>
+void
+Poisson<dim, rtree_m_points, rtree_m_cells>::solve_with_point_agglo_amg()
+{
+  if (my_rank == 0)
+    {
+      std::cout << "Running R-tree based AMG with point agglomeration"
+                << std::endl;
+      std::cout << "R-tree m (points) = " << rtree_m_points << std::endl;
+      std::cout << "R-tree M (points) = " << rtree_M_points << std::endl;
+    }
+
+  const IndexSet locally_owned_dofs = original_dof_handler.locally_owned_dofs();
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(original_dof_handler);
+
+  std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
+  std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
+  std::vector<unsigned int> coarse_space_degrees(mg_levels - 1,
+                                                 parameters.coarse_fe_degree);
+
+  std::vector<
+    std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
+                                                triangulations(mg_levels - 1);
+  std::vector<std::unique_ptr<DoFHandler<dim>>> support_dof_handlers(mg_levels -
+                                                                     1);
+
+  ContinuousAggloUtils::PointsAgglo::
+    parallel_agglomerate_and_compute_injection_matrices<dim,
+                                                        rtree_m_points,
+                                                        rtree_M_points>(
+      original_dof_handler,
+      mapping,
+      true,
+      injection_matrices,
+      injection_sparsity_patterns,
+      mg_levels,
+      coarse_space_degrees,
+      triangulations,
+      support_dof_handlers);
+
+  AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
+    injection_matrices);
+
+  MGLevelObject<std::unique_ptr<TrilinosWrappers::SparseMatrix>>
+    multigrid_matrices(0, mg_levels - 1);
+
+  multigrid_matrices[multigrid_matrices.max_level()] =
+    std::make_unique<TrilinosWrappers::SparseMatrix>();
+  multigrid_matrices[multigrid_matrices.max_level()]->reinit(system_matrix);
+  multigrid_matrices[multigrid_matrices.max_level()]->copy_from(system_matrix);
+
+  amg_projector.compute_level_matrices(multigrid_matrices);
+
+  // Set up multigrid solver
+  using LevelMatrixType = TrilinosWrappers::SparseMatrix;
+  using VectorType      = LinearAlgebra::distributed::Vector<double>;
+  mg::Matrix<VectorType> mg_matrix(multigrid_matrices);
+
+  using SmootherType = PreconditionChebyshev<LevelMatrixType, VectorType>;
+  mg::SmootherRelaxation<SmootherType, VectorType>     mg_smoother;
+  MGLevelObject<typename SmootherType::AdditionalData> smoother_data;
+  smoother_data.resize(0, mg_levels - 1);
+
+  VectorType diag_inverse(system_matrix.locally_owned_range_indices(), comm);
+  for (unsigned int row = system_matrix.local_range().first;
+       row < system_matrix.local_range().second;
+       ++row)
+    diag_inverse[row] = 1. / system_matrix.diag_element(row);
+  diag_inverse.compress(VectorOperation::insert);
+
+  std::vector<VectorType> diag_inverses(mg_levels);
+  diag_inverses[mg_levels - 1] = diag_inverse;
+
+  smoother_data[mg_levels - 1].preconditioner =
+    std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[mg_levels - 1]);
+
+  for (unsigned int level = 0; level < mg_levels - 1; ++level)
+    {
+      smoother_data[level].smoothing_range = 8;
+      diag_inverses[level].reinit(
+        multigrid_matrices[level]->locally_owned_range_indices(), comm);
+      for (unsigned int row = multigrid_matrices[level]->local_range().first;
+           row < multigrid_matrices[level]->local_range().second;
+           ++row)
+        diag_inverses[level][row] =
+          1. / multigrid_matrices[level]->diag_element(row);
+      diag_inverses[level].compress(VectorOperation::insert);
+
+      smoother_data[level].preconditioner =
+        std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[level]);
+    }
+
+  for (unsigned int level = 0; level < mg_levels; ++level)
+    {
+      if (level > 0)
+        {
+          smoother_data[level].smoothing_range     = 20.;
+          smoother_data[level].degree              = 3;
+          smoother_data[level].eig_cg_n_iterations = 20;
+        }
+      else
+        {
+          smoother_data[0].smoothing_range     = 1e-3;
+          smoother_data[0].degree              = 3;
+          smoother_data[0].eig_cg_n_iterations = 20;
+        }
+    }
+
+  mg_smoother.set_steps(parameters.smoother_steps);
+  mg_smoother.initialize(multigrid_matrices, smoother_data);
+
+  const unsigned int min_level = 0;
+
+  // Utils::MGCoarseDirect<VectorType,
+  //                       TrilinosWrappers::SparseMatrix,
+  //                       TrilinosWrappers::SolverDirect>
+  //   mg_coarse(*multigrid_matrices[0]);
+
+  Utils::MGCoarseDirectMUMPS<TrilinosWrappers::SparseMatrix,
+                             VectorType,
+                             SparseDirectMUMPS>
+    mg_coarse;
+  mg_coarse.initialize(*multigrid_matrices[min_level]);
+
+  MGLevelObject<TrilinosWrappers::SparseMatrix *> mg_level_transfers(0,
+                                                                     mg_levels -
+                                                                       1);
+  for (unsigned int l = 0; l < mg_levels - 1; ++l)
+    mg_level_transfers[l] = &injection_matrices[l];
+
+  std::vector<DoFHandler<dim> *> dof_handlers(support_dof_handlers.size() + 1);
+  for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+    dof_handlers[i] = support_dof_handlers[i].get();
+  dof_handlers[support_dof_handlers.size()] = &original_dof_handler;
+
+  MGTransferAgglomeration<dim, VectorType> mg_transfer(mg_level_transfers,
+                                                       dof_handlers);
+
+  Multigrid<VectorType> mg(mg_matrix,
+                           mg_coarse,
+                           mg_transfer,
+                           mg_smoother,
+                           mg_smoother,
+                           0,
+                           numbers::invalid_unsigned_int,
+                           Multigrid<VectorType>::v_cycle);
+
+  PreconditionMG<dim, VectorType, MGTransferAgglomeration<dim, VectorType>>
+    preconditioner(original_dof_handler, mg, mg_transfer);
+
+  VectorType dist_solution(locally_owned_dofs, comm);
+  dist_solution = 0.0;
+  SolverCG<VectorType> cg(solver_control);
+
+  cg.connect_condition_number_slot([this](double input) {
+    if (my_rank == 0)
+      std::cout << "Condition number estimate: " << std::setprecision(6)
+                << input << std::endl;
+  });
+
+  if (my_rank == 0)
+    std::cout
+      << "-----------PCG with point agglomeration AMG preconditioner start-----------"
+      << std::endl;
+
+  cg.solve(system_matrix, dist_solution, system_rhs, preconditioner);
+
+  if (my_rank == 0)
+    std::cout << "Point agglo CG converged in " << solver_control.last_step()
+              << " steps, final residual = " << solver_control.last_value()
+              << std::endl;
+
+  constraints.distribute(dist_solution);
+  locally_relevant_solution = dist_solution;
+  locally_relevant_solution.update_ghost_values();
+
+  Vector<double> error_per_cell(distributed_tria.n_active_cells());
+  VectorTools::integrate_difference(mapping,
+                                    original_dof_handler,
+                                    locally_relevant_solution,
+                                    *analytical_solution,
+                                    error_per_cell,
+                                    QGauss<dim>(fe_q.get_degree() + 2),
+                                    VectorTools::L2_norm);
+
+  double l2_error =
+    std::sqrt(Utilities::MPI::sum(error_per_cell.norm_sqr(), comm));
+  if (my_rank == 0)
+    std::cout << "Solution L2 error against analytical solution: " << l2_error
+              << std::endl;
+}
+
+template <int dim, unsigned int rtree_m_points, unsigned int rtree_m_cells>
+void
+Poisson<dim, rtree_m_points, rtree_m_cells>::solve_with_cell_agglo_amg()
+{
+  if (my_rank == 0)
+    {
+      std::cout << "Running R-tree based AMG with cell agglomeration"
+                << std::endl;
+      std::cout << "R-tree m (cells) = " << rtree_m_cells << std::endl;
+      std::cout << "R-tree M (cells) = " << rtree_M_cells << std::endl;
+    }
+
+  const IndexSet locally_owned_dofs = original_dof_handler.locally_owned_dofs();
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(original_dof_handler);
+
+  std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
+  std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
+  std::vector<unsigned int> coarse_space_degrees(mg_levels - 1,
+                                                 parameters.coarse_fe_degree);
+
+  std::vector<
+    std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
+                                                triangulations(mg_levels - 1);
+  std::vector<std::unique_ptr<DoFHandler<dim>>> support_dof_handlers(mg_levels -
+                                                                     1);
+
+  ContinuousAggloUtils::CellsAgglo::
+    parallel_agglomerate_and_compute_injection_matrices<dim,
+                                                        rtree_m_cells,
+                                                        rtree_M_cells>(
+      original_dof_handler,
+      mapping,
+      true,
+      injection_matrices,
+      injection_sparsity_patterns,
+      mg_levels,
+      coarse_space_degrees,
+      triangulations,
+      support_dof_handlers);
+
+  AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
+    injection_matrices);
+
+  MGLevelObject<std::unique_ptr<TrilinosWrappers::SparseMatrix>>
+    multigrid_matrices(0, mg_levels - 1);
+
+  multigrid_matrices[multigrid_matrices.max_level()] =
+    std::make_unique<TrilinosWrappers::SparseMatrix>();
+  multigrid_matrices[multigrid_matrices.max_level()]->reinit(system_matrix);
+  multigrid_matrices[multigrid_matrices.max_level()]->copy_from(system_matrix);
+
+  amg_projector.compute_level_matrices(multigrid_matrices);
+
+  // Set up multigrid solver
+  using LevelMatrixType = TrilinosWrappers::SparseMatrix;
+  using VectorType      = LinearAlgebra::distributed::Vector<double>;
+  mg::Matrix<VectorType> mg_matrix(multigrid_matrices);
+
+  using SmootherType = PreconditionChebyshev<LevelMatrixType, VectorType>;
+  mg::SmootherRelaxation<SmootherType, VectorType>     mg_smoother;
+  MGLevelObject<typename SmootherType::AdditionalData> smoother_data;
+  smoother_data.resize(0, mg_levels - 1);
+
+  VectorType diag_inverse(system_matrix.locally_owned_range_indices(), comm);
+  for (unsigned int row = system_matrix.local_range().first;
+       row < system_matrix.local_range().second;
+       ++row)
+    diag_inverse[row] = 1. / system_matrix.diag_element(row);
+  diag_inverse.compress(VectorOperation::insert);
+
+  std::vector<VectorType> diag_inverses(mg_levels);
+  diag_inverses[mg_levels - 1] = diag_inverse;
+
+  smoother_data[mg_levels - 1].preconditioner =
+    std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[mg_levels - 1]);
+
+  for (unsigned int level = 0; level < mg_levels - 1; ++level)
+    {
+      smoother_data[level].smoothing_range = 8;
+      diag_inverses[level].reinit(
+        multigrid_matrices[level]->locally_owned_range_indices(), comm);
+      for (unsigned int row = multigrid_matrices[level]->local_range().first;
+           row < multigrid_matrices[level]->local_range().second;
+           ++row)
+        diag_inverses[level][row] =
+          1. / multigrid_matrices[level]->diag_element(row);
+      diag_inverses[level].compress(VectorOperation::insert);
+
+      smoother_data[level].preconditioner =
+        std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[level]);
+    }
+
+  for (unsigned int level = 0; level < mg_levels; ++level)
+    {
+      if (level > 0)
+        {
+          smoother_data[level].smoothing_range     = 20.;
+          smoother_data[level].degree              = 3;
+          smoother_data[level].eig_cg_n_iterations = 20;
+        }
+      else
+        {
+          smoother_data[0].smoothing_range     = 1e-3;
+          smoother_data[0].degree              = 3;
+          smoother_data[0].eig_cg_n_iterations = 20;
+        }
+    }
+
+  mg_smoother.set_steps(parameters.smoother_steps);
+  mg_smoother.initialize(multigrid_matrices, smoother_data);
+
+  const unsigned int min_level = 0;
+
+  // Utils::MGCoarseDirect<VectorType,
+  //                       TrilinosWrappers::SparseMatrix,
+  //                       TrilinosWrappers::SolverDirect>
+  //   mg_coarse(*multigrid_matrices[0]);
+
+  Utils::MGCoarseDirectMUMPS<TrilinosWrappers::SparseMatrix,
+                             VectorType,
+                             SparseDirectMUMPS>
+    mg_coarse;
+  mg_coarse.initialize(*multigrid_matrices[min_level]);
+
+  MGLevelObject<TrilinosWrappers::SparseMatrix *> mg_level_transfers(0,
+                                                                     mg_levels -
+                                                                       1);
+  for (unsigned int l = 0; l < mg_levels - 1; ++l)
+    mg_level_transfers[l] = &injection_matrices[l];
+
+  std::vector<DoFHandler<dim> *> dof_handlers(support_dof_handlers.size() + 1);
+  for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+    dof_handlers[i] = support_dof_handlers[i].get();
+  dof_handlers[support_dof_handlers.size()] = &original_dof_handler;
+
+  MGTransferAgglomeration<dim, VectorType> mg_transfer(mg_level_transfers,
+                                                       dof_handlers);
+
+  Multigrid<VectorType> mg(mg_matrix,
+                           mg_coarse,
+                           mg_transfer,
+                           mg_smoother,
+                           mg_smoother,
+                           0,
+                           numbers::invalid_unsigned_int,
+                           Multigrid<VectorType>::v_cycle);
+
+  PreconditionMG<dim, VectorType, MGTransferAgglomeration<dim, VectorType>>
+    preconditioner(original_dof_handler, mg, mg_transfer);
+
+  VectorType dist_solution(locally_owned_dofs, comm);
+  dist_solution = 0.0;
+  SolverCG<VectorType> cg(solver_control);
+
+  cg.connect_condition_number_slot([this](double input) {
+    if (my_rank == 0)
+      std::cout << "Condition number estimate: " << std::setprecision(6)
+                << input << std::endl;
+  });
+
+  if (my_rank == 0)
+    std::cout
+      << "-----------PCG with cells agglomeration AMG preconditioner start-----------"
+      << std::endl;
+
+  cg.solve(system_matrix, dist_solution, system_rhs, preconditioner);
+
+  if (my_rank == 0)
+    std::cout << "Point agglo CG converged in " << solver_control.last_step()
+              << " steps, final residual = " << solver_control.last_value()
+              << std::endl;
+
+  constraints.distribute(dist_solution);
+  locally_relevant_solution = dist_solution;
+  locally_relevant_solution.update_ghost_values();
+
+  Vector<double> error_per_cell(distributed_tria.n_active_cells());
+  VectorTools::integrate_difference(mapping,
+                                    original_dof_handler,
+                                    locally_relevant_solution,
+                                    *analytical_solution,
+                                    error_per_cell,
+                                    QGauss<dim>(fe_q.get_degree() + 2),
+                                    VectorTools::L2_norm);
+
+  double l2_error =
+    std::sqrt(Utilities::MPI::sum(error_per_cell.norm_sqr(), comm));
+  if (my_rank == 0)
+    std::cout << "Solution L2 error against analytical solution: " << l2_error
+              << std::endl;
+}
+
+template <int dim, unsigned int rtree_m_points, unsigned int rtree_m_cells>
+void
+Poisson<dim, rtree_m_points, rtree_m_cells>::solve_with_trilinos_amg()
+{
+  using VectorType = LinearAlgebra::distributed::Vector<double>;
+
+  const IndexSet locally_owned_dofs = original_dof_handler.locally_owned_dofs();
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(original_dof_handler);
+
+  TrilinosWrappers::PreconditionAMG                 prec_amg;
+  TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
+
+  amg_data.aggregation_threshold = 1e-2; // AMG aggregation threshold
+  amg_data.smoother_type         = "Chebyshev";
+  amg_data.smoother_sweeps       = parameters.smoother_steps;
+  amg_data.output_details        = false;
+
+  if (fe_q.get_degree() > 1)
+    amg_data.higher_order_elements = true;
+
+  prec_amg.initialize(system_matrix, amg_data);
+
+  VectorType dist_solution(locally_owned_dofs, comm);
+  dist_solution = 0.0;
+  SolverCG<VectorType> cg(solver_control);
+
+  if (my_rank == 0)
+    std::cout
+      << "-----------PCG with Trilinos AMG preconditioner start-----------"
+      << std::endl;
+
+  cg.solve(system_matrix, dist_solution, system_rhs, prec_amg);
+
+  if (my_rank == 0)
+    std::cout << "Trilinos AMG CG converged in " << solver_control.last_step()
+              << " steps, final residual = " << solver_control.last_value()
+              << std::endl;
+
+  constraints.distribute(dist_solution);
+  locally_relevant_solution = dist_solution;
+  locally_relevant_solution.update_ghost_values();
+
+  Vector<double> error_per_cell(distributed_tria.n_active_cells());
+  VectorTools::integrate_difference(mapping,
+                                    original_dof_handler,
+                                    locally_relevant_solution,
+                                    *analytical_solution,
+                                    error_per_cell,
+                                    QGauss<dim>(fe_q.get_degree() + 2),
+                                    VectorTools::L2_norm);
+
+  double l2_error =
+    std::sqrt(Utilities::MPI::sum(error_per_cell.norm_sqr(), comm));
+  if (my_rank == 0)
+    std::cout << "Solution L2 error against analytical solution: " << l2_error
+              << std::endl;
+}
+
+template <int dim, unsigned int rtree_m_points, unsigned int rtree_m_cells>
+void
+Poisson<dim, rtree_m_points, rtree_m_cells>::run()
+{
+  if (my_rank == 0)
+    {
+      std::cout << "Running with " << n_mpi_processes << " MPI processes"
+                << std::endl;
+      std::cout << "Dimension: " << dim << std::endl;
+      std::cout << "Grid type: " << grid_type << std::endl;
+      std::cout << "Partitioner type: " << partitioner_type << std::endl;
+      std::cout << "FE degree: " << parameters.fe_degree << std::endl;
+      std::cout << "Coarse FE degree: " << parameters.coarse_fe_degree
+                << std::endl;
+      std::cout << "Number of MG levels: " << mg_levels << std::endl;
+      std::cout << "Smoother steps: " << parameters.smoother_steps << std::endl;
+      std::cout << "Keep ratio constant: "
+                << (parameters.keep_ratio_constant ? "true" : "false")
+                << std::endl;
+      std::cout << "Number of refinements: " << parameters.n_refinements
+                << std::endl;
+      std::cout << std::string(80, '=') << std::endl;
+    }
+  make_grid();
+  assemble_system();
+
+  if (my_rank == 0)
+    std::cout << std::string(80, '=') << std::endl;
+
+  if (parameters.do_points_agglo)
+    solve_with_point_agglo_amg();
+
+  if (my_rank == 0)
+    std::cout << std::string(80, '=') << std::endl;
+
+  if (parameters.do_cells_agglo)
+    solve_with_cell_agglo_amg();
+
+  if (my_rank == 0)
+    std::cout << std::string(80, '=') << std::endl;
+
+  if (parameters.do_trilinos_amg)
+    solve_with_trilinos_amg();
+}
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  deallog.depth_console(0);
+
+  if (dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    dealii::deallog.depth_console(10);
+
+  static constexpr unsigned int dim = 3;
+  ProblemParameters<dim>        parameters;
+  std::string                   parameter_file;
+  static constexpr unsigned int rtree_m_points = 4;
+  static constexpr unsigned int rtree_m_cells  = 4;
+
+  if (argc > 1)
+    parameter_file = argv[1];
+  else
+    parameter_file = "continuous_agglo_amg_parameters.prm";
+  ParameterAcceptor::initialize(parameter_file, "used_parameters.prm");
+
+  for (unsigned int cycle = 0; cycle < parameters.n_ref_cycles; ++cycle)
+    {
+      Poisson<dim, rtree_m_points, rtree_m_cells> poisson_problem{parameters};
+      poisson_problem.run();
+      parameters.n_refinements++;
+      if (!parameters.keep_ratio_constant)
+        parameters.mg_levels++;
+    }
+
+  std::cout << std::endl;
+  return 0;
+}

--- a/examples/continuous_agglo_amg_parameters.prm
+++ b/examples/continuous_agglo_amg_parameters.prm
@@ -9,13 +9,13 @@ subsection R-tree based MG
 
   subsection Grid generation
     # Type of grid to use. Options are 'grid_generator' and 'unstructured'.
-    set Grid type             = unstructured
+    set Grid type             = grid_generator
 
     # Number of global refinements to perform on the initial mesh.
-    set Number of initial refinements = 0
+    set Number of initial refinements = 5
     set Number of refinements cycles = 1
     set Use piston mesh       = false
-    set Use real lv mesh      = true
+    set Use real lv mesh      = false
   end
 
   subsection R3MG
@@ -26,6 +26,7 @@ subsection R-tree based MG
     set Do point agglomeration = true
     set Do cell agglomeration = true
     set Do Trilinos AMG = true
+    set Skip leaves level = true
   end
 
   subsection Reduction control

--- a/examples/continuous_agglo_amg_parameters.prm
+++ b/examples/continuous_agglo_amg_parameters.prm
@@ -1,0 +1,39 @@
+# Listing of Parameters
+# ---------------------
+subsection R-tree based MG
+  set Finite element degree = 1
+  set Output directory      = .
+  set Solution type         = product_sine
+  set Coarse Finite element degree = 1 
+
+
+  subsection Grid generation
+    # Type of grid to use. Options are 'grid_generator' and 'unstructured'.
+    set Grid type             = unstructured
+
+    # Number of global refinements to perform on the initial mesh.
+    set Number of initial refinements = 0
+    set Number of refinements cycles = 1
+    set Use piston mesh       = false
+    set Use real lv mesh      = true
+  end
+
+  subsection R3MG
+    set MG Levels = 4
+    set Partitioner type  = rtree
+    set Smoother steps    = 2
+    set Keep ratio constant = true
+    set Do point agglomeration = true
+    set Do cell agglomeration = true
+    set Do Trilinos AMG = true
+  end
+
+  subsection Reduction control
+    set Log history   = true
+    set Log result    = true
+    set Max steps     = 100
+    set Tolerance     = 1.e-9
+    set Reduction     = 1.e-6
+  end
+
+end

--- a/include/agglomerator.h
+++ b/include/agglomerator.h
@@ -34,7 +34,8 @@ namespace dealii
               typename Options,
               typename Translator,
               typename Box,
-              typename Allocators>
+              typename Allocators,
+              bool use_points = false>
     struct Rtree_visitor
       : public boost::geometry::index::detail::rtree::visitor<
           Value,
@@ -47,8 +48,11 @@ namespace dealii
       inline Rtree_visitor(
         const Translator  &translator,
         const unsigned int target_level,
-        std::vector<std::vector<typename Triangulation<
-          boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+        std::conditional_t<
+          use_points,
+          std::vector<std::vector<types::global_dof_index>>,
+          std::vector<std::vector<typename Triangulation<
+            boost::geometry::dimension<Box>::value>::active_cell_iterator>>>
                                                         &agglomerates_,
         std::vector<types::global_cell_index>           &n_nodes_per_level,
         std::map<std::pair<types::global_cell_index, types::global_cell_index>,
@@ -117,8 +121,11 @@ namespace dealii
        * vector v has the following property: v[i] = vector with all the mesh
        * iterators composing the i-th agglomerate.
        */
-      std::vector<std::vector<typename Triangulation<
-        boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+      std::conditional_t<
+        use_points,
+        std::vector<std::vector<types::global_dof_index>>,
+        std::vector<std::vector<typename Triangulation<
+          boost::geometry::dimension<Box>::value>::active_cell_iterator>>>
         &agglomerates;
 
       /**
@@ -141,16 +148,21 @@ namespace dealii
               typename Options,
               typename Translator,
               typename Box,
-              typename Allocators>
-    Rtree_visitor<Value, Options, Translator, Box, Allocators>::Rtree_visitor(
-      const Translator  &translator,
-      const unsigned int target_level,
-      std::vector<std::vector<typename Triangulation<
-        boost::geometry::dimension<Box>::value>::active_cell_iterator>>
-                                                      &agglomerates_,
-      std::vector<types::global_cell_index>           &n_nodes_per_level_,
-      std::map<std::pair<types::global_cell_index, types::global_cell_index>,
-               std::vector<types::global_cell_index>> &parent_to_children)
+              typename Allocators,
+              bool use_points>
+    Rtree_visitor<Value, Options, Translator, Box, Allocators, use_points>::
+      Rtree_visitor(
+        const Translator  &translator,
+        const unsigned int target_level,
+        std::conditional_t<
+          use_points,
+          std::vector<std::vector<types::global_dof_index>>,
+          std::vector<std::vector<typename Triangulation<
+            boost::geometry::dimension<Box>::value>::active_cell_iterator>>>
+                                                        &agglomerates_,
+        std::vector<types::global_cell_index>           &n_nodes_per_level_,
+        std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+                 std::vector<types::global_cell_index>> &parent_to_children)
       : translator(translator)
       , level(0)
       , node_counter(0)
@@ -166,10 +178,11 @@ namespace dealii
               typename Options,
               typename Translator,
               typename Box,
-              typename Allocators>
+              typename Allocators,
+              bool use_points>
     void
-    Rtree_visitor<Value, Options, Translator, Box, Allocators>::operator()(
-      const Rtree_visitor::InternalNode &node)
+    Rtree_visitor<Value, Options, Translator, Box, Allocators, use_points>::
+    operator()(const Rtree_visitor::InternalNode &node)
     {
       using elements_type =
         typename boost::geometry::index::detail::rtree::elements_type<
@@ -247,10 +260,11 @@ namespace dealii
               typename Options,
               typename Translator,
               typename Box,
-              typename Allocators>
+              typename Allocators,
+              bool use_points>
     void
-    Rtree_visitor<Value, Options, Translator, Box, Allocators>::operator()(
-      const Rtree_visitor::Leaf &leaf)
+    Rtree_visitor<Value, Options, Translator, Box, Allocators, use_points>::
+    operator()(const Rtree_visitor::Leaf &leaf)
     {
       using elements_type =
         typename boost::geometry::index::detail::rtree::elements_type<
@@ -264,17 +278,24 @@ namespace dealii
           // last one where leafs are grouped together.
           const auto offset = agglomerates.size();
           agglomerates.resize(offset + 1);
-
-          for (const auto &it : elements)
-            agglomerates[node_counter].push_back(it.second);
+          if constexpr (use_points)
+            for (const auto &it : elements)
+              agglomerates[node_counter].push_back(it);
+          else
+            for (const auto &it : elements)
+              agglomerates[node_counter].push_back(it.second);
 
           ++node_counter;
           n_nodes_per_level[target_level]++;
         }
       else
         {
-          for (const auto &it : elements)
-            agglomerates[node_counter].push_back(it.second);
+          if constexpr (use_points)
+            for (const auto &it : elements)
+              agglomerates[node_counter].push_back(it);
+          else
+            for (const auto &it : elements)
+              agglomerates[node_counter].push_back(it.second);
 
 
           if (level == target_level + 1)
@@ -296,7 +317,7 @@ namespace dealii
    * Helper class which handles agglomeration based on the R-tree data
    * structure. Notice that the R-tree type is assumed to be an R-star-tree.
    */
-  template <int dim, typename RtreeType>
+  template <int dim, typename RtreeType, bool use_points = false>
   class CellsAgglomerator
   {
   public:
@@ -314,8 +335,11 @@ namespace dealii
      * Extract agglomerates based on the current tree and the extraction level.
      * This function returns a reference to
      */
-    const std::vector<
-      std::vector<typename Triangulation<dim>::active_cell_iterator>> &
+    const std::conditional_t<
+      use_points,
+      std::vector<std::vector<types::global_dof_index>>,
+      std::vector<
+        std::vector<typename Triangulation<dim>::active_cell_iterator>>> &
     extract_agglomerates();
 
     /**
@@ -354,7 +378,10 @@ namespace dealii
      * Store agglomerates obtained after recursive extraction on nodes of
      * level @p extraction_level.
      */
-    std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+    std::conditional_t<use_points,
+                       std::vector<std::vector<types::global_dof_index>>,
+                       std::vector<std::vector<
+                         typename Triangulation<dim>::active_cell_iterator>>>
       agglomerates_on_level;
 
     /**
@@ -368,14 +395,14 @@ namespace dealii
      * which stores the index of children.
      */
     std::map<std::pair<types::global_cell_index, types::global_cell_index>,
-             std::vector<types::global_cell_index>>
+             std::vector<types::global_dof_index>>
       parent_node_to_children_nodes;
   };
 
 
 
-  template <int dim, typename RtreeType>
-  CellsAgglomerator<dim, RtreeType>::CellsAgglomerator(
+  template <int dim, typename RtreeType, bool use_points>
+  CellsAgglomerator<dim, RtreeType, use_points>::CellsAgglomerator(
     const RtreeType   &tree,
     const unsigned int extraction_level_)
     : extraction_level(extraction_level_)
@@ -386,10 +413,13 @@ namespace dealii
 
 
 
-  template <int dim, typename RtreeType>
-  const std::vector<
-    std::vector<typename Triangulation<dim>::active_cell_iterator>> &
-  CellsAgglomerator<dim, RtreeType>::extract_agglomerates()
+  template <int dim, typename RtreeType, bool use_points>
+  const std::conditional_t<
+    use_points,
+    std::vector<std::vector<types::global_dof_index>>,
+    std::vector<
+      std::vector<typename Triangulation<dim>::active_cell_iterator>>> &
+  CellsAgglomerator<dim, RtreeType, use_points>::extract_agglomerates()
   {
     AssertThrow(extraction_level <= n_levels(*rtree),
                 ExcInternalError("You are trying to extract level " +
@@ -420,7 +450,8 @@ namespace dealii
                                 typename RtreeView::options_type,
                                 typename RtreeView::translator_type,
                                 typename RtreeView::box_type,
-                                typename RtreeView::allocators_type>
+                                typename RtreeView::allocators_type,
+                                use_points>
           extractor_visitor(rtv.translator(),
                             target_level,
                             agglomerates_on_level,
@@ -438,18 +469,18 @@ namespace dealii
   // ------------------------------ inline functions -------------------------
 
 
-  template <int dim, typename RtreeType>
+  template <int dim, typename RtreeType, bool use_points>
   inline unsigned int
-  CellsAgglomerator<dim, RtreeType>::get_n_levels() const
+  CellsAgglomerator<dim, RtreeType, use_points>::get_n_levels() const
   {
     return n_levels(*rtree);
   }
 
 
 
-  template <int dim, typename RtreeType>
+  template <int dim, typename RtreeType, bool use_points>
   inline types::global_cell_index
-  CellsAgglomerator<dim, RtreeType>::get_n_nodes_per_level(
+  CellsAgglomerator<dim, RtreeType, use_points>::get_n_nodes_per_level(
     const unsigned int level) const
   {
     return n_nodes_per_level[level];
@@ -457,11 +488,11 @@ namespace dealii
 
 
 
-  template <int dim, typename RtreeType>
+  template <int dim, typename RtreeType, bool use_points>
   inline const std::map<
     std::pair<types::global_cell_index, types::global_cell_index>,
-    std::vector<types::global_cell_index>> &
-  CellsAgglomerator<dim, RtreeType>::get_hierarchy() const
+    std::vector<types::global_dof_index>> &
+  CellsAgglomerator<dim, RtreeType, use_points>::get_hierarchy() const
   {
     Assert(parent_node_to_children_nodes.size(),
            ExcMessage(

--- a/include/continuous_agglo_utils.h
+++ b/include/continuous_agglo_utils.h
@@ -407,8 +407,6 @@ namespace dealii::ContinuousAggloUtils
                         " levels, but the hierarchy can only have " +
                         std::to_string(tree_lvls + 1) + " levels."));
 
-      injection_matrices.resize(mg_levels - 1);
-
       std::vector<std::vector<BoundingBox<dim>>> boxes_per_level(mg_levels - 1);
       std::vector<
         std::map<std::pair<types::global_cell_index, types::global_cell_index>,
@@ -443,6 +441,8 @@ namespace dealii::ContinuousAggloUtils
           j++;
         }
 
+      triangulations.clear();
+      support_dof_handlers.clear();
       triangulations.resize(mg_levels - 1);
       support_dof_handlers.resize(mg_levels - 1);
 
@@ -578,7 +578,8 @@ namespace dealii::ContinuousAggloUtils
     {
       namespace bgi = boost::geometry::index;
 
-      MPI_Comm comm = fine_dh.get_mpi_communicator();
+      MPI_Comm           comm    = fine_dh.get_mpi_communicator();
+      const unsigned int my_rank = Utilities::MPI::this_mpi_process(comm);
 
       Assert(mg_levels > 1,
              ExcMessage("At least two levels are needed for agglomeration."));
@@ -591,7 +592,6 @@ namespace dealii::ContinuousAggloUtils
 
       const unsigned int locally_owned_dofs_number =
         fine_dh.locally_owned_dofs().n_elements();
-      const unsigned int global_dofs_number = fine_dh.n_dofs();
 
       const IndexSet &locally_owned_dofs_set = fine_dh.locally_owned_dofs();
       std::vector<types::global_dof_index> local_dof_indices;
@@ -607,9 +607,192 @@ namespace dealii::ContinuousAggloUtils
 
       auto local_tree = pack_rtree_of_indices<bgi::rstar<rtree_M, rtree_m>>(
         local_support_points_vector);
+      // The indices used are tied to the indices of
+      // local_support_poinst_vector. To access the original DoFs, one needs to
+      // use local_dof_indices
 
-      // After setting up the tree we need to deal with the fact that local
-      // trees might have different heights
+      unsigned int local_tree_lvls = n_levels(local_tree);
+      if (skip_leaves)
+        local_tree_lvls = std::max<unsigned int>(local_tree_lvls - 1, 0);
+
+      Assert(local_tree_lvls > 1,
+             ExcMessage(
+               "The tree on rank " + std::to_string(my_rank) +
+               " should have at least two levels to perform agglomeration."));
+
+      Assert(mg_levels <= local_tree_lvls + 1,
+             ExcMessage("You are trying to use " + std::to_string(mg_levels) +
+                        " levels, but the hierarchy on rank " +
+                        std::to_string(my_rank) + " can only have " +
+                        std::to_string(local_tree_lvls + 1) + " levels."));
+
+      // To deal with trees of different heights: we simply take the levels from
+      // the finest level and the bound is given by the shortest tree
+      // We could probably allow up to the highest local tree by padding with
+      // identity but for now this is fine
+
+      std::vector<std::vector<BoundingBox<dim>>> local_boxes_per_level(
+        mg_levels - 1);
+      std::vector<
+        std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+                 std::vector<types::global_cell_index>>>
+        local_hierarchies_per_level(mg_levels - 2);
+
+      unsigned int j = 0;
+      for (unsigned int i = local_tree_lvls - mg_levels + 1;
+           i < local_tree_lvls;
+           ++i)
+        {
+          CellsAgglomerator<dim, decltype(local_tree), true> agglomerator{
+            local_tree, i + 1};
+          const std::vector<std::vector<types::global_dof_index>> agglomerates =
+            agglomerator.extract_agglomerates();
+          local_boxes_per_level[j].reserve(agglomerates.size());
+
+          // Store hierarchy for reuse later (not needed for last level)
+          if (j < mg_levels - 2)
+            local_hierarchies_per_level[j] = agglomerator.get_hierarchy();
+
+          for (const std::vector<types::global_dof_index> &agglo : agglomerates)
+            {
+              std::vector<Point<dim>> points_in_current_agglomerate;
+              points_in_current_agglomerate.reserve(agglo.size());
+
+              for (const auto &index : agglo)
+                points_in_current_agglomerate.push_back(
+                  local_support_points_vector[index]);
+
+              BoundingBox<dim> bbox{points_in_current_agglomerate};
+              local_boxes_per_level[j].emplace_back(
+                points_in_current_agglomerate);
+            }
+          j++;
+        }
+
+      triangulations.clear();
+      support_dof_handlers.clear();
+      triangulations.resize(mg_levels - 1);
+      support_dof_handlers.resize(mg_levels - 1);
+
+      for (unsigned int i = 0; i < mg_levels - 1; ++i)
+        {
+          triangulations[i] = std::make_unique<
+            parallel::fullydistributed::Triangulation<dim, dim>>(comm);
+          create_distributed_tria_from_local_boxes(*triangulations[i],
+                                                   local_boxes_per_level[i],
+                                                   comm);
+          support_dof_handlers[i] =
+            std::make_unique<DoFHandler<dim>>(*triangulations[i]);
+
+          FE_DGQ<dim> fe_dgq(coarse_space_degrees[i]);
+          support_dof_handlers[i]->distribute_dofs(fe_dgq);
+        }
+
+      injection_matrices.clear();
+      injection_sparsity_patterns.clear();
+      injection_matrices.resize(mg_levels - 1);
+      injection_sparsity_patterns.resize(mg_levels - 1);
+
+      for (unsigned int j = 0; j < mg_levels - 2; ++j)
+        fill_injection_matrix(*support_dof_handlers[j],
+                              *support_dof_handlers[j + 1],
+                              injection_sparsity_patterns[j],
+                              injection_matrices[j],
+                              local_hierarchies_per_level[j],
+                              local_boxes_per_level[j],
+                              local_boxes_per_level[j + 1],
+                              local_tree_lvls - mg_levels + 1 + j);
+
+      // We now have to fill the last injection matrix
+      {
+        CellsAgglomerator<dim, decltype(local_tree), true> agglomerator{
+          local_tree, local_tree_lvls};
+
+        const std::vector<std::vector<types::global_dof_index>> agglomerates =
+          agglomerator.extract_agglomerates();
+
+        FE_DGQ<dim> fe_dgq(coarse_space_degrees[mg_levels - 2]);
+
+        std::vector<types::global_dof_index> dof_indices_agglo_tria(
+          fe_dgq.n_dofs_per_cell());
+
+        const IndexSet &locally_owned_dofs_coarse =
+          support_dof_handlers[mg_levels - 2]->locally_owned_dofs();
+        const IndexSet &locally_owned_dofs_fine = fine_dh.locally_owned_dofs();
+
+        injection_sparsity_patterns[mg_levels - 2].reinit(
+          locally_owned_dofs_fine, locally_owned_dofs_coarse, comm);
+
+        unsigned int agglo_index = 0;
+        for (const auto &cell :
+             support_dof_handlers[mg_levels - 2]->active_cell_iterators())
+          if (cell->is_locally_owned())
+            {
+              cell->get_dof_indices(dof_indices_agglo_tria);
+
+              // agglomerates return indices in the local tree, we need to map
+              // them back to the original DoF indices using local_dof_indices
+              for (const types::global_dof_index dof_idx :
+                   agglomerates[agglo_index])
+                injection_sparsity_patterns[mg_levels - 2].add_entries(
+                  local_dof_indices[dof_idx],
+                  dof_indices_agglo_tria.begin(),
+                  dof_indices_agglo_tria.end());
+
+              agglo_index++;
+            }
+
+        injection_sparsity_patterns[mg_levels - 2].compress();
+        injection_matrices[mg_levels - 2].reinit(
+          injection_sparsity_patterns[mg_levels - 2]);
+
+        AffineConstraints<double> dummy_constraints; // for loc2glob
+        agglo_index = 0;
+        for (const auto &cell :
+             support_dof_handlers[mg_levels - 2]->active_cell_iterators())
+          if (cell->is_locally_owned())
+            {
+              cell->get_dof_indices(dof_indices_agglo_tria);
+
+              const BoundingBox<dim> &coarse_box =
+                local_boxes_per_level[mg_levels - 2][agglo_index];
+
+              const unsigned int n_fine_support_points =
+                agglomerates[agglo_index].size();
+
+              const std::vector<types::global_dof_index> &fine_indices =
+                agglomerates[agglo_index];
+
+              FullMatrix<double> local_matrix(n_fine_support_points,
+                                              fe_dgq.n_dofs_per_cell());
+              local_matrix = 0.0;
+
+              for (unsigned int i = 0; i < n_fine_support_points; ++i)
+                {
+                  const Point<dim> p = coarse_box.real_to_unit(
+                    local_support_points_vector[fine_indices[i]]);
+
+                  for (unsigned int j = 0; j < dof_indices_agglo_tria.size();
+                       ++j)
+                    local_matrix(i, j) = fe_dgq.shape_value(j, p);
+                }
+
+              std::vector<types::global_dof_index> fine_indices_global(
+                n_fine_support_points);
+              for (unsigned int i = 0; i < n_fine_support_points; ++i)
+                fine_indices_global[i] = local_dof_indices[fine_indices[i]];
+
+              dummy_constraints.distribute_local_to_global(
+                local_matrix,
+                fine_indices_global,
+                dof_indices_agglo_tria,
+                injection_matrices[mg_levels - 2]);
+
+              ++agglo_index;
+            }
+
+        injection_matrices[mg_levels - 2].compress(VectorOperation::add);
+      }
     }
   } // namespace PointsAgglo
   namespace CellsAgglo

--- a/include/continuous_agglo_utils.h
+++ b/include/continuous_agglo_utils.h
@@ -1,0 +1,231 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef continuous_agglo_utils_h
+#define continuous_agglo_utils_h
+
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/index_set.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/grid/tria_description.h>
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/numerics/rtree.h>
+
+#include <agglomerator.h>
+
+
+namespace dealii::ContinuousAggloUtils
+{
+  // TODO: For now these are all sequential implementations, need to check what
+  // is different for the parallel implementation
+  namespace PointsAgglo
+  {
+    template <int dim>
+    void
+    create_triangulation_from_bounding_boxes(
+      Triangulation<dim>                  &dummy_tria,
+      const std::vector<BoundingBox<dim>> &boxes)
+    {
+      const unsigned int n_boxes          = boxes.size();
+      const unsigned int vertices_per_box = (dim == 2) ? 4 : 8;
+
+      // Pre-allocate space
+      std::vector<Point<dim>>    vertices;
+      std::vector<CellData<dim>> cells;
+      vertices.reserve(n_boxes * vertices_per_box);
+      cells.reserve(n_boxes);
+
+      for (const auto &box : boxes)
+        {
+          const Point<dim> &p_min = box.get_boundary_points().first;
+          const Point<dim> &p_max = box.get_boundary_points().second;
+
+          // Each box gets its own set of vertices (allows overlaps!)
+          const unsigned int vertex_offset = vertices.size();
+
+          if constexpr (dim == 2)
+            {
+              // 4 corners of the bounding box
+              vertices.push_back(Point<dim>(p_min[0], p_min[1])); // bottom-left
+              vertices.push_back(
+                Point<dim>(p_max[0], p_min[1])); // bottom-right
+              vertices.push_back(Point<dim>(p_min[0], p_max[1])); // top-left
+              vertices.push_back(Point<dim>(p_max[0], p_max[1])); // top-right
+
+              // Create a quadrilateral cell from these 4 vertices
+              CellData<dim> cell;
+              cell.vertices[0] = vertex_offset + 0; // bottom-left
+              cell.vertices[1] = vertex_offset + 1; // bottom-right
+              cell.vertices[2] = vertex_offset + 2; // top-left
+              cell.vertices[3] = vertex_offset + 3; // top-right
+              cells.push_back(cell);
+            }
+          else if constexpr (dim == 3)
+            {
+              // 8 corners of the 3D bounding box
+              vertices.push_back(Point<dim>(p_min[0], p_min[1], p_min[2]));
+              vertices.push_back(Point<dim>(p_max[0], p_min[1], p_min[2]));
+              vertices.push_back(Point<dim>(p_min[0], p_max[1], p_min[2]));
+              vertices.push_back(Point<dim>(p_max[0], p_max[1], p_min[2]));
+              vertices.push_back(Point<dim>(p_min[0], p_min[1], p_max[2]));
+              vertices.push_back(Point<dim>(p_max[0], p_min[1], p_max[2]));
+              vertices.push_back(Point<dim>(p_min[0], p_max[1], p_max[2]));
+              vertices.push_back(Point<dim>(p_max[0], p_max[1], p_max[2]));
+
+              // Create a hexahedral cell from these 8 vertices
+              CellData<dim> cell;
+              for (unsigned int v = 0; v < 8; ++v)
+                cell.vertices[v] = vertex_offset + v;
+              cells.push_back(cell);
+            }
+        }
+
+      // Create the triangulation
+      dummy_tria.create_triangulation(vertices, cells, SubCellData());
+    }
+
+
+
+    template <int dim>
+    void
+    create_distributed_tria_from_local_boxes(
+      parallel::fullydistributed::Triangulation<dim, dim> &distributed_tria,
+      const std::vector<BoundingBox<dim>>                 &local_boxes,
+      MPI_Comm                                             communicator)
+    {
+      unsigned int my_rank = Utilities::MPI::this_mpi_process(communicator);
+
+      Triangulation<dim> tria_local;
+      create_triangulation_from_bounding_boxes(tria_local, local_boxes);
+
+      // Mark all cells as owned by my rank
+      for (const auto &cell : tria_local.active_cell_iterators())
+        cell->set_subdomain_id(my_rank);
+
+      const TriangulationDescription::Description<dim, dim> description =
+        TriangulationDescription::Utilities::
+          create_description_from_triangulation(tria_local, communicator);
+
+      distributed_tria.create_triangulation(description);
+    }
+
+
+
+    template <int dim, typename MatrixType, typename SparsityPatternType>
+    void
+    fill_injection_matrix(
+      const DoFHandler<dim> &coarse_dof_handler,
+      const DoFHandler<dim> &fine_dof_handler,
+      SparsityPatternType   &sparsity_pattern,
+      MatrixType            &transfer_matrix,
+      const std::map<
+        std::pair<types::global_cell_index, types::global_cell_index>,
+        std::vector<types::global_cell_index>> &parent_to_child_info,
+      const std::vector<BoundingBox<dim>>      &coarse_level_boxes,
+      const std::vector<BoundingBox<dim>>      &fine_level_boxes,
+      const unsigned int                        coarse_level)
+    {}
+
+
+    // Note for me: we suppose that the support points are ordered in the same
+    // way as the DoFs numbering of the finest level, so that we can use the
+    // support points to construct the agglomeration hierarchy. This is not a
+    // strong assumption, since we can always reorder the support points to
+    // match the DoF ordering. Deal.II automatically does this.
+    template <int dim,
+              typename MatrixType,
+              typename VectorType,
+              unsigned int rtree_m,
+              unsigned int rtree_M>
+    void
+    agglomerate_and_compute_injection_matrices(
+      VectorType              &support_points_vector,
+      bool                     skip_leaves,
+      std::vector<MatrixType> &injection_matrices,
+      unsigned int             mg_levels)
+    {
+      namespace bgi = boost::geometry::index;
+
+      if constexpr (std::is_same_v<MatrixType, SparseMatrix<double>>)
+        {
+          auto tree = pack_rtree_of_indices<bgi::rstar<rtree_m, rtree_M>>(
+            support_points_vector);
+
+          unsigned int tree_lvls = n_levels(tree);
+          if (skip_leaves)
+            tree_lvls = std::max<unsigned int>(tree_lvls - 1, 0);
+
+          Assert(
+            tree_lvls > 1,
+            ExcMessage(
+              "The tree should have at least two levels to perform agglomeration."));
+
+          Assert(mg_levels <= tree_lvls + 1,
+                 ExcMessage("You are trying to use " +
+                            std::to_string(mg_levels) +
+                            " levels, but the hierarchy can only have " +
+                            std::to_string(tree_lvls + 1) + " levels."));
+
+          injection_matrices.resize(mg_levels - 1);
+
+          std::vector<std::vector<BoundingBox<dim>>> boxes_per_level(mg_levels -
+                                                                     1);
+          for (unsigned int i = tree_lvls - mg_levels + 1; i < tree_lvls; ++i)
+            {
+              unsigned int                                 j = 0;
+              CellsAgglomerator<dim, decltype(tree), true> agglomerator{tree,
+                                                                        i + 1};
+              const std::vector<std::vector<types::global_dof_index>>
+                agglomerates = agglomerator.extract_agglomerates();
+              boxes_per_level[j].reserve(agglomerates.size());
+
+              for (const std::vector<types::global_dof_index> &agglo :
+                   agglomerates)
+                {
+                  std::vector<Point<dim>> points_in_current_agglomerate;
+                  points_in_current_agglomerate.reserve(agglo.size());
+
+                  for (const auto &index : agglo)
+                    points_in_current_agglomerate.push_back(
+                      support_points_vector[index]);
+
+                  BoundingBox<dim> bbox{points_in_current_agglomerate};
+                  boxes_per_level[j].emplace_back(
+                    points_in_current_agglomerate);
+                }
+              j++;
+            }
+        }
+      else
+        {
+          Assert(false, ExcNotImplemented());
+        }
+    }
+
+  } // namespace PointsAgglo
+  namespace CellsAgglo
+  {}
+} // namespace dealii::ContinuousAggloUtils
+
+#endif

--- a/include/continuous_agglo_utils.h
+++ b/include/continuous_agglo_utils.h
@@ -47,166 +47,274 @@
 
 namespace dealii::ContinuousAggloUtils
 {
-  namespace PointsAgglo
+  template <int dim>
+  void
+  create_triangulation_from_bounding_boxes(
+    Triangulation<dim>                  &dummy_tria,
+    const std::vector<BoundingBox<dim>> &boxes)
   {
-    template <int dim>
-    void
-    create_triangulation_from_bounding_boxes(
-      Triangulation<dim>                  &dummy_tria,
-      const std::vector<BoundingBox<dim>> &boxes)
-    {
-      const unsigned int n_boxes          = boxes.size();
-      const unsigned int vertices_per_box = (dim == 2) ? 4 : 8;
+    const unsigned int n_boxes          = boxes.size();
+    const unsigned int vertices_per_box = (dim == 2) ? 4 : 8;
 
-      std::vector<Point<dim>>    vertices;
-      std::vector<CellData<dim>> cells;
-      vertices.reserve(n_boxes * vertices_per_box);
-      cells.reserve(n_boxes);
+    std::vector<Point<dim>>    vertices;
+    std::vector<CellData<dim>> cells;
+    vertices.reserve(n_boxes * vertices_per_box);
+    cells.reserve(n_boxes);
 
-      for (const auto &box : boxes)
-        {
-          const Point<dim> &p_min = box.get_boundary_points().first;
-          const Point<dim> &p_max = box.get_boundary_points().second;
+    for (const auto &box : boxes)
+      {
+        const Point<dim> &p_min = box.get_boundary_points().first;
+        const Point<dim> &p_max = box.get_boundary_points().second;
 
-          // Each box gets its own set of vertices (allows overlaps!)
-          const unsigned int vertex_offset = vertices.size();
+        // Each box gets its own set of vertices (allows overlaps!)
+        const unsigned int vertex_offset = vertices.size();
 
-          if constexpr (dim == 2)
-            {
-              // 4 corners of the bounding box
-              vertices.push_back(Point<dim>(p_min[0], p_min[1])); // bottom-left
-              vertices.push_back(
-                Point<dim>(p_max[0], p_min[1])); // bottom-right
-              vertices.push_back(Point<dim>(p_min[0], p_max[1])); // top-left
-              vertices.push_back(Point<dim>(p_max[0], p_max[1])); // top-right
+        if constexpr (dim == 2)
+          {
+            // 4 corners of the bounding box
+            vertices.push_back(Point<dim>(p_min[0], p_min[1])); // bottom-left
+            vertices.push_back(Point<dim>(p_max[0], p_min[1])); // bottom-right
+            vertices.push_back(Point<dim>(p_min[0], p_max[1])); // top-left
+            vertices.push_back(Point<dim>(p_max[0], p_max[1])); // top-right
 
-              // Create a quadrilateral cell from these 4 vertices
-              CellData<dim> cell;
-              cell.vertices[0] = vertex_offset + 0; // bottom-left
-              cell.vertices[1] = vertex_offset + 1; // bottom-right
-              cell.vertices[2] = vertex_offset + 2; // top-left
-              cell.vertices[3] = vertex_offset + 3; // top-right
-              cells.push_back(cell);
-            }
-          else if constexpr (dim == 3)
-            {
-              // 8 corners of the 3D bounding box
-              vertices.push_back(Point<dim>(p_min[0], p_min[1], p_min[2]));
-              vertices.push_back(Point<dim>(p_max[0], p_min[1], p_min[2]));
-              vertices.push_back(Point<dim>(p_min[0], p_max[1], p_min[2]));
-              vertices.push_back(Point<dim>(p_max[0], p_max[1], p_min[2]));
-              vertices.push_back(Point<dim>(p_min[0], p_min[1], p_max[2]));
-              vertices.push_back(Point<dim>(p_max[0], p_min[1], p_max[2]));
-              vertices.push_back(Point<dim>(p_min[0], p_max[1], p_max[2]));
-              vertices.push_back(Point<dim>(p_max[0], p_max[1], p_max[2]));
+            // Create a quadrilateral cell from these 4 vertices
+            CellData<dim> cell;
+            cell.vertices[0] = vertex_offset + 0; // bottom-left
+            cell.vertices[1] = vertex_offset + 1; // bottom-right
+            cell.vertices[2] = vertex_offset + 2; // top-left
+            cell.vertices[3] = vertex_offset + 3; // top-right
+            cells.push_back(cell);
+          }
+        else if constexpr (dim == 3)
+          {
+            // 8 corners of the 3D bounding box
+            vertices.push_back(Point<dim>(p_min[0], p_min[1], p_min[2]));
+            vertices.push_back(Point<dim>(p_max[0], p_min[1], p_min[2]));
+            vertices.push_back(Point<dim>(p_min[0], p_max[1], p_min[2]));
+            vertices.push_back(Point<dim>(p_max[0], p_max[1], p_min[2]));
+            vertices.push_back(Point<dim>(p_min[0], p_min[1], p_max[2]));
+            vertices.push_back(Point<dim>(p_max[0], p_min[1], p_max[2]));
+            vertices.push_back(Point<dim>(p_min[0], p_max[1], p_max[2]));
+            vertices.push_back(Point<dim>(p_max[0], p_max[1], p_max[2]));
 
-              // Create a hexahedral cell from these 8 vertices
-              CellData<dim> cell;
-              for (unsigned int v = 0; v < 8; ++v)
-                cell.vertices[v] = vertex_offset + v;
-              cells.push_back(cell);
-            }
-        }
+            // Create a hexahedral cell from these 8 vertices
+            CellData<dim> cell;
+            for (unsigned int v = 0; v < 8; ++v)
+              cell.vertices[v] = vertex_offset + v;
+            cells.push_back(cell);
+          }
+      }
 
-      // Create the triangulation
-      dummy_tria.create_triangulation(vertices, cells, SubCellData());
-    }
+    // Create the triangulation
+    dummy_tria.create_triangulation(vertices, cells, SubCellData());
+  }
 
 
 
-    template <int dim>
-    void
-    create_distributed_tria_from_local_boxes(
-      parallel::fullydistributed::Triangulation<dim, dim> &distributed_tria,
-      const std::vector<BoundingBox<dim>>                 &local_boxes,
-      MPI_Comm                                             communicator)
-    {
-      unsigned int my_rank = Utilities::MPI::this_mpi_process(communicator);
+  template <int dim>
+  void
+  create_distributed_tria_from_local_boxes(
+    parallel::fullydistributed::Triangulation<dim, dim> &distributed_tria,
+    const std::vector<BoundingBox<dim>>                 &local_boxes,
+    MPI_Comm                                             communicator)
+  {
+    unsigned int my_rank = Utilities::MPI::this_mpi_process(communicator);
 
-      Triangulation<dim> tria_local;
-      create_triangulation_from_bounding_boxes(tria_local, local_boxes);
+    Triangulation<dim> tria_local;
+    create_triangulation_from_bounding_boxes(tria_local, local_boxes);
 
-      // Mark all cells as owned by my rank
-      for (const auto &cell : tria_local.active_cell_iterators())
-        cell->set_subdomain_id(my_rank);
+    // Mark all cells as owned by my rank
+    for (const auto &cell : tria_local.active_cell_iterators())
+      cell->set_subdomain_id(my_rank);
 
-      const TriangulationDescription::Description<dim, dim> description =
-        TriangulationDescription::Utilities::
-          create_description_from_triangulation(tria_local, communicator);
+    const TriangulationDescription::Description<dim, dim> description =
+      TriangulationDescription::Utilities::
+        create_description_from_triangulation(tria_local, communicator);
 
-      distributed_tria.create_triangulation(description);
-    }
-
-
-
-    template <int dim, typename MatrixType, typename SparsityPatternType>
-    void
-    fill_injection_matrix(
-      const DoFHandler<dim> &coarse_dof_handler,
-      const DoFHandler<dim> &fine_dof_handler,
-      SparsityPatternType   &sparsity_pattern,
-      MatrixType            &transfer_matrix,
-      const std::map<
-        std::pair<types::global_cell_index, types::global_cell_index>,
-        std::vector<types::global_cell_index>> &parent_to_child_info,
-      const std::vector<BoundingBox<dim>>      &coarse_level_boxes,
-      const std::vector<BoundingBox<dim>>      &fine_level_boxes,
-      const unsigned int                        coarse_level)
-    {
-      if constexpr (std::is_same_v<MatrixType, SparseMatrix<double>> &&
-                    std::is_same_v<SparsityPatternType, SparsityPattern>)
-        {
-          const FiniteElement<dim> &fe_dgq = coarse_dof_handler.get_fe();
-          const Triangulation<dim> &fine_tria =
-            fine_dof_handler.get_triangulation();
-          AffineConstraints<double> constraints;
-
-          const std::vector<Point<dim>> &unit_support_points =
-            fe_dgq.get_unit_support_points();
-
-          DynamicSparsityPattern dsp;
-          dsp.reinit(fine_dof_handler.n_dofs(), coarse_dof_handler.n_dofs());
-          AffineConstraints<double>            dummy_constraints;
-          std::vector<types::global_dof_index> coarse_dof_indices(
-            fe_dgq.n_dofs_per_cell());
-          std::vector<types::global_dof_index> fine_dof_indices(
-            fe_dgq.n_dofs_per_cell());
+    distributed_tria.create_triangulation(description);
+  }
 
 
-          // Loop over coarse tria and print DoFs
-          for (const auto &cell : coarse_dof_handler.active_cell_iterators())
+
+  template <int dim, typename MatrixType, typename SparsityPatternType>
+  void
+  fill_injection_matrix(
+    const DoFHandler<dim> &coarse_dof_handler,
+    const DoFHandler<dim> &fine_dof_handler,
+    SparsityPatternType   &sparsity_pattern,
+    MatrixType            &transfer_matrix,
+    const std::map<
+      std::pair<types::global_cell_index, types::global_cell_index>,
+      std::vector<types::global_cell_index>> &parent_to_child_info,
+    const std::vector<BoundingBox<dim>>      &coarse_level_boxes,
+    const std::vector<BoundingBox<dim>>      &fine_level_boxes,
+    const unsigned int                        coarse_level)
+  {
+    if constexpr (std::is_same_v<MatrixType, SparseMatrix<double>> &&
+                  std::is_same_v<SparsityPatternType, SparsityPattern>)
+      {
+        const FiniteElement<dim> &fe_dgq = coarse_dof_handler.get_fe();
+        const Triangulation<dim> &fine_tria =
+          fine_dof_handler.get_triangulation();
+        AffineConstraints<double> constraints;
+
+        const std::vector<Point<dim>> &unit_support_points =
+          fe_dgq.get_unit_support_points();
+
+        DynamicSparsityPattern dsp;
+        dsp.reinit(fine_dof_handler.n_dofs(), coarse_dof_handler.n_dofs());
+        AffineConstraints<double>            dummy_constraints;
+        std::vector<types::global_dof_index> coarse_dof_indices(
+          fe_dgq.n_dofs_per_cell());
+        std::vector<types::global_dof_index> fine_dof_indices(
+          fe_dgq.n_dofs_per_cell());
+
+
+        // Loop over coarse tria and print DoFs
+        for (const auto &cell : coarse_dof_handler.active_cell_iterators())
+          {
+            cell->get_dof_indices(coarse_dof_indices);
+
+            std::vector<types::global_dof_index> indices_of_children =
+              parent_to_child_info.at(
+                {cell->active_cell_index(), coarse_level + 1});
+
+            for (const auto &idx : indices_of_children)
+              {
+                DoFAccessor<dim, dim, dim, false> dof_accessor_child(
+                  &fine_tria, 0, idx, &fine_dof_handler);
+                dof_accessor_child.get_dof_indices(fine_dof_indices);
+
+                for (const types::global_dof_index row : fine_dof_indices)
+                  dsp.add_entries(row,
+                                  coarse_dof_indices.begin(),
+                                  coarse_dof_indices.end());
+              }
+          }
+
+        // Filled sparsity pattern
+        sparsity_pattern.copy_from(dsp);
+
+        // Now onto filling the matrix...
+        transfer_matrix.reinit(sparsity_pattern);
+        const unsigned int dofs_per_cell = fe_dgq.n_dofs_per_cell();
+        FullMatrix<double> local_matrix(dofs_per_cell, dofs_per_cell);
+
+        for (const auto &cell : coarse_dof_handler.active_cell_iterators())
+          {
+            cell->get_dof_indices(coarse_dof_indices);
+
+            const BoundingBox<dim> &coarse_box =
+              coarse_level_boxes[cell->active_cell_index()];
+
+            std::vector<types::global_dof_index> indices_of_children =
+              parent_to_child_info.at(
+                {cell->active_cell_index(), coarse_level + 1});
+
+            for (const auto &idx : indices_of_children)
+              {
+                DoFAccessor<dim, dim, dim, false> dof_accessor_child(
+                  &fine_tria, 0, idx, &fine_dof_handler);
+                dof_accessor_child.get_dof_indices(fine_dof_indices);
+                const BoundingBox<dim> &fine_bbox = fine_level_boxes[idx];
+
+                local_matrix = 0.;
+
+                // Now we plot the fine support points
+                std::vector<Point<dim>> real_qpoints;
+                real_qpoints.reserve(unit_support_points.size());
+                for (const Point<dim> &p : unit_support_points)
+                  real_qpoints.push_back(fine_bbox.unit_to_real(p));
+
+                for (unsigned int i = 0; i < coarse_dof_indices.size(); ++i)
+                  {
+                    const auto &p = coarse_box.real_to_unit(real_qpoints[i]);
+                    for (unsigned int j = 0; j < fine_dof_indices.size(); ++j)
+                      {
+                        local_matrix(i, j) = fe_dgq.shape_value(j, p);
+                      }
+                  }
+
+                constraints.distribute_local_to_global(local_matrix,
+                                                       fine_dof_indices,
+                                                       coarse_dof_indices,
+                                                       transfer_matrix);
+              }
+          }
+      }
+    else if constexpr (std::is_same_v<MatrixType,
+                                      TrilinosWrappers::SparseMatrix> &&
+                       std::is_same_v<SparsityPatternType,
+                                      TrilinosWrappers::SparsityPattern>)
+      {
+        const FiniteElement<dim> &fe_dgq = coarse_dof_handler.get_fe();
+        const Triangulation<dim> &fine_tria =
+          fine_dof_handler.get_triangulation();
+
+        // Check that the triangulation is distributed
+        Assert(
+          (dynamic_cast<
+             const parallel::fullydistributed::Triangulation<dim, dim> *>(
+             &fine_tria) != nullptr),
+          ExcMessage(
+            "The triangulation should be a parallel::fullydistributed::Triangulation."));
+
+        const MPI_Comm comm = fine_tria.get_mpi_communicator();
+
+        // just for local2global
+        AffineConstraints<double> constraints;
+        constraints.close();
+
+        const IndexSet &owned_fine   = fine_dof_handler.locally_owned_dofs();
+        const IndexSet &owned_coarse = coarse_dof_handler.locally_owned_dofs();
+
+        sparsity_pattern.reinit(owned_fine, owned_coarse, comm);
+
+        std::vector<types::global_dof_index> coarse_dof_indices(
+          fe_dgq.n_dofs_per_cell());
+        std::vector<types::global_dof_index> fine_dof_indices(
+          fe_dgq.n_dofs_per_cell());
+
+        for (const auto &cell : coarse_dof_handler.active_cell_iterators())
+          if (cell->is_locally_owned())
             {
               cell->get_dof_indices(coarse_dof_indices);
+
+              // std::cout << "Debug: Coarse cell " <<
+              // cell->active_cell_index()
+              //           << " with DoFs: ";
+              // for (const auto &idx : coarse_dof_indices)
+              //   std::cout << idx << " ";
+              // std::cout << std::endl;
 
               std::vector<types::global_dof_index> indices_of_children =
                 parent_to_child_info.at(
                   {cell->active_cell_index(), coarse_level + 1});
 
-              for (const auto &idx : indices_of_children)
+              for (const auto child_idx : indices_of_children)
                 {
-                  DoFAccessor<dim, dim, dim, false> dof_accessor_child(
-                    &fine_tria, 0, idx, &fine_dof_handler);
-                  dof_accessor_child.get_dof_indices(fine_dof_indices);
+                  DoFAccessor<dim, dim, dim, false> child_accessor(
+                    &fine_tria, 0, child_idx, &fine_dof_handler);
+                  child_accessor.get_dof_indices(fine_dof_indices);
 
-                  for (const types::global_dof_index row : fine_dof_indices)
-                    dsp.add_entries(row,
-                                    coarse_dof_indices.begin(),
-                                    coarse_dof_indices.end());
+                  for (const auto row : fine_dof_indices)
+                    sparsity_pattern.add_entries(row,
+                                                 coarse_dof_indices.begin(),
+                                                 coarse_dof_indices.end());
                 }
             }
 
-          // Filled sparsity pattern
-          sparsity_pattern.copy_from(dsp);
+        sparsity_pattern.compress();
+        transfer_matrix.reinit(sparsity_pattern);
 
-          // Now onto filling the matrix...
-          transfer_matrix.reinit(sparsity_pattern);
-          const unsigned int dofs_per_cell = fe_dgq.n_dofs_per_cell();
-          FullMatrix<double> local_matrix(dofs_per_cell, dofs_per_cell);
+        FullMatrix<double> local_matrix(fe_dgq.n_dofs_per_cell(),
+                                        fe_dgq.n_dofs_per_cell());
+        const auto &unit_support_points = fe_dgq.get_unit_support_points();
 
-          for (const auto &cell : coarse_dof_handler.active_cell_iterators())
+        for (const auto &cell : coarse_dof_handler.active_cell_iterators())
+          if (cell->is_locally_owned())
             {
               cell->get_dof_indices(coarse_dof_indices);
-
               const BoundingBox<dim> &coarse_box =
                 coarse_level_boxes[cell->active_cell_index()];
 
@@ -214,28 +322,27 @@ namespace dealii::ContinuousAggloUtils
                 parent_to_child_info.at(
                   {cell->active_cell_index(), coarse_level + 1});
 
-              for (const auto &idx : indices_of_children)
+              for (const auto child_idx : indices_of_children)
                 {
-                  DoFAccessor<dim, dim, dim, false> dof_accessor_child(
-                    &fine_tria, 0, idx, &fine_dof_handler);
-                  dof_accessor_child.get_dof_indices(fine_dof_indices);
-                  const BoundingBox<dim> &fine_bbox = fine_level_boxes[idx];
+                  DoFAccessor<dim, dim, dim, false> child_accessor(
+                    &fine_tria, 0, child_idx, &fine_dof_handler);
+                  child_accessor.get_dof_indices(fine_dof_indices);
 
-                  local_matrix = 0.;
+                  const BoundingBox<dim> &fine_box =
+                    fine_level_boxes[child_idx];
+                  local_matrix = 0.0;
 
-                  // Now we plot the fine support points
                   std::vector<Point<dim>> real_qpoints;
                   real_qpoints.reserve(unit_support_points.size());
-                  for (const Point<dim> &p : unit_support_points)
-                    real_qpoints.push_back(fine_bbox.unit_to_real(p));
+                  for (const auto &p : unit_support_points)
+                    real_qpoints.push_back(fine_box.unit_to_real(p));
 
                   for (unsigned int i = 0; i < coarse_dof_indices.size(); ++i)
                     {
-                      const auto &p = coarse_box.real_to_unit(real_qpoints[i]);
+                      const Point<dim> p =
+                        coarse_box.real_to_unit(real_qpoints[i]);
                       for (unsigned int j = 0; j < fine_dof_indices.size(); ++j)
-                        {
-                          local_matrix(i, j) = fe_dgq.shape_value(j, p);
-                        }
+                        local_matrix(i, j) = fe_dgq.shape_value(j, p);
                     }
 
                   constraints.distribute_local_to_global(local_matrix,
@@ -244,128 +351,19 @@ namespace dealii::ContinuousAggloUtils
                                                          transfer_matrix);
                 }
             }
-        }
-      else if constexpr (std::is_same_v<MatrixType,
-                                        TrilinosWrappers::SparseMatrix> &&
-                         std::is_same_v<SparsityPatternType,
-                                        TrilinosWrappers::SparsityPattern>)
-        {
-          const FiniteElement<dim> &fe_dgq = coarse_dof_handler.get_fe();
-          const Triangulation<dim> &fine_tria =
-            fine_dof_handler.get_triangulation();
 
-          // Check that the triangulation is distributed
-          Assert(
-            (dynamic_cast<
-               const parallel::fullydistributed::Triangulation<dim, dim> *>(
-               &fine_tria) != nullptr),
-            ExcMessage(
-              "The triangulation should be a parallel::fullydistributed::Triangulation."));
-
-          const MPI_Comm comm = fine_tria.get_mpi_communicator();
-
-          // just for local2global
-          AffineConstraints<double> constraints;
-          constraints.close();
-
-          const IndexSet &owned_fine = fine_dof_handler.locally_owned_dofs();
-          const IndexSet &owned_coarse =
-            coarse_dof_handler.locally_owned_dofs();
-
-          sparsity_pattern.reinit(owned_fine, owned_coarse, comm);
-
-          std::vector<types::global_dof_index> coarse_dof_indices(
-            fe_dgq.n_dofs_per_cell());
-          std::vector<types::global_dof_index> fine_dof_indices(
-            fe_dgq.n_dofs_per_cell());
-
-          for (const auto &cell : coarse_dof_handler.active_cell_iterators())
-            if (cell->is_locally_owned())
-              {
-                cell->get_dof_indices(coarse_dof_indices);
-
-                // std::cout << "Debug: Coarse cell " <<
-                // cell->active_cell_index()
-                //           << " with DoFs: ";
-                // for (const auto &idx : coarse_dof_indices)
-                //   std::cout << idx << " ";
-                // std::cout << std::endl;
-
-                std::vector<types::global_dof_index> indices_of_children =
-                  parent_to_child_info.at(
-                    {cell->active_cell_index(), coarse_level + 1});
-
-                for (const auto child_idx : indices_of_children)
-                  {
-                    DoFAccessor<dim, dim, dim, false> child_accessor(
-                      &fine_tria, 0, child_idx, &fine_dof_handler);
-                    child_accessor.get_dof_indices(fine_dof_indices);
-
-                    for (const auto row : fine_dof_indices)
-                      sparsity_pattern.add_entries(row,
-                                                   coarse_dof_indices.begin(),
-                                                   coarse_dof_indices.end());
-                  }
-              }
-
-          sparsity_pattern.compress();
-          transfer_matrix.reinit(sparsity_pattern);
-
-          FullMatrix<double> local_matrix(fe_dgq.n_dofs_per_cell(),
-                                          fe_dgq.n_dofs_per_cell());
-          const auto &unit_support_points = fe_dgq.get_unit_support_points();
-
-          for (const auto &cell : coarse_dof_handler.active_cell_iterators())
-            if (cell->is_locally_owned())
-              {
-                cell->get_dof_indices(coarse_dof_indices);
-                const BoundingBox<dim> &coarse_box =
-                  coarse_level_boxes[cell->active_cell_index()];
-
-                std::vector<types::global_dof_index> indices_of_children =
-                  parent_to_child_info.at(
-                    {cell->active_cell_index(), coarse_level + 1});
-
-                for (const auto child_idx : indices_of_children)
-                  {
-                    DoFAccessor<dim, dim, dim, false> child_accessor(
-                      &fine_tria, 0, child_idx, &fine_dof_handler);
-                    child_accessor.get_dof_indices(fine_dof_indices);
-
-                    const BoundingBox<dim> &fine_box =
-                      fine_level_boxes[child_idx];
-                    local_matrix = 0.0;
-
-                    std::vector<Point<dim>> real_qpoints;
-                    real_qpoints.reserve(unit_support_points.size());
-                    for (const auto &p : unit_support_points)
-                      real_qpoints.push_back(fine_box.unit_to_real(p));
-
-                    for (unsigned int i = 0; i < coarse_dof_indices.size(); ++i)
-                      {
-                        const Point<dim> p =
-                          coarse_box.real_to_unit(real_qpoints[i]);
-                        for (unsigned int j = 0; j < fine_dof_indices.size();
-                             ++j)
-                          local_matrix(i, j) = fe_dgq.shape_value(j, p);
-                      }
-
-                    constraints.distribute_local_to_global(local_matrix,
-                                                           fine_dof_indices,
-                                                           coarse_dof_indices,
-                                                           transfer_matrix);
-                  }
-              }
-
-          transfer_matrix.compress(VectorOperation::add);
-        }
-      else
-        {
-          Assert(false, ExcNotImplemented());
-        }
-    }
+        transfer_matrix.compress(VectorOperation::add);
+      }
+    else
+      {
+        Assert(false, ExcNotImplemented());
+      }
+  }
 
 
+
+  namespace PointsAgglo
+  {
     // Note for me:
     // This function is not supporting multiple DoFs insisting on the same
     // support point as it uses the size of the vector of support points to
@@ -449,8 +447,9 @@ namespace dealii::ContinuousAggloUtils
       for (unsigned int i = 0; i < mg_levels - 1; ++i)
         {
           triangulations[i] = std::make_unique<Triangulation<dim>>();
-          create_triangulation_from_bounding_boxes(*triangulations[i],
-                                                   boxes_per_level[i]);
+          dealii::ContinuousAggloUtils::
+            create_triangulation_from_bounding_boxes(*triangulations[i],
+                                                     boxes_per_level[i]);
           support_dof_handlers[i] =
             std::make_unique<DoFHandler<dim>>(*triangulations[i]);
 
@@ -463,14 +462,15 @@ namespace dealii::ContinuousAggloUtils
       injection_sparsity_patterns.resize(mg_levels - 1);
 
       for (unsigned int j = 0; j < mg_levels - 2; ++j)
-        fill_injection_matrix(*support_dof_handlers[j],
-                              *support_dof_handlers[j + 1],
-                              injection_sparsity_patterns[j],
-                              injection_matrices[j],
-                              hierarchies_per_level[j],
-                              boxes_per_level[j],
-                              boxes_per_level[j + 1],
-                              tree_lvls - mg_levels + 1 + j);
+        dealii::ContinuousAggloUtils::fill_injection_matrix(
+          *support_dof_handlers[j],
+          *support_dof_handlers[j + 1],
+          injection_sparsity_patterns[j],
+          injection_matrices[j],
+          hierarchies_per_level[j],
+          boxes_per_level[j],
+          boxes_per_level[j + 1],
+          tree_lvls - mg_levels + 1 + j);
 
       // We now have to fill the last injection matrix
       {
@@ -678,9 +678,10 @@ namespace dealii::ContinuousAggloUtils
         {
           triangulations[i] = std::make_unique<
             parallel::fullydistributed::Triangulation<dim, dim>>(comm);
-          create_distributed_tria_from_local_boxes(*triangulations[i],
-                                                   local_boxes_per_level[i],
-                                                   comm);
+          dealii::ContinuousAggloUtils::
+            create_distributed_tria_from_local_boxes(*triangulations[i],
+                                                     local_boxes_per_level[i],
+                                                     comm);
           support_dof_handlers[i] =
             std::make_unique<DoFHandler<dim>>(*triangulations[i]);
 
@@ -694,14 +695,15 @@ namespace dealii::ContinuousAggloUtils
       injection_sparsity_patterns.resize(mg_levels - 1);
 
       for (unsigned int j = 0; j < mg_levels - 2; ++j)
-        fill_injection_matrix(*support_dof_handlers[j],
-                              *support_dof_handlers[j + 1],
-                              injection_sparsity_patterns[j],
-                              injection_matrices[j],
-                              local_hierarchies_per_level[j],
-                              local_boxes_per_level[j],
-                              local_boxes_per_level[j + 1],
-                              local_tree_lvls - mg_levels + 1 + j);
+        dealii::ContinuousAggloUtils::fill_injection_matrix(
+          *support_dof_handlers[j],
+          *support_dof_handlers[j + 1],
+          injection_sparsity_patterns[j],
+          injection_matrices[j],
+          local_hierarchies_per_level[j],
+          local_boxes_per_level[j],
+          local_boxes_per_level[j + 1],
+          local_tree_lvls - mg_levels + 1 + j);
 
       // We now have to fill the last injection matrix
       {
@@ -796,7 +798,7 @@ namespace dealii::ContinuousAggloUtils
     }
   } // namespace PointsAgglo
   namespace CellsAgglo
-  {}
+  {} // namespace CellsAgglo
 } // namespace dealii::ContinuousAggloUtils
 
 #endif

--- a/include/continuous_agglo_utils.h
+++ b/include/continuous_agglo_utils.h
@@ -798,7 +798,300 @@ namespace dealii::ContinuousAggloUtils
     }
   } // namespace PointsAgglo
   namespace CellsAgglo
-  {} // namespace CellsAgglo
+  {
+    template <int dim>
+    void
+    create_bounding_box_from_agglo_cells(
+      const std::vector<
+        std::vector<typename Triangulation<dim>::active_cell_iterator>>
+                                    &vec_agglomerates,
+      std::vector<BoundingBox<dim>> &agglomerate_boxes,
+      const Mapping<dim, dim>       &mapping)
+    {
+      agglomerate_boxes.reserve(vec_agglomerates.size());
+
+      for (const auto &agglo : vec_agglomerates)
+        {
+          bool       init = false;
+          Point<dim> p_min, p_max;
+
+          for (const auto &cell : agglo)
+            {
+              const auto &bb = mapping.get_bounding_box(cell);
+              const auto &bp = bb.get_boundary_points(); // {min,max}
+
+              if (!init)
+                {
+                  p_min = bp.first;
+                  p_max = bp.second;
+                  init  = true;
+                }
+              else
+                {
+                  for (unsigned int d = 0; d < dim; ++d)
+                    {
+                      p_min[d] = std::min(p_min[d], bp.first[d]);
+                      p_max[d] = std::max(p_max[d], bp.second[d]);
+                    }
+                }
+            }
+          agglomerate_boxes.emplace_back(std::make_pair(p_min, p_max));
+        }
+    }
+
+
+
+    template <int dim, unsigned int rtree_m, unsigned int rtree_M>
+    void
+    agglomerate_and_compute_injection_matrices(
+      const DoFHandler<dim>             &fine_dh,
+      const Mapping<dim, dim>           &mapping,
+      const bool                         skip_leaves,
+      std::vector<SparseMatrix<double>> &injection_matrices,
+      std::vector<SparsityPattern>      &injection_sparsity_patterns,
+      const unsigned int                 mg_levels,
+      const std::vector<unsigned int>   &coarse_space_degrees,
+      std::vector<std::unique_ptr<Triangulation<dim>>> &triangulations,
+      std::vector<std::unique_ptr<DoFHandler<dim>>>    &support_dof_handlers)
+    {
+      namespace bgi = boost::geometry::index;
+
+      Assert(mg_levels > 1,
+             ExcMessage("At least two levels are needed for agglomeration."));
+      Assert(coarse_space_degrees.size() == mg_levels - 1,
+             ExcMessage(
+               "The size of coarse_space_degrees should be mg_levels - 1."));
+
+      const Triangulation<dim> &fine_tria = fine_dh.get_triangulation();
+
+      std::vector<std::pair<BoundingBox<dim>,
+                            typename Triangulation<dim>::active_cell_iterator>>
+        boxes(fine_tria.n_active_cells());
+
+      unsigned int i = 0;
+      for (const auto &cell : fine_tria.active_cell_iterators())
+        boxes[i++] = std::make_pair(mapping.get_bounding_box(cell), cell);
+
+      auto tree = pack_rtree<bgi::rstar<rtree_M, rtree_m>>(boxes);
+
+      unsigned int tree_lvls = n_levels(tree);
+      if (skip_leaves)
+        tree_lvls = std::max<unsigned int>(tree_lvls - 1, 0);
+
+      Assert(
+        tree_lvls > 1,
+        ExcMessage(
+          "The tree should have at least two levels to perform agglomeration."));
+
+      Assert(mg_levels <= tree_lvls + 1,
+             ExcMessage("You are trying to use " + std::to_string(mg_levels) +
+                        " levels, but the hierarchy can only have " +
+                        std::to_string(tree_lvls + 1) + " levels."));
+
+      std::vector<std::vector<BoundingBox<dim>>> boxes_per_level(mg_levels - 1);
+      std::vector<
+        std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+                 std::vector<types::global_cell_index>>>
+        hierarchies_per_level(mg_levels - 2);
+
+      unsigned int j = 0;
+      for (unsigned int i = tree_lvls - mg_levels + 1; i < tree_lvls; ++i)
+        {
+          CellsAgglomerator<dim, decltype(tree)> agglomerator{tree, i + 1};
+          const std::vector<
+            std::vector<typename Triangulation<dim>::active_cell_iterator>>
+            agglomerates = agglomerator.extract_agglomerates();
+          boxes_per_level[j].reserve(agglomerates.size());
+
+          // Store hierarchy for reuse later (not needed for last level)
+          if (j < mg_levels - 2)
+            hierarchies_per_level[j] = agglomerator.get_hierarchy();
+
+          create_bounding_box_from_agglo_cells(agglomerates,
+                                               boxes_per_level[j],
+                                               mapping);
+          j++;
+        }
+
+      triangulations.clear();
+      support_dof_handlers.clear();
+      triangulations.resize(mg_levels - 1);
+      support_dof_handlers.resize(mg_levels - 1);
+
+      for (unsigned int i = 0; i < mg_levels - 1; ++i)
+        {
+          triangulations[i] = std::make_unique<Triangulation<dim>>();
+          dealii::ContinuousAggloUtils::
+            create_triangulation_from_bounding_boxes(*triangulations[i],
+                                                     boxes_per_level[i]);
+          support_dof_handlers[i] =
+            std::make_unique<DoFHandler<dim>>(*triangulations[i]);
+
+          FE_DGQ<dim> fe_dgq(coarse_space_degrees[i]);
+          support_dof_handlers[i]->distribute_dofs(fe_dgq);
+        }
+
+      injection_matrices.clear();
+      injection_sparsity_patterns.clear();
+      injection_matrices.resize(mg_levels - 1);
+      injection_sparsity_patterns.resize(mg_levels - 1);
+
+      for (unsigned int j = 0; j < mg_levels - 2; ++j)
+        dealii::ContinuousAggloUtils::fill_injection_matrix(
+          *support_dof_handlers[j],
+          *support_dof_handlers[j + 1],
+          injection_sparsity_patterns[j],
+          injection_matrices[j],
+          hierarchies_per_level[j],
+          boxes_per_level[j],
+          boxes_per_level[j + 1],
+          tree_lvls - mg_levels + 1 + j);
+
+      {
+        CellsAgglomerator<dim, decltype(tree)> agglomerator{tree, tree_lvls};
+
+        std::vector<
+          std::vector<typename Triangulation<dim>::active_cell_iterator>>
+          agglomerates = agglomerator.extract_agglomerates();
+
+        FE_DGQ<dim> fe_dgq(coarse_space_degrees[mg_levels - 2]);
+
+        std::vector<types::global_dof_index> dof_indices_agglo_tria(
+          fe_dgq.n_dofs_per_cell());
+        std::vector<types::global_dof_index> fine_dof_indices(
+          fine_dh.get_fe().n_dofs_per_cell());
+
+        DynamicSparsityPattern dsp_agglo_to_original_tria;
+        dsp_agglo_to_original_tria.reinit(
+          fine_dh.n_dofs(), support_dof_handlers[mg_levels - 2]->n_dofs());
+
+        IndexSet assigned_dofs(fine_dh.n_dofs());
+
+        for (const auto &cell :
+             support_dof_handlers[mg_levels - 2]->active_cell_iterators())
+          {
+            cell->get_dof_indices(dof_indices_agglo_tria);
+
+            for (const auto &child_cell :
+                 agglomerates[cell->active_cell_index()])
+              {
+                const auto child_cell_dh =
+                  child_cell->as_dof_handler_iterator(fine_dh);
+
+                child_cell_dh->get_dof_indices(fine_dof_indices);
+
+                for (const auto &fine_dof_idx : fine_dof_indices)
+                  {
+                    if (assigned_dofs.is_element(fine_dof_idx))
+                      continue;
+                    else
+                      {
+                        dsp_agglo_to_original_tria.add_entries(
+                          fine_dof_idx,
+                          dof_indices_agglo_tria.begin(),
+                          dof_indices_agglo_tria.end());
+                        assigned_dofs.add_index(fine_dof_idx);
+                      }
+                  }
+              }
+          }
+        injection_sparsity_patterns[mg_levels - 2].copy_from(
+          dsp_agglo_to_original_tria);
+        injection_matrices[mg_levels - 2].reinit(
+          injection_sparsity_patterns[mg_levels - 2]);
+
+        AffineConstraints<double> dummy_constraints; // for loc2glob
+        assigned_dofs.clear();                       // reset for filling matrix
+
+        std::vector<Point<dim>> unit_support_points =
+          fine_dh.get_fe().get_unit_support_points();
+
+
+        for (const auto &cell :
+             support_dof_handlers[mg_levels - 2]->active_cell_iterators())
+          {
+            cell->get_dof_indices(dof_indices_agglo_tria);
+
+            const BoundingBox<dim> &coarse_box =
+              boxes_per_level[mg_levels - 2][cell->active_cell_index()];
+
+            std::vector<Point<dim>> fine_support_points;
+            fine_support_points.reserve(
+              unit_support_points.size() *
+              agglomerates[cell->active_cell_index()].size());
+
+            std::vector<types::global_dof_index> actual_fine_dof_indices;
+
+            actual_fine_dof_indices.reserve(
+              unit_support_points.size() *
+              agglomerates[cell->active_cell_index()].size());
+
+            for (const auto &child_cell :
+                 agglomerates[cell->active_cell_index()])
+              {
+                const auto child_cell_dh =
+                  child_cell->as_dof_handler_iterator(fine_dh);
+
+                child_cell_dh->get_dof_indices(fine_dof_indices);
+
+                unsigned int find_dof_counter = 0;
+                for (const auto &fine_dof_idx : fine_dof_indices)
+                  {
+                    if (!assigned_dofs.is_element(fine_dof_idx))
+                      {
+                        assigned_dofs.add_index(fine_dof_idx);
+                        actual_fine_dof_indices.push_back(fine_dof_idx);
+                        Point<dim> real_p = mapping.transform_unit_to_real_cell(
+                          child_cell, unit_support_points[find_dof_counter]);
+                        fine_support_points.push_back(real_p);
+                      }
+                    find_dof_counter++;
+                  }
+              }
+
+            FullMatrix<double> local_matrix(fine_support_points.size(),
+                                            fe_dgq.n_dofs_per_cell());
+
+            local_matrix = 0.0;
+
+            for (unsigned int i = 0; i < fine_support_points.size(); ++i)
+              {
+                const Point<dim> p =
+                  coarse_box.real_to_unit(fine_support_points[i]);
+                for (unsigned int j = 0; j < dof_indices_agglo_tria.size(); ++j)
+                  {
+                    local_matrix(i, j) = fe_dgq.shape_value(j, p);
+                  }
+              }
+
+            dummy_constraints.distribute_local_to_global(
+              local_matrix,
+              actual_fine_dof_indices,
+              dof_indices_agglo_tria,
+              injection_matrices[mg_levels - 2]);
+          }
+      }
+    }
+
+
+
+    template <int dim, unsigned int rtree_m, unsigned int rtree_M>
+    void
+    parallel_agglomerate_and_compute_injection_matrices(
+      const DoFHandler<dim>                       &fine_dh,
+      const Mapping<dim, dim>                     &mapping,
+      const bool                                   skip_leaves,
+      std::vector<TrilinosWrappers::SparseMatrix> &injection_matrices,
+      std::vector<TrilinosWrappers::SparsityPattern>
+                                      &injection_sparsity_patterns,
+      const unsigned int               mg_levels,
+      const std::vector<unsigned int> &coarse_space_degrees,
+      std::vector<
+        std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
+                                                    &triangulations,
+      std::vector<std::unique_ptr<DoFHandler<dim>>> &support_dof_handlers)
+    {}
+  } // namespace CellsAgglo
 } // namespace dealii::ContinuousAggloUtils
 
 #endif

--- a/include/continuous_agglo_utils.h
+++ b/include/continuous_agglo_utils.h
@@ -13,14 +13,19 @@
 #ifndef continuous_agglo_utils_h
 #define continuous_agglo_utils_h
 
+#include <deal.II/base/bounding_box.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/index_set.h>
+#include <deal.II/base/point.h>
 
 #include <deal.II/distributed/fully_distributed_tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_dgq.h>
+
+#include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_description.h>
 
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
@@ -33,6 +38,10 @@
 #include <deal.II/numerics/rtree.h>
 
 #include <agglomerator.h>
+
+#include <map>
+#include <memory>
+#include <vector>
 
 
 namespace dealii::ContinuousAggloUtils
@@ -361,26 +370,36 @@ namespace dealii::ContinuousAggloUtils
     // support points to construct the agglomeration hierarchy. This is not a
     // strong assumption, since we can always reorder the support points to
     // match the DoF ordering. Deal.II automatically does this.
-    template <int dim,
+    // This function is not supporting multiple DoFs insisting on the same
+    // support point as it uses the size of the vector of support points to
+    // determine the number of DoFs on the finest level.
+    template <int          dim,
+              unsigned int rtree_m,
+              unsigned int rtree_M,
               typename MatrixType,
               typename SparsityPatternType,
-              typename VectorType,
-              unsigned int rtree_m,
-              unsigned int rtree_M>
+              typename VectorType>
     void
     agglomerate_and_compute_injection_matrices(
-      VectorType                       &support_points_vector,
-      bool                              skip_leaves,
+      const VectorType                 &support_points_vector,
+      const bool                        skip_leaves,
       std::vector<MatrixType>          &injection_matrices,
       std::vector<SparsityPatternType> &injection_sparsity_patterns,
-      unsigned int                      mg_levels)
+      const unsigned int                mg_levels,
+      const std::vector<unsigned int>  &coarse_space_degrees)
     {
       namespace bgi = boost::geometry::index;
+
+      Assert(mg_levels > 1,
+             ExcMessage("At least two levels are needed for agglomeration."));
+      Assert(coarse_space_degrees.size() == mg_levels - 1,
+             ExcMessage(
+               "The size of coarse_space_degrees should be mg_levels - 1."));
 
       if constexpr (std::is_same_v<MatrixType, SparseMatrix<double>> &&
                     std::is_same_v<SparsityPatternType, SparsityPattern>)
         {
-          auto tree = pack_rtree_of_indices<bgi::rstar<rtree_m, rtree_M>>(
+          auto tree = pack_rtree_of_indices<bgi::rstar<rtree_M, rtree_m>>(
             support_points_vector);
 
           unsigned int tree_lvls = n_levels(tree);
@@ -402,14 +421,23 @@ namespace dealii::ContinuousAggloUtils
 
           std::vector<std::vector<BoundingBox<dim>>> boxes_per_level(mg_levels -
                                                                      1);
+          std::vector<std::map<
+            std::pair<types::global_cell_index, types::global_cell_index>,
+            std::vector<types::global_cell_index>>>
+            hierarchies_per_level(mg_levels - 2);
+
+          unsigned int j = 0;
           for (unsigned int i = tree_lvls - mg_levels + 1; i < tree_lvls; ++i)
             {
-              unsigned int                                 j = 0;
               CellsAgglomerator<dim, decltype(tree), true> agglomerator{tree,
                                                                         i + 1};
               const std::vector<std::vector<types::global_dof_index>>
                 agglomerates = agglomerator.extract_agglomerates();
               boxes_per_level[j].reserve(agglomerates.size());
+
+              // Store hierarchy for reuse later (not needed for last level)
+              if (j < mg_levels - 2)
+                hierarchies_per_level[j] = agglomerator.get_hierarchy();
 
               for (const std::vector<types::global_dof_index> &agglo :
                    agglomerates)
@@ -427,6 +455,119 @@ namespace dealii::ContinuousAggloUtils
                 }
               j++;
             }
+
+          std::vector<std::unique_ptr<Triangulation<dim>>> triangulations(
+            mg_levels - 1);
+          std::vector<std::unique_ptr<DoFHandler<dim>>> support_DoFHandlers(
+            mg_levels - 1);
+
+          for (unsigned int i = 0; i < mg_levels - 1; ++i)
+            {
+              triangulations[i] = std::make_unique<Triangulation<dim>>();
+              create_triangulation_from_bounding_boxes(*triangulations[i],
+                                                       boxes_per_level[i]);
+              support_DoFHandlers[i] =
+                std::make_unique<DoFHandler<dim>>(*triangulations[i]);
+
+              FE_DGQ<dim> fe_dgq(coarse_space_degrees[i]);
+              support_DoFHandlers[i]->distribute_dofs(fe_dgq);
+            }
+          injection_matrices.clear();
+          injection_sparsity_patterns.clear();
+          injection_matrices.resize(mg_levels - 1);
+          injection_sparsity_patterns.resize(mg_levels - 1);
+
+          for (unsigned int j = 0; j < mg_levels - 2; ++j)
+            fill_injection_matrix(*support_DoFHandlers[j],
+                                  *support_DoFHandlers[j + 1],
+                                  injection_sparsity_patterns[j],
+                                  injection_matrices[j],
+                                  hierarchies_per_level[j],
+                                  boxes_per_level[j],
+                                  boxes_per_level[j + 1],
+                                  tree_lvls - mg_levels + 1 + j);
+
+          // We now have to fill the last injection matrix
+          {
+            CellsAgglomerator<dim, decltype(tree), true> agglomerator{
+              tree, tree_lvls};
+
+            const std::vector<std::vector<types::global_dof_index>>
+              agglomerates = agglomerator.extract_agglomerates();
+
+            FE_DGQ<dim> fe_dgq(coarse_space_degrees[mg_levels - 2]);
+
+            std::vector<types::global_dof_index> dof_indices_agglo_tria(
+              fe_dgq.n_dofs_per_cell());
+
+            DynamicSparsityPattern dsp_agglo_to_original_tria;
+            dsp_agglo_to_original_tria.reinit(
+              support_points_vector
+                .size(), // should be equal to the number of DoFs if only  1
+                         // DoFs insist per support point
+              support_DoFHandlers[mg_levels - 2]->n_dofs());
+
+            unsigned int agglo_index = 0;
+            for (const auto &cell :
+                 support_DoFHandlers[mg_levels - 2]->active_cell_iterators())
+              {
+                cell->get_dof_indices(dof_indices_agglo_tria);
+
+                for (const types::global_dof_index dof_idx :
+                     agglomerates[agglo_index])
+                  dsp_agglo_to_original_tria.add_entries(
+                    dof_idx,
+                    dof_indices_agglo_tria.begin(),
+                    dof_indices_agglo_tria.end());
+
+                agglo_index++;
+              }
+
+            injection_sparsity_patterns[mg_levels - 2].copy_from(
+              dsp_agglo_to_original_tria);
+            injection_matrices[mg_levels - 2].reinit(
+              injection_sparsity_patterns[mg_levels - 2]);
+
+            AffineConstraints<double> dummy_constraints; // for loc2glob
+
+            agglo_index = 0;
+            for (const auto &cell :
+                 support_DoFHandlers[mg_levels - 2]->active_cell_iterators())
+              {
+                cell->get_dof_indices(dof_indices_agglo_tria);
+
+                const BoundingBox<dim> &coarse_box =
+                  boxes_per_level[mg_levels - 2][cell->active_cell_index()];
+
+                const unsigned int n_fine_support_points =
+                  agglomerates[agglo_index].size();
+
+                const std::vector<types::global_dof_index> fine_indices =
+                  agglomerates[agglo_index];
+
+                FullMatrix<double> local_matrix(n_fine_support_points,
+                                                fe_dgq.n_dofs_per_cell());
+                local_matrix = 0.0;
+
+                for (unsigned int i = 0; i < n_fine_support_points; ++i)
+                  {
+                    const Point<dim> p = coarse_box.real_to_unit(
+                      support_points_vector[fine_indices[i]]);
+
+                    for (unsigned int j = 0; j < dof_indices_agglo_tria.size();
+                         ++j)
+                      local_matrix(i, j) = fe_dgq.shape_value(j, p);
+                  }
+
+                dummy_constraints.distribute_local_to_global(
+                  local_matrix,
+                  fine_indices,
+                  dof_indices_agglo_tria,
+                  injection_matrices[mg_levels - 2]);
+
+                ++agglo_index;
+              }
+          }
         }
       else
         {

--- a/include/continuous_agglo_utils.h
+++ b/include/continuous_agglo_utils.h
@@ -1211,14 +1211,12 @@ namespace dealii::ContinuousAggloUtils
 
         std::vector<types::global_dof_index> dof_indices_agglo_tria(
           fe_dgq.n_dofs_per_cell());
-        std::vector<types::global_dof_index> local_dof_indices_agglo_tria;
-        local_dof_indices_agglo_tria.reserve(fe_dgq.n_dofs_per_cell());
 
         std::vector<types::global_dof_index> fine_dof_indices(
           fine_dh.get_fe().n_dofs_per_cell());
         std::vector<types::global_dof_index>
           local_fine_dof_indices; // i need the local to filter out the ghost
-                                  // dofs
+                                  // dofs, not needed for the DG ones
         local_fine_dof_indices.reserve(fine_dof_indices.size());
 
         const IndexSet &locally_owned_dofs_coarse =
@@ -1233,17 +1231,11 @@ namespace dealii::ContinuousAggloUtils
         assigned_dofs
           .clear(); // to track which fine dofs have been assigned to an agglo
 
-        // I am not 100% sure this is ok, but since active_cell_index() is local
-        // this should be ok for the agglomerates
         for (const auto &cell :
              support_dof_handlers[mg_levels - 2]->active_cell_iterators())
           if (cell->is_locally_owned())
             {
               cell->get_dof_indices(dof_indices_agglo_tria);
-              local_dof_indices_agglo_tria.clear();
-              for (const auto &idx : dof_indices_agglo_tria)
-                if (locally_owned_dofs_coarse.is_element(idx))
-                  local_dof_indices_agglo_tria.push_back(idx);
 
               for (const auto &child_cell :
                    agglomerates[cell->active_cell_index()])
@@ -1265,8 +1257,8 @@ namespace dealii::ContinuousAggloUtils
                         {
                           injection_sparsity_patterns[mg_levels - 2]
                             .add_entries(fine_dof_idx,
-                                         local_dof_indices_agglo_tria.begin(),
-                                         local_dof_indices_agglo_tria.end());
+                                         dof_indices_agglo_tria.begin(),
+                                         dof_indices_agglo_tria.end());
                           assigned_dofs.add_index(fine_dof_idx);
                         }
                     }
@@ -1288,10 +1280,6 @@ namespace dealii::ContinuousAggloUtils
           if (cell->is_locally_owned())
             {
               cell->get_dof_indices(dof_indices_agglo_tria);
-              local_dof_indices_agglo_tria.clear();
-              for (const auto &idx : dof_indices_agglo_tria)
-                if (locally_owned_dofs_coarse.is_element(idx))
-                  local_dof_indices_agglo_tria.push_back(idx);
 
               const BoundingBox<dim> &coarse_box =
                 local_boxes_per_level[mg_levels - 2][cell->active_cell_index()];
@@ -1344,9 +1332,8 @@ namespace dealii::ContinuousAggloUtils
                       find_dof_counter++;
                     }
                 }
-              FullMatrix<double> local_matrix(
-                fine_support_points.size(),
-                local_dof_indices_agglo_tria.size());
+              FullMatrix<double> local_matrix(fine_support_points.size(),
+                                              dof_indices_agglo_tria.size());
 
               local_matrix = 0.0;
 
@@ -1354,8 +1341,7 @@ namespace dealii::ContinuousAggloUtils
                 {
                   const Point<dim> p =
                     coarse_box.real_to_unit(fine_support_points[i]);
-                  for (unsigned int j = 0;
-                       j < local_dof_indices_agglo_tria.size();
+                  for (unsigned int j = 0; j < dof_indices_agglo_tria.size();
                        ++j)
                     {
                       local_matrix(i, j) = fe_dgq.shape_value(j, p);
@@ -1365,7 +1351,7 @@ namespace dealii::ContinuousAggloUtils
               dummy_constraints.distribute_local_to_global(
                 local_matrix,
                 actual_fine_dof_indices,
-                local_dof_indices_agglo_tria,
+                dof_indices_agglo_tria,
                 injection_matrices[mg_levels - 2]);
             }
         injection_matrices[mg_levels - 2].compress(VectorOperation::add);

--- a/include/continuous_agglo_utils.h
+++ b/include/continuous_agglo_utils.h
@@ -1090,7 +1090,287 @@ namespace dealii::ContinuousAggloUtils
         std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
                                                     &triangulations,
       std::vector<std::unique_ptr<DoFHandler<dim>>> &support_dof_handlers)
-    {}
+    {
+      namespace bgi = boost::geometry::index;
+
+      MPI_Comm           comm    = fine_dh.get_mpi_communicator();
+      const unsigned int my_rank = Utilities::MPI::this_mpi_process(comm);
+
+      Assert(mg_levels > 1,
+             ExcMessage("At least two levels are needed for agglomeration."));
+      Assert(coarse_space_degrees.size() == mg_levels - 1,
+             ExcMessage(
+               "The size of coarse_space_degrees should be mg_levels - 1."));
+
+      const parallel::fullydistributed::Triangulation<dim, dim> &fine_tria =
+        dynamic_cast<
+          const parallel::fullydistributed::Triangulation<dim, dim> &>(
+          fine_dh.get_triangulation());
+
+      std::vector<std::pair<BoundingBox<dim>,
+                            typename Triangulation<dim>::active_cell_iterator>>
+        local_boxes(fine_tria.n_locally_owned_active_cells());
+
+      unsigned int i = 0;
+      for (const auto &cell : fine_tria.active_cell_iterators())
+        if (cell->is_locally_owned())
+          local_boxes[i++] =
+            std::make_pair(mapping.get_bounding_box(cell), cell);
+
+      auto local_tree = pack_rtree<bgi::rstar<rtree_M, rtree_m>>(local_boxes);
+
+      unsigned int local_tree_lvls = n_levels(local_tree);
+      if (skip_leaves)
+        local_tree_lvls = std::max<unsigned int>(local_tree_lvls - 1, 0);
+
+      Assert(local_tree_lvls > 1,
+             ExcMessage(
+               "The tree on rank " + std::to_string(my_rank) +
+               " should have at least two levels to perform agglomeration."));
+
+      Assert(mg_levels <= local_tree_lvls + 1,
+             ExcMessage("You are trying to use " + std::to_string(mg_levels) +
+                        " levels, but the hierarchy on rank " +
+                        std::to_string(my_rank) + " can only have " +
+                        std::to_string(local_tree_lvls + 1) + " levels."));
+
+      std::vector<std::vector<BoundingBox<dim>>> local_boxes_per_level(
+        mg_levels - 1);
+      std::vector<
+        std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+                 std::vector<types::global_cell_index>>>
+        local_hierarchies_per_level(mg_levels - 2);
+
+      unsigned int j = 0;
+      for (unsigned int i = local_tree_lvls - mg_levels + 1;
+           i < local_tree_lvls;
+           ++i)
+        {
+          CellsAgglomerator<dim, decltype(local_tree)> agglomerator{local_tree,
+                                                                    i + 1};
+          const std::vector<
+            std::vector<typename Triangulation<dim>::active_cell_iterator>>
+            agglomerates = agglomerator.extract_agglomerates();
+          local_boxes_per_level[j].reserve(agglomerates.size());
+
+          if (j < mg_levels - 2)
+            local_hierarchies_per_level[j] = agglomerator.get_hierarchy();
+
+          create_bounding_box_from_agglo_cells(agglomerates,
+                                               local_boxes_per_level[j],
+                                               mapping);
+          j++;
+        }
+
+      triangulations.clear();
+      support_dof_handlers.clear();
+      triangulations.resize(mg_levels - 1);
+      support_dof_handlers.resize(mg_levels - 1);
+
+      for (unsigned int i = 0; i < mg_levels - 1; ++i)
+        {
+          triangulations[i] = std::make_unique<
+            parallel::fullydistributed::Triangulation<dim, dim>>(comm);
+          dealii::ContinuousAggloUtils::
+            create_distributed_tria_from_local_boxes(*triangulations[i],
+                                                     local_boxes_per_level[i],
+                                                     comm);
+          support_dof_handlers[i] =
+            std::make_unique<DoFHandler<dim>>(*triangulations[i]);
+
+          FE_DGQ<dim> fe_dgq(coarse_space_degrees[i]);
+          support_dof_handlers[i]->distribute_dofs(fe_dgq);
+        }
+
+      injection_matrices.clear();
+      injection_sparsity_patterns.clear();
+      injection_matrices.resize(mg_levels - 1);
+      injection_sparsity_patterns.resize(mg_levels - 1);
+
+      for (unsigned int j = 0; j < mg_levels - 2; ++j)
+        dealii::ContinuousAggloUtils::fill_injection_matrix(
+          *support_dof_handlers[j],
+          *support_dof_handlers[j + 1],
+          injection_sparsity_patterns[j],
+          injection_matrices[j],
+          local_hierarchies_per_level[j],
+          local_boxes_per_level[j],
+          local_boxes_per_level[j + 1],
+          local_tree_lvls - mg_levels + 1 + j);
+
+      // We now have to fill the last injection matrix
+      {
+        CellsAgglomerator<dim, decltype(local_tree)> agglomerator{
+          local_tree, local_tree_lvls};
+
+        std::vector<
+          std::vector<typename Triangulation<dim>::active_cell_iterator>>
+          agglomerates = agglomerator.extract_agglomerates();
+
+        FE_DGQ<dim> fe_dgq(coarse_space_degrees[mg_levels - 2]);
+
+        std::vector<types::global_dof_index> dof_indices_agglo_tria(
+          fe_dgq.n_dofs_per_cell());
+        std::vector<types::global_dof_index> local_dof_indices_agglo_tria;
+        local_dof_indices_agglo_tria.reserve(fe_dgq.n_dofs_per_cell());
+
+        std::vector<types::global_dof_index> fine_dof_indices(
+          fine_dh.get_fe().n_dofs_per_cell());
+        std::vector<types::global_dof_index>
+          local_fine_dof_indices; // i need the local to filter out the ghost
+                                  // dofs
+        local_fine_dof_indices.reserve(fine_dof_indices.size());
+
+        const IndexSet &locally_owned_dofs_coarse =
+          support_dof_handlers[mg_levels - 2]->locally_owned_dofs();
+        const IndexSet &locally_owned_dofs_fine = fine_dh.locally_owned_dofs();
+
+        injection_sparsity_patterns[mg_levels - 2].reinit(
+          locally_owned_dofs_fine, locally_owned_dofs_coarse, comm);
+
+        IndexSet assigned_dofs;
+        assigned_dofs = locally_owned_dofs_fine;
+        assigned_dofs
+          .clear(); // to track which fine dofs have been assigned to an agglo
+
+        // I am not 100% sure this is ok, but since active_cell_index() is local
+        // this should be ok for the agglomerates
+        for (const auto &cell :
+             support_dof_handlers[mg_levels - 2]->active_cell_iterators())
+          if (cell->is_locally_owned())
+            {
+              cell->get_dof_indices(dof_indices_agglo_tria);
+              local_dof_indices_agglo_tria.clear();
+              for (const auto &idx : dof_indices_agglo_tria)
+                if (locally_owned_dofs_coarse.is_element(idx))
+                  local_dof_indices_agglo_tria.push_back(idx);
+
+              for (const auto &child_cell :
+                   agglomerates[cell->active_cell_index()])
+                {
+                  const auto child_cell_dh =
+                    child_cell->as_dof_handler_iterator(fine_dh);
+
+                  child_cell_dh->get_dof_indices(fine_dof_indices);
+                  local_fine_dof_indices.clear();
+                  for (const auto &idx : fine_dof_indices)
+                    if (locally_owned_dofs_fine.is_element(idx))
+                      local_fine_dof_indices.push_back(idx);
+
+                  for (const auto &fine_dof_idx : local_fine_dof_indices)
+                    {
+                      if (assigned_dofs.is_element(fine_dof_idx))
+                        continue;
+                      else
+                        {
+                          injection_sparsity_patterns[mg_levels - 2]
+                            .add_entries(fine_dof_idx,
+                                         local_dof_indices_agglo_tria.begin(),
+                                         local_dof_indices_agglo_tria.end());
+                          assigned_dofs.add_index(fine_dof_idx);
+                        }
+                    }
+                }
+            }
+
+        injection_sparsity_patterns[mg_levels - 2].compress();
+        injection_matrices[mg_levels - 2].reinit(
+          injection_sparsity_patterns[mg_levels - 2]);
+
+        AffineConstraints<double> dummy_constraints; // for loc2glob
+        assigned_dofs.clear();                       // reset for filling matrix
+
+        std::vector<Point<dim>> unit_support_points =
+          fine_dh.get_fe().get_unit_support_points();
+
+        for (const auto &cell :
+             support_dof_handlers[mg_levels - 2]->active_cell_iterators())
+          if (cell->is_locally_owned())
+            {
+              cell->get_dof_indices(dof_indices_agglo_tria);
+              local_dof_indices_agglo_tria.clear();
+              for (const auto &idx : dof_indices_agglo_tria)
+                if (locally_owned_dofs_coarse.is_element(idx))
+                  local_dof_indices_agglo_tria.push_back(idx);
+
+              const BoundingBox<dim> &coarse_box =
+                local_boxes_per_level[mg_levels - 2][cell->active_cell_index()];
+
+              std::vector<Point<dim>> fine_support_points;
+              fine_support_points.reserve(
+                unit_support_points.size() *
+                agglomerates[cell->active_cell_index()].size());
+
+              std::vector<types::global_dof_index> actual_fine_dof_indices;
+
+              actual_fine_dof_indices.reserve(
+                unit_support_points.size() *
+                agglomerates[cell->active_cell_index()].size());
+
+              for (const auto &child_cell :
+                   agglomerates[cell->active_cell_index()])
+                {
+                  const auto child_cell_dh =
+                    child_cell->as_dof_handler_iterator(fine_dh);
+
+                  child_cell_dh->get_dof_indices(fine_dof_indices);
+                  local_fine_dof_indices.clear();
+                  std::vector<unsigned int> non_ghost_counter;
+                  unsigned int              ctr = 0;
+                  for (const auto &idx : fine_dof_indices)
+                    {
+                      if (locally_owned_dofs_fine.is_element(idx))
+                        {
+                          local_fine_dof_indices.push_back(idx);
+                          non_ghost_counter.push_back(ctr);
+                        }
+                      ctr++;
+                    }
+
+                  unsigned int find_dof_counter = 0;
+                  for (const auto &fine_dof_idx : local_fine_dof_indices)
+                    {
+                      if (!assigned_dofs.is_element(fine_dof_idx))
+                        {
+                          assigned_dofs.add_index(fine_dof_idx);
+                          actual_fine_dof_indices.push_back(fine_dof_idx);
+                          Point<dim> real_p =
+                            mapping.transform_unit_to_real_cell(
+                              child_cell,
+                              unit_support_points
+                                [non_ghost_counter[find_dof_counter]]);
+                          fine_support_points.push_back(real_p);
+                        }
+                      find_dof_counter++;
+                    }
+                }
+              FullMatrix<double> local_matrix(
+                fine_support_points.size(),
+                local_dof_indices_agglo_tria.size());
+
+              local_matrix = 0.0;
+
+              for (unsigned int i = 0; i < fine_support_points.size(); ++i)
+                {
+                  const Point<dim> p =
+                    coarse_box.real_to_unit(fine_support_points[i]);
+                  for (unsigned int j = 0;
+                       j < local_dof_indices_agglo_tria.size();
+                       ++j)
+                    {
+                      local_matrix(i, j) = fe_dgq.shape_value(j, p);
+                    }
+                }
+
+              dummy_constraints.distribute_local_to_global(
+                local_matrix,
+                actual_fine_dof_indices,
+                local_dof_indices_agglo_tria,
+                injection_matrices[mg_levels - 2]);
+            }
+        injection_matrices[mg_levels - 2].compress(VectorOperation::add);
+      }
+    }
   } // namespace CellsAgglo
 } // namespace dealii::ContinuousAggloUtils
 

--- a/include/continuous_agglo_utils.h
+++ b/include/continuous_agglo_utils.h
@@ -24,6 +24,7 @@
 #include <deal.II/dofs/dof_tools.h>
 
 #include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/mapping.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_description.h>
@@ -365,28 +366,19 @@ namespace dealii::ContinuousAggloUtils
     }
 
 
-    // Note for me: we suppose that the support points are ordered in the same
-    // way as the DoFs numbering of the finest level, so that we can use the
-    // support points to construct the agglomeration hierarchy. This is not a
-    // strong assumption, since we can always reorder the support points to
-    // match the DoF ordering. Deal.II automatically does this.
+    // Note for me:
     // This function is not supporting multiple DoFs insisting on the same
     // support point as it uses the size of the vector of support points to
     // determine the number of DoFs on the finest level.
-    template <int          dim,
-              unsigned int rtree_m,
-              unsigned int rtree_M,
-              typename MatrixType,
-              typename SparsityPatternType,
-              typename VectorType>
+    template <int dim, unsigned int rtree_m, unsigned int rtree_M>
     void
     agglomerate_and_compute_injection_matrices(
-      const VectorType                 &support_points_vector,
-      const bool                        skip_leaves,
-      std::vector<MatrixType>          &injection_matrices,
-      std::vector<SparsityPatternType> &injection_sparsity_patterns,
-      const unsigned int                mg_levels,
-      const std::vector<unsigned int>  &coarse_space_degrees,
+      const std::vector<Point<dim>>     &support_points_vector,
+      const bool                         skip_leaves,
+      std::vector<SparseMatrix<double>> &injection_matrices,
+      std::vector<SparsityPattern>      &injection_sparsity_patterns,
+      const unsigned int                 mg_levels,
+      const std::vector<unsigned int>   &coarse_space_degrees,
       std::vector<std::unique_ptr<Triangulation<dim>>> &triangulations,
       std::vector<std::unique_ptr<DoFHandler<dim>>>    &support_dof_handlers)
     {
@@ -398,183 +390,227 @@ namespace dealii::ContinuousAggloUtils
              ExcMessage(
                "The size of coarse_space_degrees should be mg_levels - 1."));
 
-      if constexpr (std::is_same_v<MatrixType, SparseMatrix<double>> &&
-                    std::is_same_v<SparsityPatternType, SparsityPattern>)
+      auto tree = pack_rtree_of_indices<bgi::rstar<rtree_M, rtree_m>>(
+        support_points_vector);
+
+      unsigned int tree_lvls = n_levels(tree);
+      if (skip_leaves)
+        tree_lvls = std::max<unsigned int>(tree_lvls - 1, 0);
+
+      Assert(
+        tree_lvls > 1,
+        ExcMessage(
+          "The tree should have at least two levels to perform agglomeration."));
+
+      Assert(mg_levels <= tree_lvls + 1,
+             ExcMessage("You are trying to use " + std::to_string(mg_levels) +
+                        " levels, but the hierarchy can only have " +
+                        std::to_string(tree_lvls + 1) + " levels."));
+
+      injection_matrices.resize(mg_levels - 1);
+
+      std::vector<std::vector<BoundingBox<dim>>> boxes_per_level(mg_levels - 1);
+      std::vector<
+        std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+                 std::vector<types::global_cell_index>>>
+        hierarchies_per_level(mg_levels - 2);
+
+      unsigned int j = 0;
+      for (unsigned int i = tree_lvls - mg_levels + 1; i < tree_lvls; ++i)
         {
-          auto tree = pack_rtree_of_indices<bgi::rstar<rtree_M, rtree_m>>(
-            support_points_vector);
+          CellsAgglomerator<dim, decltype(tree), true> agglomerator{tree,
+                                                                    i + 1};
+          const std::vector<std::vector<types::global_dof_index>> agglomerates =
+            agglomerator.extract_agglomerates();
+          boxes_per_level[j].reserve(agglomerates.size());
 
-          unsigned int tree_lvls = n_levels(tree);
-          if (skip_leaves)
-            tree_lvls = std::max<unsigned int>(tree_lvls - 1, 0);
+          // Store hierarchy for reuse later (not needed for last level)
+          if (j < mg_levels - 2)
+            hierarchies_per_level[j] = agglomerator.get_hierarchy();
 
-          Assert(
-            tree_lvls > 1,
-            ExcMessage(
-              "The tree should have at least two levels to perform agglomeration."));
-
-          Assert(mg_levels <= tree_lvls + 1,
-                 ExcMessage("You are trying to use " +
-                            std::to_string(mg_levels) +
-                            " levels, but the hierarchy can only have " +
-                            std::to_string(tree_lvls + 1) + " levels."));
-
-          injection_matrices.resize(mg_levels - 1);
-
-          std::vector<std::vector<BoundingBox<dim>>> boxes_per_level(mg_levels -
-                                                                     1);
-          std::vector<std::map<
-            std::pair<types::global_cell_index, types::global_cell_index>,
-            std::vector<types::global_cell_index>>>
-            hierarchies_per_level(mg_levels - 2);
-
-          unsigned int j = 0;
-          for (unsigned int i = tree_lvls - mg_levels + 1; i < tree_lvls; ++i)
+          for (const std::vector<types::global_dof_index> &agglo : agglomerates)
             {
-              CellsAgglomerator<dim, decltype(tree), true> agglomerator{tree,
-                                                                        i + 1};
-              const std::vector<std::vector<types::global_dof_index>>
-                agglomerates = agglomerator.extract_agglomerates();
-              boxes_per_level[j].reserve(agglomerates.size());
+              std::vector<Point<dim>> points_in_current_agglomerate;
+              points_in_current_agglomerate.reserve(agglo.size());
 
-              // Store hierarchy for reuse later (not needed for last level)
-              if (j < mg_levels - 2)
-                hierarchies_per_level[j] = agglomerator.get_hierarchy();
+              for (const auto &index : agglo)
+                points_in_current_agglomerate.push_back(
+                  support_points_vector[index]);
 
-              for (const std::vector<types::global_dof_index> &agglo :
-                   agglomerates)
-                {
-                  std::vector<Point<dim>> points_in_current_agglomerate;
-                  points_in_current_agglomerate.reserve(agglo.size());
-
-                  for (const auto &index : agglo)
-                    points_in_current_agglomerate.push_back(
-                      support_points_vector[index]);
-
-                  BoundingBox<dim> bbox{points_in_current_agglomerate};
-                  boxes_per_level[j].emplace_back(
-                    points_in_current_agglomerate);
-                }
-              j++;
+              BoundingBox<dim> bbox{points_in_current_agglomerate};
+              boxes_per_level[j].emplace_back(points_in_current_agglomerate);
             }
+          j++;
+        }
 
-          triangulations.resize(mg_levels - 1);
-          support_dof_handlers.resize(mg_levels - 1);
+      triangulations.resize(mg_levels - 1);
+      support_dof_handlers.resize(mg_levels - 1);
 
-          for (unsigned int i = 0; i < mg_levels - 1; ++i)
-            {
-              triangulations[i] = std::make_unique<Triangulation<dim>>();
-              create_triangulation_from_bounding_boxes(*triangulations[i],
-                                                       boxes_per_level[i]);
-              support_dof_handlers[i] =
-                std::make_unique<DoFHandler<dim>>(*triangulations[i]);
+      for (unsigned int i = 0; i < mg_levels - 1; ++i)
+        {
+          triangulations[i] = std::make_unique<Triangulation<dim>>();
+          create_triangulation_from_bounding_boxes(*triangulations[i],
+                                                   boxes_per_level[i]);
+          support_dof_handlers[i] =
+            std::make_unique<DoFHandler<dim>>(*triangulations[i]);
 
-              FE_DGQ<dim> fe_dgq(coarse_space_degrees[i]);
-              support_dof_handlers[i]->distribute_dofs(fe_dgq);
-            }
-          injection_matrices.clear();
-          injection_sparsity_patterns.clear();
-          injection_matrices.resize(mg_levels - 1);
-          injection_sparsity_patterns.resize(mg_levels - 1);
+          FE_DGQ<dim> fe_dgq(coarse_space_degrees[i]);
+          support_dof_handlers[i]->distribute_dofs(fe_dgq);
+        }
+      injection_matrices.clear();
+      injection_sparsity_patterns.clear();
+      injection_matrices.resize(mg_levels - 1);
+      injection_sparsity_patterns.resize(mg_levels - 1);
 
-          for (unsigned int j = 0; j < mg_levels - 2; ++j)
-            fill_injection_matrix(*support_dof_handlers[j],
-                                  *support_dof_handlers[j + 1],
-                                  injection_sparsity_patterns[j],
-                                  injection_matrices[j],
-                                  hierarchies_per_level[j],
-                                  boxes_per_level[j],
-                                  boxes_per_level[j + 1],
-                                  tree_lvls - mg_levels + 1 + j);
+      for (unsigned int j = 0; j < mg_levels - 2; ++j)
+        fill_injection_matrix(*support_dof_handlers[j],
+                              *support_dof_handlers[j + 1],
+                              injection_sparsity_patterns[j],
+                              injection_matrices[j],
+                              hierarchies_per_level[j],
+                              boxes_per_level[j],
+                              boxes_per_level[j + 1],
+                              tree_lvls - mg_levels + 1 + j);
 
-          // We now have to fill the last injection matrix
+      // We now have to fill the last injection matrix
+      {
+        CellsAgglomerator<dim, decltype(tree), true> agglomerator{tree,
+                                                                  tree_lvls};
+
+        const std::vector<std::vector<types::global_dof_index>> agglomerates =
+          agglomerator.extract_agglomerates();
+
+        FE_DGQ<dim> fe_dgq(coarse_space_degrees[mg_levels - 2]);
+
+        std::vector<types::global_dof_index> dof_indices_agglo_tria(
+          fe_dgq.n_dofs_per_cell());
+
+        DynamicSparsityPattern dsp_agglo_to_original_tria;
+        dsp_agglo_to_original_tria.reinit(
+          support_points_vector
+            .size(), // should be equal to the number of DoFs if only  1
+                     // DoFs insist per support point
+          support_dof_handlers[mg_levels - 2]->n_dofs());
+
+        unsigned int agglo_index = 0;
+        for (const auto &cell :
+             support_dof_handlers[mg_levels - 2]->active_cell_iterators())
           {
-            CellsAgglomerator<dim, decltype(tree), true> agglomerator{
-              tree, tree_lvls};
+            cell->get_dof_indices(dof_indices_agglo_tria);
 
-            const std::vector<std::vector<types::global_dof_index>>
-              agglomerates = agglomerator.extract_agglomerates();
+            for (const types::global_dof_index dof_idx :
+                 agglomerates[agglo_index])
+              dsp_agglo_to_original_tria.add_entries(
+                dof_idx,
+                dof_indices_agglo_tria.begin(),
+                dof_indices_agglo_tria.end());
 
-            FE_DGQ<dim> fe_dgq(coarse_space_degrees[mg_levels - 2]);
-
-            std::vector<types::global_dof_index> dof_indices_agglo_tria(
-              fe_dgq.n_dofs_per_cell());
-
-            DynamicSparsityPattern dsp_agglo_to_original_tria;
-            dsp_agglo_to_original_tria.reinit(
-              support_points_vector
-                .size(), // should be equal to the number of DoFs if only  1
-                         // DoFs insist per support point
-              support_dof_handlers[mg_levels - 2]->n_dofs());
-
-            unsigned int agglo_index = 0;
-            for (const auto &cell :
-                 support_dof_handlers[mg_levels - 2]->active_cell_iterators())
-              {
-                cell->get_dof_indices(dof_indices_agglo_tria);
-
-                for (const types::global_dof_index dof_idx :
-                     agglomerates[agglo_index])
-                  dsp_agglo_to_original_tria.add_entries(
-                    dof_idx,
-                    dof_indices_agglo_tria.begin(),
-                    dof_indices_agglo_tria.end());
-
-                agglo_index++;
-              }
-
-            injection_sparsity_patterns[mg_levels - 2].copy_from(
-              dsp_agglo_to_original_tria);
-            injection_matrices[mg_levels - 2].reinit(
-              injection_sparsity_patterns[mg_levels - 2]);
-
-            AffineConstraints<double> dummy_constraints; // for loc2glob
-
-            agglo_index = 0;
-            for (const auto &cell :
-                 support_dof_handlers[mg_levels - 2]->active_cell_iterators())
-              {
-                cell->get_dof_indices(dof_indices_agglo_tria);
-
-                const BoundingBox<dim> &coarse_box =
-                  boxes_per_level[mg_levels - 2][cell->active_cell_index()];
-
-                const unsigned int n_fine_support_points =
-                  agglomerates[agglo_index].size();
-
-                const std::vector<types::global_dof_index> fine_indices =
-                  agglomerates[agglo_index];
-
-                FullMatrix<double> local_matrix(n_fine_support_points,
-                                                fe_dgq.n_dofs_per_cell());
-                local_matrix = 0.0;
-
-                for (unsigned int i = 0; i < n_fine_support_points; ++i)
-                  {
-                    const Point<dim> p = coarse_box.real_to_unit(
-                      support_points_vector[fine_indices[i]]);
-
-                    for (unsigned int j = 0; j < dof_indices_agglo_tria.size();
-                         ++j)
-                      local_matrix(i, j) = fe_dgq.shape_value(j, p);
-                  }
-
-                dummy_constraints.distribute_local_to_global(
-                  local_matrix,
-                  fine_indices,
-                  dof_indices_agglo_tria,
-                  injection_matrices[mg_levels - 2]);
-
-                ++agglo_index;
-              }
+            agglo_index++;
           }
-        }
-      else
-        {
-          Assert(false, ExcNotImplemented());
-        }
+
+        injection_sparsity_patterns[mg_levels - 2].copy_from(
+          dsp_agglo_to_original_tria);
+        injection_matrices[mg_levels - 2].reinit(
+          injection_sparsity_patterns[mg_levels - 2]);
+
+        AffineConstraints<double> dummy_constraints; // for loc2glob
+
+        agglo_index = 0;
+        for (const auto &cell :
+             support_dof_handlers[mg_levels - 2]->active_cell_iterators())
+          {
+            cell->get_dof_indices(dof_indices_agglo_tria);
+
+            const BoundingBox<dim> &coarse_box =
+              boxes_per_level[mg_levels - 2][cell->active_cell_index()];
+
+            const unsigned int n_fine_support_points =
+              agglomerates[agglo_index].size();
+
+            const std::vector<types::global_dof_index> fine_indices =
+              agglomerates[agglo_index];
+
+            FullMatrix<double> local_matrix(n_fine_support_points,
+                                            fe_dgq.n_dofs_per_cell());
+            local_matrix = 0.0;
+
+            for (unsigned int i = 0; i < n_fine_support_points; ++i)
+              {
+                const Point<dim> p = coarse_box.real_to_unit(
+                  support_points_vector[fine_indices[i]]);
+
+                for (unsigned int j = 0; j < dof_indices_agglo_tria.size(); ++j)
+                  local_matrix(i, j) = fe_dgq.shape_value(j, p);
+              }
+
+            dummy_constraints.distribute_local_to_global(
+              local_matrix,
+              fine_indices,
+              dof_indices_agglo_tria,
+              injection_matrices[mg_levels - 2]);
+
+            ++agglo_index;
+          }
+      }
     }
 
+
+
+    // For the parallel version there are way too many issues with sending just
+    // the map. Using the DoFHandler of the fine original tria is easier. This
+    // also means that we need a mapping I am using a generic mapping since i
+    // don't know if there are weird geometries.
+    template <int dim, unsigned int rtree_m, unsigned int rtree_M>
+    void
+    parallel_agglomerate_and_compute_injection_matrices(
+      const DoFHandler<dim>                       &fine_dh,
+      const Mapping<dim, dim>                     &mapping,
+      const bool                                   skip_leaves,
+      std::vector<TrilinosWrappers::SparseMatrix> &injection_matrices,
+      std::vector<TrilinosWrappers::SparsityPattern>
+                                      &injection_sparsity_patterns,
+      const unsigned int               mg_levels,
+      const std::vector<unsigned int> &coarse_space_degrees,
+      std::vector<
+        std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
+                                                    &triangulations,
+      std::vector<std::unique_ptr<DoFHandler<dim>>> &support_dof_handlers)
+    {
+      namespace bgi = boost::geometry::index;
+
+      MPI_Comm comm = fine_dh.get_mpi_communicator();
+
+      Assert(mg_levels > 1,
+             ExcMessage("At least two levels are needed for agglomeration."));
+      Assert(coarse_space_degrees.size() == mg_levels - 1,
+             ExcMessage(
+               "The size of coarse_space_degrees should be mg_levels - 1."));
+
+      std::map<types::global_dof_index, Point<dim>> support_points_map =
+        DoFTools::map_dofs_to_support_points(mapping, fine_dh);
+
+      const unsigned int locally_owned_dofs_number =
+        fine_dh.locally_owned_dofs().n_elements();
+      const unsigned int global_dofs_number = fine_dh.n_dofs();
+
+      const IndexSet &locally_owned_dofs_set = fine_dh.locally_owned_dofs();
+      std::vector<types::global_dof_index> local_dof_indices;
+      std::vector<Point<dim>>              local_support_points_vector;
+      local_support_points_vector.reserve(locally_owned_dofs_number);
+      local_dof_indices.reserve(locally_owned_dofs_number);
+      for (const auto &entry : support_points_map)
+        if (locally_owned_dofs_set.is_element(entry.first))
+          {
+            local_dof_indices.push_back(entry.first);
+            local_support_points_vector.push_back(entry.second);
+          }
+
+      auto local_tree = pack_rtree_of_indices<bgi::rstar<rtree_M, rtree_m>>(
+        local_support_points_vector);
+
+      // After setting up the tree we need to deal with the fact that local
+      // trees might have different heights
+    }
   } // namespace PointsAgglo
   namespace CellsAgglo
   {}

--- a/include/continuous_agglo_utils.h
+++ b/include/continuous_agglo_utils.h
@@ -37,8 +37,6 @@
 
 namespace dealii::ContinuousAggloUtils
 {
-  // TODO: For now these are all sequential implementations, need to check what
-  // is different for the parallel implementation
   namespace PointsAgglo
   {
     template <int dim>
@@ -50,7 +48,6 @@ namespace dealii::ContinuousAggloUtils
       const unsigned int n_boxes          = boxes.size();
       const unsigned int vertices_per_box = (dim == 2) ? 4 : 8;
 
-      // Pre-allocate space
       std::vector<Point<dim>>    vertices;
       std::vector<CellData<dim>> cells;
       vertices.reserve(n_boxes * vertices_per_box);
@@ -145,7 +142,218 @@ namespace dealii::ContinuousAggloUtils
       const std::vector<BoundingBox<dim>>      &coarse_level_boxes,
       const std::vector<BoundingBox<dim>>      &fine_level_boxes,
       const unsigned int                        coarse_level)
-    {}
+    {
+      if constexpr (std::is_same_v<MatrixType, SparseMatrix<double>> &&
+                    std::is_same_v<SparsityPatternType, SparsityPattern>)
+        {
+          const FiniteElement<dim> &fe_dgq = coarse_dof_handler.get_fe();
+          const Triangulation<dim> &fine_tria =
+            fine_dof_handler.get_triangulation();
+          AffineConstraints<double> constraints;
+
+          const std::vector<Point<dim>> &unit_support_points =
+            fe_dgq.get_unit_support_points();
+
+          DynamicSparsityPattern dsp;
+          dsp.reinit(fine_dof_handler.n_dofs(), coarse_dof_handler.n_dofs());
+          AffineConstraints<double>            dummy_constraints;
+          std::vector<types::global_dof_index> coarse_dof_indices(
+            fe_dgq.n_dofs_per_cell());
+          std::vector<types::global_dof_index> fine_dof_indices(
+            fe_dgq.n_dofs_per_cell());
+
+
+          // Loop over coarse tria and print DoFs
+          for (const auto &cell : coarse_dof_handler.active_cell_iterators())
+            {
+              cell->get_dof_indices(coarse_dof_indices);
+
+              std::vector<types::global_dof_index> indices_of_children =
+                parent_to_child_info.at(
+                  {cell->active_cell_index(), coarse_level + 1});
+
+              for (const auto &idx : indices_of_children)
+                {
+                  DoFAccessor<dim, dim, dim, false> dof_accessor_child(
+                    &fine_tria, 0, idx, &fine_dof_handler);
+                  dof_accessor_child.get_dof_indices(fine_dof_indices);
+
+                  for (const types::global_dof_index row : fine_dof_indices)
+                    dsp.add_entries(row,
+                                    coarse_dof_indices.begin(),
+                                    coarse_dof_indices.end());
+                }
+            }
+
+          // Filled sparsity pattern
+          sparsity_pattern.copy_from(dsp);
+
+          // Now onto filling the matrix...
+          transfer_matrix.reinit(sparsity_pattern);
+          const unsigned int dofs_per_cell = fe_dgq.n_dofs_per_cell();
+          FullMatrix<double> local_matrix(dofs_per_cell, dofs_per_cell);
+
+          for (const auto &cell : coarse_dof_handler.active_cell_iterators())
+            {
+              cell->get_dof_indices(coarse_dof_indices);
+
+              const BoundingBox<dim> &coarse_box =
+                coarse_level_boxes[cell->active_cell_index()];
+
+              std::vector<types::global_dof_index> indices_of_children =
+                parent_to_child_info.at(
+                  {cell->active_cell_index(), coarse_level + 1});
+
+              for (const auto &idx : indices_of_children)
+                {
+                  DoFAccessor<dim, dim, dim, false> dof_accessor_child(
+                    &fine_tria, 0, idx, &fine_dof_handler);
+                  dof_accessor_child.get_dof_indices(fine_dof_indices);
+                  const BoundingBox<dim> &fine_bbox = fine_level_boxes[idx];
+
+                  local_matrix = 0.;
+
+                  // Now we plot the fine support points
+                  std::vector<Point<dim>> real_qpoints;
+                  real_qpoints.reserve(unit_support_points.size());
+                  for (const Point<dim> &p : unit_support_points)
+                    real_qpoints.push_back(fine_bbox.unit_to_real(p));
+
+                  for (unsigned int i = 0; i < coarse_dof_indices.size(); ++i)
+                    {
+                      const auto &p = coarse_box.real_to_unit(real_qpoints[i]);
+                      for (unsigned int j = 0; j < fine_dof_indices.size(); ++j)
+                        {
+                          local_matrix(i, j) = fe_dgq.shape_value(j, p);
+                        }
+                    }
+
+                  constraints.distribute_local_to_global(local_matrix,
+                                                         fine_dof_indices,
+                                                         coarse_dof_indices,
+                                                         transfer_matrix);
+                }
+            }
+        }
+      else if constexpr (std::is_same_v<MatrixType,
+                                        TrilinosWrappers::SparseMatrix> &&
+                         std::is_same_v<SparsityPatternType,
+                                        TrilinosWrappers::SparsityPattern>)
+        {
+          const FiniteElement<dim> &fe_dgq = coarse_dof_handler.get_fe();
+          const Triangulation<dim> &fine_tria =
+            fine_dof_handler.get_triangulation();
+
+          // Check that the triangulation is distributed
+          Assert(
+            (dynamic_cast<
+               const parallel::fullydistributed::Triangulation<dim, dim> *>(
+               &fine_tria) != nullptr),
+            ExcMessage(
+              "The triangulation should be a parallel::fullydistributed::Triangulation."));
+
+          const MPI_Comm comm = fine_tria.get_mpi_communicator();
+
+          // just for local2global
+          AffineConstraints<double> constraints;
+          constraints.close();
+
+          const IndexSet &owned_fine = fine_dof_handler.locally_owned_dofs();
+          const IndexSet &owned_coarse =
+            coarse_dof_handler.locally_owned_dofs();
+
+          sparsity_pattern.reinit(owned_fine, owned_coarse, comm);
+
+          std::vector<types::global_dof_index> coarse_dof_indices(
+            fe_dgq.n_dofs_per_cell());
+          std::vector<types::global_dof_index> fine_dof_indices(
+            fe_dgq.n_dofs_per_cell());
+
+          for (const auto &cell : coarse_dof_handler.active_cell_iterators())
+            if (cell->is_locally_owned())
+              {
+                cell->get_dof_indices(coarse_dof_indices);
+
+                // std::cout << "Debug: Coarse cell " <<
+                // cell->active_cell_index()
+                //           << " with DoFs: ";
+                // for (const auto &idx : coarse_dof_indices)
+                //   std::cout << idx << " ";
+                // std::cout << std::endl;
+
+                std::vector<types::global_dof_index> indices_of_children =
+                  parent_to_child_info.at(
+                    {cell->active_cell_index(), coarse_level + 1});
+
+                for (const auto child_idx : indices_of_children)
+                  {
+                    DoFAccessor<dim, dim, dim, false> child_accessor(
+                      &fine_tria, 0, child_idx, &fine_dof_handler);
+                    child_accessor.get_dof_indices(fine_dof_indices);
+
+                    for (const auto row : fine_dof_indices)
+                      sparsity_pattern.add_entries(row,
+                                                   coarse_dof_indices.begin(),
+                                                   coarse_dof_indices.end());
+                  }
+              }
+
+          sparsity_pattern.compress();
+          transfer_matrix.reinit(sparsity_pattern);
+
+          FullMatrix<double> local_matrix(fe_dgq.n_dofs_per_cell(),
+                                          fe_dgq.n_dofs_per_cell());
+          const auto &unit_support_points = fe_dgq.get_unit_support_points();
+
+          for (const auto &cell : coarse_dof_handler.active_cell_iterators())
+            if (cell->is_locally_owned())
+              {
+                cell->get_dof_indices(coarse_dof_indices);
+                const BoundingBox<dim> &coarse_box =
+                  coarse_level_boxes[cell->active_cell_index()];
+
+                std::vector<types::global_dof_index> indices_of_children =
+                  parent_to_child_info.at(
+                    {cell->active_cell_index(), coarse_level + 1});
+
+                for (const auto child_idx : indices_of_children)
+                  {
+                    DoFAccessor<dim, dim, dim, false> child_accessor(
+                      &fine_tria, 0, child_idx, &fine_dof_handler);
+                    child_accessor.get_dof_indices(fine_dof_indices);
+
+                    const BoundingBox<dim> &fine_box =
+                      fine_level_boxes[child_idx];
+                    local_matrix = 0.0;
+
+                    std::vector<Point<dim>> real_qpoints;
+                    real_qpoints.reserve(unit_support_points.size());
+                    for (const auto &p : unit_support_points)
+                      real_qpoints.push_back(fine_box.unit_to_real(p));
+
+                    for (unsigned int i = 0; i < coarse_dof_indices.size(); ++i)
+                      {
+                        const Point<dim> p =
+                          coarse_box.real_to_unit(real_qpoints[i]);
+                        for (unsigned int j = 0; j < fine_dof_indices.size();
+                             ++j)
+                          local_matrix(i, j) = fe_dgq.shape_value(j, p);
+                      }
+
+                    constraints.distribute_local_to_global(local_matrix,
+                                                           fine_dof_indices,
+                                                           coarse_dof_indices,
+                                                           transfer_matrix);
+                  }
+              }
+
+          transfer_matrix.compress(VectorOperation::add);
+        }
+      else
+        {
+          Assert(false, ExcNotImplemented());
+        }
+    }
 
 
     // Note for me: we suppose that the support points are ordered in the same
@@ -155,19 +363,22 @@ namespace dealii::ContinuousAggloUtils
     // match the DoF ordering. Deal.II automatically does this.
     template <int dim,
               typename MatrixType,
+              typename SparsityPatternType,
               typename VectorType,
               unsigned int rtree_m,
               unsigned int rtree_M>
     void
     agglomerate_and_compute_injection_matrices(
-      VectorType              &support_points_vector,
-      bool                     skip_leaves,
-      std::vector<MatrixType> &injection_matrices,
-      unsigned int             mg_levels)
+      VectorType                       &support_points_vector,
+      bool                              skip_leaves,
+      std::vector<MatrixType>          &injection_matrices,
+      std::vector<SparsityPatternType> &injection_sparsity_patterns,
+      unsigned int                      mg_levels)
     {
       namespace bgi = boost::geometry::index;
 
-      if constexpr (std::is_same_v<MatrixType, SparseMatrix<double>>)
+      if constexpr (std::is_same_v<MatrixType, SparseMatrix<double>> &&
+                    std::is_same_v<SparsityPatternType, SparsityPattern>)
         {
           auto tree = pack_rtree_of_indices<bgi::rstar<rtree_m, rtree_M>>(
             support_points_vector);

--- a/include/continuous_agglo_utils.h
+++ b/include/continuous_agglo_utils.h
@@ -386,7 +386,9 @@ namespace dealii::ContinuousAggloUtils
       std::vector<MatrixType>          &injection_matrices,
       std::vector<SparsityPatternType> &injection_sparsity_patterns,
       const unsigned int                mg_levels,
-      const std::vector<unsigned int>  &coarse_space_degrees)
+      const std::vector<unsigned int>  &coarse_space_degrees,
+      std::vector<std::unique_ptr<Triangulation<dim>>> &triangulations,
+      std::vector<std::unique_ptr<DoFHandler<dim>>>    &support_dof_handlers)
     {
       namespace bgi = boost::geometry::index;
 
@@ -456,21 +458,19 @@ namespace dealii::ContinuousAggloUtils
               j++;
             }
 
-          std::vector<std::unique_ptr<Triangulation<dim>>> triangulations(
-            mg_levels - 1);
-          std::vector<std::unique_ptr<DoFHandler<dim>>> support_DoFHandlers(
-            mg_levels - 1);
+          triangulations.resize(mg_levels - 1);
+          support_dof_handlers.resize(mg_levels - 1);
 
           for (unsigned int i = 0; i < mg_levels - 1; ++i)
             {
               triangulations[i] = std::make_unique<Triangulation<dim>>();
               create_triangulation_from_bounding_boxes(*triangulations[i],
                                                        boxes_per_level[i]);
-              support_DoFHandlers[i] =
+              support_dof_handlers[i] =
                 std::make_unique<DoFHandler<dim>>(*triangulations[i]);
 
               FE_DGQ<dim> fe_dgq(coarse_space_degrees[i]);
-              support_DoFHandlers[i]->distribute_dofs(fe_dgq);
+              support_dof_handlers[i]->distribute_dofs(fe_dgq);
             }
           injection_matrices.clear();
           injection_sparsity_patterns.clear();
@@ -478,8 +478,8 @@ namespace dealii::ContinuousAggloUtils
           injection_sparsity_patterns.resize(mg_levels - 1);
 
           for (unsigned int j = 0; j < mg_levels - 2; ++j)
-            fill_injection_matrix(*support_DoFHandlers[j],
-                                  *support_DoFHandlers[j + 1],
+            fill_injection_matrix(*support_dof_handlers[j],
+                                  *support_dof_handlers[j + 1],
                                   injection_sparsity_patterns[j],
                                   injection_matrices[j],
                                   hierarchies_per_level[j],
@@ -505,11 +505,11 @@ namespace dealii::ContinuousAggloUtils
               support_points_vector
                 .size(), // should be equal to the number of DoFs if only  1
                          // DoFs insist per support point
-              support_DoFHandlers[mg_levels - 2]->n_dofs());
+              support_dof_handlers[mg_levels - 2]->n_dofs());
 
             unsigned int agglo_index = 0;
             for (const auto &cell :
-                 support_DoFHandlers[mg_levels - 2]->active_cell_iterators())
+                 support_dof_handlers[mg_levels - 2]->active_cell_iterators())
               {
                 cell->get_dof_indices(dof_indices_agglo_tria);
 
@@ -532,7 +532,7 @@ namespace dealii::ContinuousAggloUtils
 
             agglo_index = 0;
             for (const auto &cell :
-                 support_DoFHandlers[mg_levels - 2]->active_cell_iterators())
+                 support_dof_handlers[mg_levels - 2]->active_cell_iterators())
               {
                 cell->get_dof_indices(dof_indices_agglo_tria);
 

--- a/test/polydeal/build_all_continuous_transfers.cc
+++ b/test/polydeal/build_all_continuous_transfers.cc
@@ -1,0 +1,170 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/point.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/vector.h>
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include "continuous_agglo_utils.h"
+
+static constexpr double       tolerance  = 1e-12;
+static constexpr unsigned int dim        = 2;
+using namespace dealii;
+
+int
+main()
+{
+  static constexpr unsigned int min_elem_per_node = 2;
+  static constexpr unsigned int max_elem_per_node = 4;
+  static constexpr unsigned int mg_levels         = 3;
+  static constexpr bool         skip_leaves       = true;
+
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, 0., 1.);
+  tria.refine_global(4);
+
+  DoFHandler<dim> dof_handler(tria);
+  FE_Q<dim>       fe(1);
+  dof_handler.distribute_dofs(fe);
+
+  std::vector<Point<dim>> support_points_vector(dof_handler.n_dofs());
+  MappingQ1<dim>          mapping;
+
+  DoFTools::map_dofs_to_support_points(mapping,
+                                       dof_handler,
+                                       support_points_vector);
+
+  std::vector<SparseMatrix<double>> injection_matrices;
+  std::vector<SparsityPattern>      injection_sparsity_patterns;
+  std::vector<unsigned int>         coarse_space_degrees(mg_levels - 1, 1);
+  std::vector<std::unique_ptr<Triangulation<dim>>> triangulations;
+  std::vector<std::unique_ptr<DoFHandler<dim>>>    support_dof_handlers;
+
+  ContinuousAggloUtils::PointsAgglo::
+    agglomerate_and_compute_injection_matrices<dim,
+                                               min_elem_per_node,
+                                               max_elem_per_node>(
+      support_points_vector,
+      skip_leaves,
+      injection_matrices,
+      injection_sparsity_patterns,
+      mg_levels,
+      coarse_space_degrees,
+      triangulations,
+      support_dof_handlers);
+
+  std::cout << "Built " << injection_matrices.size() << " injection matrices"
+            << std::endl;
+
+  for (unsigned int level = 0; level < injection_matrices.size(); ++level)
+    {
+      const auto &mat = injection_matrices[level];
+
+      std::vector<Point<dim>> coarse_support_points(
+        support_dof_handlers[level]->n_dofs());
+      DoFTools::map_dofs_to_support_points(mapping,
+                                           *support_dof_handlers[level],
+                                           coarse_support_points);
+
+      AssertThrow(mat.n() == coarse_support_points.size(),
+                  ExcDimensionMismatch(mat.n(), coarse_support_points.size()));
+
+      Vector<double> coarse_values(coarse_support_points.size());
+      for (unsigned int i = 0; i < coarse_values.size(); ++i)
+        coarse_values[i] =
+          coarse_support_points[i][0] + coarse_support_points[i][1];
+
+      if (level < mg_levels - 2)
+        {
+          std::vector<Point<dim>> fine_support_points(
+            support_dof_handlers[level + 1]->n_dofs());
+          DoFTools::map_dofs_to_support_points(
+            mapping, *support_dof_handlers[level + 1], fine_support_points);
+
+          AssertThrow(mat.m() == fine_support_points.size(),
+                      ExcDimensionMismatch(mat.m(),
+                                           fine_support_points.size()));
+
+          Vector<double> fine_values(fine_support_points.size());
+          for (unsigned int i = 0; i < fine_values.size(); ++i)
+            fine_values[i] =
+              fine_support_points[i][0] + fine_support_points[i][1];
+
+          Vector<double> transferred_values(fine_values.size());
+          mat.vmult(transferred_values, coarse_values);
+
+          transferred_values -= fine_values;
+          const double l2_error = transferred_values.l2_norm();
+
+          AssertThrow(
+            l2_error < tolerance,
+            ExcMessage(
+              "Agglomerated transfer " + std::to_string(level) +
+              " (coarse->fine) failed linear test with error " +
+              std::to_string(l2_error)));
+
+          std::cout << "Level " << level << " (" << mat.m() << " x " << mat.n()
+                    << "): L2 error = " << l2_error << std::endl;
+        }
+      else
+        {
+          AssertThrow(mat.m() == support_points_vector.size(),
+                      ExcDimensionMismatch(mat.m(),
+                                           support_points_vector.size()));
+
+          Vector<double> fine_values(support_points_vector.size());
+          for (unsigned int i = 0; i < fine_values.size(); ++i)
+            fine_values[i] =
+              support_points_vector[i][0] + support_points_vector[i][1];
+
+          Vector<double> transferred_values(fine_values.size());
+          mat.vmult(transferred_values, coarse_values);
+
+          transferred_values -= fine_values;
+          const double l2_error = transferred_values.l2_norm();
+
+          AssertThrow(
+            l2_error < tolerance,
+            ExcMessage(
+              "Final transfer (agglo->original) failed linear test with error " +
+              std::to_string(l2_error)));
+
+          std::cout << "Level " << level << " (" << mat.m() << " x " << mat.n()
+                    << "): L2 error = " << l2_error << " (agglo->original)"
+                    << std::endl;
+        }
+    }
+
+  std::cout << "All continuous transfer tests: OK" << std::endl;
+}

--- a/test/polydeal/build_all_continuous_transfers.cc
+++ b/test/polydeal/build_all_continuous_transfers.cc
@@ -38,8 +38,8 @@
 
 #include "continuous_agglo_utils.h"
 
-static constexpr double       tolerance  = 1e-12;
-static constexpr unsigned int dim        = 2;
+static constexpr double       tolerance = 1e-12;
+static constexpr unsigned int dim       = 2;
 using namespace dealii;
 
 int
@@ -65,106 +65,216 @@ main()
                                        dof_handler,
                                        support_points_vector);
 
-  std::vector<SparseMatrix<double>> injection_matrices;
-  std::vector<SparsityPattern>      injection_sparsity_patterns;
-  std::vector<unsigned int>         coarse_space_degrees(mg_levels - 1, 1);
-  std::vector<std::unique_ptr<Triangulation<dim>>> triangulations;
-  std::vector<std::unique_ptr<DoFHandler<dim>>>    support_dof_handlers;
+  // Point agglo test
+  {
+    std::vector<SparseMatrix<double>> injection_matrices;
+    std::vector<SparsityPattern>      injection_sparsity_patterns;
+    std::vector<unsigned int>         coarse_space_degrees(mg_levels - 1, 1);
+    std::vector<std::unique_ptr<Triangulation<dim>>> triangulations;
+    std::vector<std::unique_ptr<DoFHandler<dim>>>    support_dof_handlers;
 
-  ContinuousAggloUtils::PointsAgglo::
-    agglomerate_and_compute_injection_matrices<dim,
-                                               min_elem_per_node,
-                                               max_elem_per_node>(
-      support_points_vector,
-      skip_leaves,
-      injection_matrices,
-      injection_sparsity_patterns,
-      mg_levels,
-      coarse_space_degrees,
-      triangulations,
-      support_dof_handlers);
+    ContinuousAggloUtils::PointsAgglo::
+      agglomerate_and_compute_injection_matrices<dim,
+                                                 min_elem_per_node,
+                                                 max_elem_per_node>(
+        support_points_vector,
+        skip_leaves,
+        injection_matrices,
+        injection_sparsity_patterns,
+        mg_levels,
+        coarse_space_degrees,
+        triangulations,
+        support_dof_handlers);
 
-  std::cout << "Built " << injection_matrices.size() << " injection matrices"
-            << std::endl;
+    std::cout << "Built " << injection_matrices.size() << " injection matrices"
+              << std::endl;
 
-  for (unsigned int level = 0; level < injection_matrices.size(); ++level)
-    {
-      const auto &mat = injection_matrices[level];
+    for (unsigned int level = 0; level < injection_matrices.size(); ++level)
+      {
+        const auto &mat = injection_matrices[level];
 
-      std::vector<Point<dim>> coarse_support_points(
-        support_dof_handlers[level]->n_dofs());
-      DoFTools::map_dofs_to_support_points(mapping,
-                                           *support_dof_handlers[level],
-                                           coarse_support_points);
+        std::vector<Point<dim>> coarse_support_points(
+          support_dof_handlers[level]->n_dofs());
+        DoFTools::map_dofs_to_support_points(mapping,
+                                             *support_dof_handlers[level],
+                                             coarse_support_points);
 
-      AssertThrow(mat.n() == coarse_support_points.size(),
-                  ExcDimensionMismatch(mat.n(), coarse_support_points.size()));
+        AssertThrow(mat.n() == coarse_support_points.size(),
+                    ExcDimensionMismatch(mat.n(),
+                                         coarse_support_points.size()));
 
-      Vector<double> coarse_values(coarse_support_points.size());
-      for (unsigned int i = 0; i < coarse_values.size(); ++i)
-        coarse_values[i] =
-          coarse_support_points[i][0] + coarse_support_points[i][1];
+        Vector<double> coarse_values(coarse_support_points.size());
+        for (unsigned int i = 0; i < coarse_values.size(); ++i)
+          coarse_values[i] =
+            coarse_support_points[i][0] + coarse_support_points[i][1];
 
-      if (level < mg_levels - 2)
-        {
-          std::vector<Point<dim>> fine_support_points(
-            support_dof_handlers[level + 1]->n_dofs());
-          DoFTools::map_dofs_to_support_points(
-            mapping, *support_dof_handlers[level + 1], fine_support_points);
+        if (level < mg_levels - 2)
+          {
+            std::vector<Point<dim>> fine_support_points(
+              support_dof_handlers[level + 1]->n_dofs());
+            DoFTools::map_dofs_to_support_points(
+              mapping, *support_dof_handlers[level + 1], fine_support_points);
 
-          AssertThrow(mat.m() == fine_support_points.size(),
-                      ExcDimensionMismatch(mat.m(),
-                                           fine_support_points.size()));
+            AssertThrow(mat.m() == fine_support_points.size(),
+                        ExcDimensionMismatch(mat.m(),
+                                             fine_support_points.size()));
 
-          Vector<double> fine_values(fine_support_points.size());
-          for (unsigned int i = 0; i < fine_values.size(); ++i)
-            fine_values[i] =
-              fine_support_points[i][0] + fine_support_points[i][1];
+            Vector<double> fine_values(fine_support_points.size());
+            for (unsigned int i = 0; i < fine_values.size(); ++i)
+              fine_values[i] =
+                fine_support_points[i][0] + fine_support_points[i][1];
 
-          Vector<double> transferred_values(fine_values.size());
-          mat.vmult(transferred_values, coarse_values);
+            Vector<double> transferred_values(fine_values.size());
+            mat.vmult(transferred_values, coarse_values);
 
-          transferred_values -= fine_values;
-          const double l2_error = transferred_values.l2_norm();
+            transferred_values -= fine_values;
+            const double l2_error = transferred_values.l2_norm();
 
-          AssertThrow(
-            l2_error < tolerance,
-            ExcMessage(
-              "Agglomerated transfer " + std::to_string(level) +
-              " (coarse->fine) failed linear test with error " +
-              std::to_string(l2_error)));
+            AssertThrow(l2_error < tolerance,
+                        ExcMessage(
+                          "Agglomerated transfer " + std::to_string(level) +
+                          " (coarse->fine) failed linear test with error " +
+                          std::to_string(l2_error)));
 
-          std::cout << "Level " << level << " (" << mat.m() << " x " << mat.n()
-                    << "): L2 error = " << l2_error << std::endl;
-        }
-      else
-        {
-          AssertThrow(mat.m() == support_points_vector.size(),
-                      ExcDimensionMismatch(mat.m(),
-                                           support_points_vector.size()));
+            std::cout << "Level " << level << " (" << mat.m() << " x "
+                      << mat.n() << "): L2 error = " << l2_error << std::endl;
+          }
+        else
+          {
+            AssertThrow(mat.m() == support_points_vector.size(),
+                        ExcDimensionMismatch(mat.m(),
+                                             support_points_vector.size()));
 
-          Vector<double> fine_values(support_points_vector.size());
-          for (unsigned int i = 0; i < fine_values.size(); ++i)
-            fine_values[i] =
-              support_points_vector[i][0] + support_points_vector[i][1];
+            Vector<double> fine_values(support_points_vector.size());
+            for (unsigned int i = 0; i < fine_values.size(); ++i)
+              fine_values[i] =
+                support_points_vector[i][0] + support_points_vector[i][1];
 
-          Vector<double> transferred_values(fine_values.size());
-          mat.vmult(transferred_values, coarse_values);
+            Vector<double> transferred_values(fine_values.size());
+            mat.vmult(transferred_values, coarse_values);
 
-          transferred_values -= fine_values;
-          const double l2_error = transferred_values.l2_norm();
+            transferred_values -= fine_values;
+            const double l2_error = transferred_values.l2_norm();
 
-          AssertThrow(
-            l2_error < tolerance,
-            ExcMessage(
-              "Final transfer (agglo->original) failed linear test with error " +
-              std::to_string(l2_error)));
+            AssertThrow(
+              l2_error < tolerance,
+              ExcMessage(
+                "Final transfer (agglo->original) failed linear test with error " +
+                std::to_string(l2_error)));
 
-          std::cout << "Level " << level << " (" << mat.m() << " x " << mat.n()
-                    << "): L2 error = " << l2_error << " (agglo->original)"
-                    << std::endl;
-        }
-    }
+            std::cout << "Level " << level << " (" << mat.m() << " x "
+                      << mat.n() << "): L2 error = " << l2_error
+                      << " (agglo->original)" << std::endl;
+          }
+      }
 
-  std::cout << "All continuous transfer tests: OK" << std::endl;
+    std::cout << "All point-agglo continuous transfer tests: OK" << std::endl;
+  }
+
+  // Cell agglo test
+  {
+    std::vector<SparseMatrix<double>> injection_matrices;
+    std::vector<SparsityPattern>      injection_sparsity_patterns;
+    std::vector<unsigned int>         coarse_space_degrees(mg_levels - 1, 1);
+    std::vector<std::unique_ptr<Triangulation<dim>>> triangulations;
+    std::vector<std::unique_ptr<DoFHandler<dim>>>    support_dof_handlers;
+
+    ContinuousAggloUtils::CellsAgglo::
+      agglomerate_and_compute_injection_matrices<dim,
+                                                 min_elem_per_node,
+                                                 max_elem_per_node>(
+        dof_handler,
+        mapping,
+        skip_leaves,
+        injection_matrices,
+        injection_sparsity_patterns,
+        mg_levels,
+        coarse_space_degrees,
+        triangulations,
+        support_dof_handlers);
+
+    std::cout << "Built " << injection_matrices.size() << " injection matrices"
+              << std::endl;
+
+    for (unsigned int level = 0; level < injection_matrices.size(); ++level)
+      {
+        const auto &mat = injection_matrices[level];
+
+        std::vector<Point<dim>> coarse_support_points(
+          support_dof_handlers[level]->n_dofs());
+        DoFTools::map_dofs_to_support_points(mapping,
+                                             *support_dof_handlers[level],
+                                             coarse_support_points);
+
+        AssertThrow(mat.n() == coarse_support_points.size(),
+                    ExcDimensionMismatch(mat.n(),
+                                         coarse_support_points.size()));
+
+        Vector<double> coarse_values(coarse_support_points.size());
+        for (unsigned int i = 0; i < coarse_values.size(); ++i)
+          coarse_values[i] =
+            coarse_support_points[i][0] + coarse_support_points[i][1];
+
+        if (level < mg_levels - 2)
+          {
+            std::vector<Point<dim>> fine_support_points(
+              support_dof_handlers[level + 1]->n_dofs());
+            DoFTools::map_dofs_to_support_points(
+              mapping, *support_dof_handlers[level + 1], fine_support_points);
+
+            AssertThrow(mat.m() == fine_support_points.size(),
+                        ExcDimensionMismatch(mat.m(),
+                                             fine_support_points.size()));
+
+            Vector<double> fine_values(fine_support_points.size());
+            for (unsigned int i = 0; i < fine_values.size(); ++i)
+              fine_values[i] =
+                fine_support_points[i][0] + fine_support_points[i][1];
+
+            Vector<double> transferred_values(fine_values.size());
+            mat.vmult(transferred_values, coarse_values);
+
+            transferred_values -= fine_values;
+            const double l2_error = transferred_values.l2_norm();
+
+            AssertThrow(l2_error < tolerance,
+                        ExcMessage(
+                          "Agglomerated transfer " + std::to_string(level) +
+                          " (coarse->fine) failed linear test with error " +
+                          std::to_string(l2_error)));
+
+            std::cout << "Level " << level << " (" << mat.m() << " x "
+                      << mat.n() << "): L2 error = " << l2_error << std::endl;
+          }
+        else
+          {
+            AssertThrow(mat.m() == support_points_vector.size(),
+                        ExcDimensionMismatch(mat.m(),
+                                             support_points_vector.size()));
+
+            Vector<double> fine_values(support_points_vector.size());
+            for (unsigned int i = 0; i < fine_values.size(); ++i)
+              fine_values[i] =
+                support_points_vector[i][0] + support_points_vector[i][1];
+
+            Vector<double> transferred_values(fine_values.size());
+            mat.vmult(transferred_values, coarse_values);
+
+            transferred_values -= fine_values;
+            const double l2_error = transferred_values.l2_norm();
+
+            AssertThrow(
+              l2_error < tolerance,
+              ExcMessage(
+                "Final transfer (agglo->original) failed linear test with error " +
+                std::to_string(l2_error)));
+
+            std::cout << "Level " << level << " (" << mat.m() << " x "
+                      << mat.n() << "): L2 error = " << l2_error
+                      << " (agglo->original)" << std::endl;
+          }
+      }
+
+    std::cout << "All cell-agglo continuous transfer tests: OK" << std::endl;
+  }
 }

--- a/test/polydeal/build_all_continuous_transfers.output
+++ b/test/polydeal/build_all_continuous_transfers.output
@@ -1,4 +1,8 @@
 Built 2 injection matrices
 Level 0 (76 x 20): L2 error = 0
 Level 1 (289 x 76): L2 error = 4.87108e-16 (agglo->original)
-All continuous transfer tests: OK
+All point-agglo continuous transfer tests: OK
+Built 2 injection matrices
+Level 0 (64 x 16): L2 error = 0
+Level 1 (289 x 64): L2 error = 0 (agglo->original)
+All cell-agglo continuous transfer tests: OK

--- a/test/polydeal/build_all_continuous_transfers.output
+++ b/test/polydeal/build_all_continuous_transfers.output
@@ -1,0 +1,4 @@
+Built 2 injection matrices
+Level 0 (76 x 20): L2 error = 0
+Level 1 (289 x 76): L2 error = 4.87108e-16 (agglo->original)
+All continuous transfer tests: OK

--- a/test/polydeal/build_continuous_transfer.cc
+++ b/test/polydeal/build_continuous_transfer.cc
@@ -98,7 +98,7 @@ main()
 
         fine_level_boxes.emplace_back(points_in_current_agglomerate);
       }
-    ContinuousAggloUtils::PointsAgglo::create_triangulation_from_bounding_boxes(
+    ContinuousAggloUtils::create_triangulation_from_bounding_boxes(
       fine_tria, fine_level_boxes);
     fine_dof_handler.distribute_dofs(fe_dgq);
   }
@@ -122,7 +122,7 @@ main()
 
         coarse_level_boxes.emplace_back(points_in_current_agglomerate);
       }
-    ContinuousAggloUtils::PointsAgglo::create_triangulation_from_bounding_boxes(
+    ContinuousAggloUtils::create_triangulation_from_bounding_boxes(
       coarse_tria, coarse_level_boxes);
     coarse_dof_handler.distribute_dofs(fe_dgq);
 
@@ -142,15 +142,14 @@ main()
                                          fine_dof_handler,
                                          fine_support_points);
 
-    ContinuousAggloUtils::PointsAgglo::fill_injection_matrix<dim>(
-      coarse_dof_handler,
-      fine_dof_handler,
-      sparsity_pattern,
-      transfer_matrix,
-      parent_to_child_info,
-      coarse_level_boxes,
-      fine_level_boxes,
-      coarse_level - 1);
+    ContinuousAggloUtils::fill_injection_matrix<dim>(coarse_dof_handler,
+                                                     fine_dof_handler,
+                                                     sparsity_pattern,
+                                                     transfer_matrix,
+                                                     parent_to_child_info,
+                                                     coarse_level_boxes,
+                                                     fine_level_boxes,
+                                                     coarse_level - 1);
 
     AssertThrow(transfer_matrix.m() == fine_dof_handler.n_dofs(),
                 ExcDimensionMismatch(transfer_matrix.m(),

--- a/test/polydeal/build_continuous_transfer.cc
+++ b/test/polydeal/build_continuous_transfer.cc
@@ -1,0 +1,193 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/point.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/vector.h>
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include "continuous_agglo_utils.h"
+
+static constexpr double       tolerance  = 1e-12;
+static constexpr unsigned int dim        = 2;
+static constexpr bool         use_points = true;
+using namespace dealii;
+
+int
+main()
+{
+  namespace bgi                                   = boost::geometry::index;
+  static constexpr unsigned int min_elem_per_node = 2;
+  static constexpr unsigned int max_elem_per_node = 4;
+
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, 0., 1.);
+  tria.refine_global(4);
+
+  DoFHandler<dim> dof_handler(tria);
+  FE_Q<dim>       fe(1);
+  FE_DGQ<dim>     fe_dgq(1);
+  dof_handler.distribute_dofs(fe);
+
+  std::vector<Point<dim>> support_points_vector(dof_handler.n_dofs());
+  MappingQ1<dim>          mapping;
+
+  DoFTools::map_dofs_to_support_points(mapping,
+                                       dof_handler,
+                                       support_points_vector);
+
+  auto tree =
+    pack_rtree_of_indices<bgi::rstar<max_elem_per_node, min_elem_per_node>>(
+      support_points_vector);
+
+  std::cout << "R-tree built with " << n_levels(tree) << " levels "
+            << std::endl;
+  unsigned int                  fine_level   = n_levels(tree);
+  unsigned int                  coarse_level = fine_level - 1;
+  std::vector<BoundingBox<dim>> coarse_level_boxes;
+  std::vector<BoundingBox<dim>> fine_level_boxes;
+
+  Triangulation<dim> fine_tria;
+  Triangulation<dim> coarse_tria;
+  DoFHandler<dim>    fine_dof_handler(fine_tria);
+  DoFHandler<dim>    coarse_dof_handler(coarse_tria);
+
+  {
+    CellsAgglomerator<dim, decltype(tree), use_points>      agglomerator{tree,
+                                                                    fine_level};
+    const std::vector<std::vector<types::global_dof_index>> agglomerates =
+      agglomerator.extract_agglomerates();
+    fine_level_boxes.reserve(agglomerates.size());
+    for (const std::vector<types::global_dof_index> &agglo : agglomerates)
+      {
+        std::vector<Point<dim>> points_in_current_agglomerate;
+        points_in_current_agglomerate.reserve(agglo.size());
+
+        for (const auto &index : agglo)
+          points_in_current_agglomerate.push_back(support_points_vector[index]);
+
+        fine_level_boxes.emplace_back(points_in_current_agglomerate);
+      }
+    ContinuousAggloUtils::PointsAgglo::create_triangulation_from_bounding_boxes(
+      fine_tria, fine_level_boxes);
+    fine_dof_handler.distribute_dofs(fe_dgq);
+  }
+
+  SparseMatrix<double> transfer_matrix;
+  SparsityPattern      sparsity_pattern;
+
+  {
+    CellsAgglomerator<dim, decltype(tree), use_points> agglomerator{
+      tree, coarse_level};
+    const std::vector<std::vector<types::global_dof_index>> agglomerates =
+      agglomerator.extract_agglomerates();
+    coarse_level_boxes.reserve(agglomerates.size());
+    for (const std::vector<types::global_dof_index> &agglo : agglomerates)
+      {
+        std::vector<Point<dim>> points_in_current_agglomerate;
+        points_in_current_agglomerate.reserve(agglo.size());
+
+        for (const auto &index : agglo)
+          points_in_current_agglomerate.push_back(support_points_vector[index]);
+
+        coarse_level_boxes.emplace_back(points_in_current_agglomerate);
+      }
+    ContinuousAggloUtils::PointsAgglo::create_triangulation_from_bounding_boxes(
+      coarse_tria, coarse_level_boxes);
+    coarse_dof_handler.distribute_dofs(fe_dgq);
+
+    const std::map<
+      std::pair<types::global_cell_index, types::global_cell_index>,
+      std::vector<types::global_cell_index>> &parent_to_child_info =
+      agglomerator.get_hierarchy();
+
+    std::vector<Point<dim>> coarse_support_points(coarse_dof_handler.n_dofs());
+    std::vector<Point<dim>> fine_support_points(fine_dof_handler.n_dofs());
+
+    MappingQ1<dim> mapping;
+    DoFTools::map_dofs_to_support_points(mapping,
+                                         coarse_dof_handler,
+                                         coarse_support_points);
+    DoFTools::map_dofs_to_support_points(mapping,
+                                         fine_dof_handler,
+                                         fine_support_points);
+
+    ContinuousAggloUtils::PointsAgglo::fill_injection_matrix<dim>(
+      coarse_dof_handler,
+      fine_dof_handler,
+      sparsity_pattern,
+      transfer_matrix,
+      parent_to_child_info,
+      coarse_level_boxes,
+      fine_level_boxes,
+      coarse_level - 1);
+
+    AssertThrow(transfer_matrix.m() == fine_dof_handler.n_dofs(),
+                ExcDimensionMismatch(transfer_matrix.m(),
+                                     fine_dof_handler.n_dofs()));
+    AssertThrow(transfer_matrix.n() == coarse_dof_handler.n_dofs(),
+                ExcDimensionMismatch(transfer_matrix.n(),
+                                     coarse_dof_handler.n_dofs()));
+
+    Vector<double> coarse_values(coarse_dof_handler.n_dofs());
+    Vector<double> fine_values(fine_dof_handler.n_dofs());
+    Vector<double> transferred_values(fine_dof_handler.n_dofs());
+
+    for (unsigned int i = 0; i < coarse_values.size(); ++i)
+      coarse_values[i] =
+        coarse_support_points[i][0] + coarse_support_points[i][1];
+
+    for (unsigned int i = 0; i < fine_values.size(); ++i)
+      fine_values[i] = fine_support_points[i][0] + fine_support_points[i][1];
+
+    transfer_matrix.vmult(transferred_values, coarse_values);
+
+    transferred_values -= fine_values;
+    const double l2_error = transferred_values.l2_norm();
+
+    AssertThrow(l2_error < tolerance,
+                ExcMessage(
+                  "Continuous transfer matrix failed the linear field test."));
+
+    std::cout << "Coarse DoFs: " << coarse_dof_handler.n_dofs() << std::endl;
+    std::cout << "Fine DoFs: " << fine_dof_handler.n_dofs() << std::endl;
+    std::cout << "Transfer matrix: " << transfer_matrix.m() << " x "
+              << transfer_matrix.n() << std::endl;
+    std::cout << "Linear transfer L2 error: " << l2_error << std::endl;
+    std::cout << "Continuous transfer matrix test: OK" << std::endl;
+  }
+
+  // Check  that dimensions are coherent
+  Assert(transfer_matrix.m() == fine_dof_handler.n_dofs(),
+         ExcDimensionMismatch(transfer_matrix.m(), fine_dof_handler.n_dofs()));
+}

--- a/test/polydeal/build_continuous_transfer.output
+++ b/test/polydeal/build_continuous_transfer.output
@@ -1,0 +1,6 @@
+R-tree built with 4 levels
+Coarse DoFs: 76
+Fine DoFs: 292
+Transfer matrix: 292 x 76
+Linear transfer L2 error: 4.33556e-16
+Continuous transfer matrix test: OK

--- a/test/polydeal/continuous_poisson_distributed_sanity.cc
+++ b/test/polydeal/continuous_poisson_distributed_sanity.cc
@@ -108,237 +108,497 @@ main(int argc, char *argv[])
   FE_Q<dim>       fe(1);
   dof_handler.distribute_dofs(fe);
   MappingQ1<dim> mapping;
+  // Point agglo section
+  {
+    if (my_rank == 0)
+      std::cout << "Running point agglomeration test" << std::endl;
 
-  std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
-  std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
-  unsigned int                                   mg_levels            = 3;
-  std::vector<unsigned int>                      coarse_space_degrees = {1, 1};
+    std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
+    std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
+    unsigned int                                   mg_levels = 3;
+    std::vector<unsigned int> coarse_space_degrees           = {1, 1};
 
-  std::vector<
-    std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
-                                                triangulations(mg_levels - 1);
-  std::vector<std::unique_ptr<DoFHandler<dim>>> support_dof_handlers(mg_levels -
-                                                                     1);
+    std::vector<
+      std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
+                                                  triangulations(mg_levels - 1);
+    std::vector<std::unique_ptr<DoFHandler<dim>>> support_dof_handlers(
+      mg_levels - 1);
 
-  ContinuousAggloUtils::PointsAgglo::
-    parallel_agglomerate_and_compute_injection_matrices<dim,
-                                                        min_elem_per_node,
-                                                        max_elem_per_node>(
-      dof_handler,
-      mapping,
-      true,
-      injection_matrices,
-      injection_sparsity_patterns,
-      mg_levels,
-      coarse_space_degrees,
-      triangulations,
-      support_dof_handlers);
+    ContinuousAggloUtils::PointsAgglo::
+      parallel_agglomerate_and_compute_injection_matrices<dim,
+                                                          min_elem_per_node,
+                                                          max_elem_per_node>(
+        dof_handler,
+        mapping,
+        true,
+        injection_matrices,
+        injection_sparsity_patterns,
+        mg_levels,
+        coarse_space_degrees,
+        triangulations,
+        support_dof_handlers);
 
-  // Set up Dirichlet boundary conditions using AffineConstraints
-  const IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  const IndexSet locally_relevant_dofs =
-    DoFTools::extract_locally_relevant_dofs(dof_handler);
+    // Set up Dirichlet boundary conditions using AffineConstraints
+    const IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
-  AffineConstraints<double> constraints;
-  constraints.clear();
-  constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
-  LinearSumFunction linear_bc;
-  VectorTools::interpolate_boundary_values(
-    mapping, dof_handler, 0, linear_bc, constraints);
-  constraints.close();
+    AffineConstraints<double> constraints;
+    constraints.clear();
+    constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
+    LinearSumFunction linear_bc;
+    VectorTools::interpolate_boundary_values(
+      mapping, dof_handler, 0, linear_bc, constraints);
+    constraints.close();
 
-  // Build distributed sparsity pattern and system matrix
-  TrilinosWrappers::SparsityPattern sparsity_pattern(locally_owned_dofs, comm);
-  DoFTools::make_sparsity_pattern(dof_handler,
-                                  sparsity_pattern,
-                                  constraints,
-                                  false);
-  sparsity_pattern.compress();
-  TrilinosWrappers::SparseMatrix system_matrix;
-  system_matrix.reinit(sparsity_pattern);
+    // Build distributed sparsity pattern and system matrix
+    TrilinosWrappers::SparsityPattern sparsity_pattern(locally_owned_dofs,
+                                                       comm);
+    DoFTools::make_sparsity_pattern(dof_handler,
+                                    sparsity_pattern,
+                                    constraints,
+                                    false);
+    sparsity_pattern.compress();
+    TrilinosWrappers::SparseMatrix system_matrix;
+    system_matrix.reinit(sparsity_pattern);
 
-  // Assemble Laplace matrix
-  FEValues<dim>             fe_values(mapping,
-                          fe,
-                          QGauss<dim>(fe.degree + 1),
-                          update_gradients | update_JxW_values |
-                            update_quadrature_points);
-  const unsigned int        dofs_per_cell = fe.n_dofs_per_cell();
-  FullMatrix<double>        cell_matrix(dofs_per_cell, dofs_per_cell);
-  Vector<double>            cell_rhs(dofs_per_cell);
-  std::vector<unsigned int> local_dof_indices(dofs_per_cell);
+    // Assemble Laplace matrix
+    FEValues<dim>             fe_values(mapping,
+                            fe,
+                            QGauss<dim>(fe.degree + 1),
+                            update_gradients | update_JxW_values |
+                              update_quadrature_points);
+    const unsigned int        dofs_per_cell = fe.n_dofs_per_cell();
+    FullMatrix<double>        cell_matrix(dofs_per_cell, dofs_per_cell);
+    Vector<double>            cell_rhs(dofs_per_cell);
+    std::vector<unsigned int> local_dof_indices(dofs_per_cell);
 
-  LinearAlgebra::distributed::Vector<double> system_rhs(locally_owned_dofs,
-                                                        locally_relevant_dofs,
-                                                        comm);
-  system_rhs = 0.0;
+    LinearAlgebra::distributed::Vector<double> system_rhs(locally_owned_dofs,
+                                                          locally_relevant_dofs,
+                                                          comm);
+    system_rhs = 0.0;
 
-  for (const auto &cell : dof_handler.active_cell_iterators())
-    if (cell->is_locally_owned())
+    for (const auto &cell : dof_handler.active_cell_iterators())
+      if (cell->is_locally_owned())
+        {
+          cell_matrix = 0.0;
+          cell_rhs    = 0.0;
+          fe_values.reinit(cell);
+
+          for (const unsigned int q : fe_values.quadrature_point_indices())
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                cell_matrix(i, j) += fe_values.shape_grad(i, q) *
+                                     fe_values.shape_grad(j, q) *
+                                     fe_values.JxW(q);
+
+          cell->get_dof_indices(local_dof_indices);
+          constraints.distribute_local_to_global(cell_matrix,
+                                                 cell_rhs,
+                                                 local_dof_indices,
+                                                 system_matrix,
+                                                 system_rhs);
+        }
+
+    system_matrix.compress(VectorOperation::add);
+    system_rhs.compress(VectorOperation::add);
+
+    // Set up level matrices via AmgProjector
+    AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
+      injection_matrices);
+
+    MGLevelObject<std::unique_ptr<TrilinosWrappers::SparseMatrix>>
+      multigrid_matrices(0, mg_levels - 1);
+
+    multigrid_matrices[multigrid_matrices.max_level()] =
+      std::make_unique<TrilinosWrappers::SparseMatrix>();
+    multigrid_matrices[multigrid_matrices.max_level()]->reinit(system_matrix);
+    multigrid_matrices[multigrid_matrices.max_level()]->copy_from(
+      system_matrix);
+
+    amg_projector.compute_level_matrices(multigrid_matrices);
+
+    // Set up multigrid solver
+    using LevelMatrixType = TrilinosWrappers::SparseMatrix;
+    using VectorType      = LinearAlgebra::distributed::Vector<double>;
+    mg::Matrix<VectorType> mg_matrix(multigrid_matrices);
+
+    using SmootherType = PreconditionChebyshev<LevelMatrixType, VectorType>;
+    mg::SmootherRelaxation<SmootherType, VectorType>     mg_smoother;
+    MGLevelObject<typename SmootherType::AdditionalData> smoother_data;
+    smoother_data.resize(0, mg_levels - 1);
+
+    VectorType diag_inverse(system_matrix.locally_owned_range_indices(), comm);
+    for (unsigned int row = system_matrix.local_range().first;
+         row < system_matrix.local_range().second;
+         ++row)
+      diag_inverse[row] = 1. / system_matrix.diag_element(row);
+    diag_inverse.compress(VectorOperation::insert);
+
+    std::vector<VectorType> diag_inverses(mg_levels);
+    diag_inverses[mg_levels - 1] = diag_inverse;
+
+    smoother_data[mg_levels - 1].preconditioner =
+      std::make_shared<DiagonalMatrix<VectorType>>(
+        diag_inverses[mg_levels - 1]);
+
+    for (unsigned int level = 0; level < mg_levels - 1; ++level)
       {
-        cell_matrix = 0.0;
-        cell_rhs    = 0.0;
-        fe_values.reinit(cell);
+        smoother_data[level].smoothing_range = 8;
+        diag_inverses[level].reinit(
+          multigrid_matrices[level]->locally_owned_range_indices(), comm);
+        for (unsigned int row = multigrid_matrices[level]->local_range().first;
+             row < multigrid_matrices[level]->local_range().second;
+             ++row)
+          diag_inverses[level][row] =
+            1. / multigrid_matrices[level]->diag_element(row);
+        diag_inverses[level].compress(VectorOperation::insert);
 
-        for (const unsigned int q : fe_values.quadrature_point_indices())
-          for (unsigned int i = 0; i < dofs_per_cell; ++i)
-            for (unsigned int j = 0; j < dofs_per_cell; ++j)
-              cell_matrix(i, j) += fe_values.shape_grad(i, q) *
-                                   fe_values.shape_grad(j, q) *
-                                   fe_values.JxW(q);
-
-        cell->get_dof_indices(local_dof_indices);
-        constraints.distribute_local_to_global(
-          cell_matrix, cell_rhs, local_dof_indices, system_matrix, system_rhs);
+        smoother_data[level].preconditioner =
+          std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[level]);
       }
 
-  system_matrix.compress(VectorOperation::add);
-  system_rhs.compress(VectorOperation::add);
+    for (unsigned int level = 0; level < mg_levels; ++level)
+      {
+        if (level > 0)
+          {
+            smoother_data[level].smoothing_range     = 20.;
+            smoother_data[level].degree              = 3;
+            smoother_data[level].eig_cg_n_iterations = 20;
+          }
+        else
+          {
+            smoother_data[0].smoothing_range     = 1e-3;
+            smoother_data[0].degree              = 3;
+            smoother_data[0].eig_cg_n_iterations = 20;
+          }
+      }
 
-  // Set up level matrices via AmgProjector
-  AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
-    injection_matrices);
+    mg_smoother.set_steps(2);
+    mg_smoother.initialize(multigrid_matrices, smoother_data);
 
-  MGLevelObject<std::unique_ptr<TrilinosWrappers::SparseMatrix>>
-    multigrid_matrices(0, mg_levels - 1);
+    Utils::MGCoarseDirect<VectorType,
+                          TrilinosWrappers::SparseMatrix,
+                          TrilinosWrappers::SolverDirect>
+      mg_coarse(*multigrid_matrices[0]);
 
-  multigrid_matrices[multigrid_matrices.max_level()] =
-    std::make_unique<TrilinosWrappers::SparseMatrix>();
-  multigrid_matrices[multigrid_matrices.max_level()]->reinit(system_matrix);
-  multigrid_matrices[multigrid_matrices.max_level()]->copy_from(system_matrix);
+    MGLevelObject<TrilinosWrappers::SparseMatrix *> mg_level_transfers(
+      0, mg_levels - 1);
+    for (unsigned int l = 0; l < mg_levels - 1; ++l)
+      mg_level_transfers[l] = &injection_matrices[l];
 
-  amg_projector.compute_level_matrices(multigrid_matrices);
+    std::vector<DoFHandler<dim> *> dof_handlers(support_dof_handlers.size() +
+                                                1);
+    for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+      dof_handlers[i] = support_dof_handlers[i].get();
+    dof_handlers[support_dof_handlers.size()] = &dof_handler;
 
-  // Set up multigrid solver
-  using LevelMatrixType = TrilinosWrappers::SparseMatrix;
-  using VectorType      = LinearAlgebra::distributed::Vector<double>;
-  mg::Matrix<VectorType> mg_matrix(multigrid_matrices);
+    MGTransferAgglomeration<dim, VectorType> mg_transfer(mg_level_transfers,
+                                                         dof_handlers);
 
-  using SmootherType = PreconditionChebyshev<LevelMatrixType, VectorType>;
-  mg::SmootherRelaxation<SmootherType, VectorType>     mg_smoother;
-  MGLevelObject<typename SmootherType::AdditionalData> smoother_data;
-  smoother_data.resize(0, mg_levels - 1);
+    Multigrid<VectorType> mg(mg_matrix,
+                             mg_coarse,
+                             mg_transfer,
+                             mg_smoother,
+                             mg_smoother,
+                             0,
+                             numbers::invalid_unsigned_int,
+                             Multigrid<VectorType>::v_cycle);
 
-  VectorType diag_inverse(system_matrix.locally_owned_range_indices(), comm);
-  for (unsigned int row = system_matrix.local_range().first;
-       row < system_matrix.local_range().second;
-       ++row)
-    diag_inverse[row] = 1. / system_matrix.diag_element(row);
-  diag_inverse.compress(VectorOperation::insert);
+    PreconditionMG<dim, VectorType, MGTransferAgglomeration<dim, VectorType>>
+      preconditioner(dof_handler, mg, mg_transfer);
 
-  std::vector<VectorType> diag_inverses(mg_levels);
-  diag_inverses[mg_levels - 1] = diag_inverse;
+    // Solve with CG
+    VectorType dist_solution(locally_owned_dofs, comm);
+    dist_solution = 0.0;
 
-  smoother_data[mg_levels - 1].preconditioner =
-    std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[mg_levels - 1]);
+    ReductionControl     solver_control(1000, 1e-12, 1e-9);
+    SolverCG<VectorType> cg(solver_control);
+    cg.solve(system_matrix, dist_solution, system_rhs, preconditioner);
+    if (my_rank == 0)
+      std::cout << "CG converged in " << solver_control.last_step()
+                << " steps, final residual = " << solver_control.last_value()
+                << std::endl;
 
-  for (unsigned int level = 0; level < mg_levels - 1; ++level)
-    {
-      smoother_data[level].smoothing_range = 8;
-      diag_inverses[level].reinit(
-        multigrid_matrices[level]->locally_owned_range_indices(), comm);
-      for (unsigned int row = multigrid_matrices[level]->local_range().first;
-           row < multigrid_matrices[level]->local_range().second;
-           ++row)
-        diag_inverses[level][row] =
-          1. / multigrid_matrices[level]->diag_element(row);
-      diag_inverses[level].compress(VectorOperation::insert);
+    constraints.distribute(dist_solution);
 
-      smoother_data[level].preconditioner =
-        std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[level]);
-    }
+    const double rhs_norm      = system_rhs.l2_norm();
+    const double solution_norm = dist_solution.l2_norm();
 
-  for (unsigned int level = 0; level < mg_levels; ++level)
-    {
-      if (level > 0)
+    if (my_rank == 0)
+      std::cout << "RHS norm = " << rhs_norm
+                << ", solution norm = " << solution_norm << std::endl;
+
+    // Compute L2 error against exact solution u(x,y) = x + y
+    VectorType solution_ghosted(locally_owned_dofs,
+                                locally_relevant_dofs,
+                                comm);
+    solution_ghosted = dist_solution;
+    solution_ghosted.update_ghost_values();
+
+    Vector<double> error_per_cell(starting_tria_pft.n_active_cells());
+    VectorTools::integrate_difference(mapping,
+                                      dof_handler,
+                                      solution_ghosted,
+                                      linear_bc,
+                                      error_per_cell,
+                                      QGauss<dim>(fe.degree + 2),
+                                      VectorTools::L2_norm);
+
+    double l2_error =
+      std::sqrt(Utilities::MPI::sum(error_per_cell.norm_sqr(), comm));
+
+    if (my_rank == 0)
+      std::cout << "L2 error: " << l2_error << std::endl;
+
+    Assert(l2_error < tolerance,
+           ExcMessage("L2 error too large: " + std::to_string(l2_error)));
+  }
+
+  // Cell agglo section
+  {
+    if (my_rank == 0)
+      std::cout << "Running cell agglomeration test" << std::endl;
+
+    std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
+    std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
+    unsigned int                                   mg_levels = 3;
+    std::vector<unsigned int> coarse_space_degrees           = {1, 1};
+
+    std::vector<
+      std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
+                                                  triangulations(mg_levels - 1);
+    std::vector<std::unique_ptr<DoFHandler<dim>>> support_dof_handlers(
+      mg_levels - 1);
+
+    ContinuousAggloUtils::CellsAgglo::
+      parallel_agglomerate_and_compute_injection_matrices<dim,
+                                                          min_elem_per_node,
+                                                          max_elem_per_node>(
+        dof_handler,
+        mapping,
+        true,
+        injection_matrices,
+        injection_sparsity_patterns,
+        mg_levels,
+        coarse_space_degrees,
+        triangulations,
+        support_dof_handlers);
+
+    // Set up Dirichlet boundary conditions using AffineConstraints
+    const IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
+
+    AffineConstraints<double> constraints;
+    constraints.clear();
+    constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
+    LinearSumFunction linear_bc;
+    VectorTools::interpolate_boundary_values(
+      mapping, dof_handler, 0, linear_bc, constraints);
+    constraints.close();
+
+    // Build distributed sparsity pattern and system matrix
+    TrilinosWrappers::SparsityPattern sparsity_pattern(locally_owned_dofs,
+                                                       comm);
+    DoFTools::make_sparsity_pattern(dof_handler,
+                                    sparsity_pattern,
+                                    constraints,
+                                    false);
+    sparsity_pattern.compress();
+    TrilinosWrappers::SparseMatrix system_matrix;
+    system_matrix.reinit(sparsity_pattern);
+
+    // Assemble Laplace matrix
+    FEValues<dim>             fe_values(mapping,
+                            fe,
+                            QGauss<dim>(fe.degree + 1),
+                            update_gradients | update_JxW_values |
+                              update_quadrature_points);
+    const unsigned int        dofs_per_cell = fe.n_dofs_per_cell();
+    FullMatrix<double>        cell_matrix(dofs_per_cell, dofs_per_cell);
+    Vector<double>            cell_rhs(dofs_per_cell);
+    std::vector<unsigned int> local_dof_indices(dofs_per_cell);
+
+    LinearAlgebra::distributed::Vector<double> system_rhs(locally_owned_dofs,
+                                                          locally_relevant_dofs,
+                                                          comm);
+    system_rhs = 0.0;
+
+    for (const auto &cell : dof_handler.active_cell_iterators())
+      if (cell->is_locally_owned())
         {
-          smoother_data[level].smoothing_range     = 20.;
-          smoother_data[level].degree              = 3;
-          smoother_data[level].eig_cg_n_iterations = 20;
+          cell_matrix = 0.0;
+          cell_rhs    = 0.0;
+          fe_values.reinit(cell);
+
+          for (const unsigned int q : fe_values.quadrature_point_indices())
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                cell_matrix(i, j) += fe_values.shape_grad(i, q) *
+                                     fe_values.shape_grad(j, q) *
+                                     fe_values.JxW(q);
+
+          cell->get_dof_indices(local_dof_indices);
+          constraints.distribute_local_to_global(cell_matrix,
+                                                 cell_rhs,
+                                                 local_dof_indices,
+                                                 system_matrix,
+                                                 system_rhs);
         }
-      else
-        {
-          smoother_data[0].smoothing_range     = 1e-3;
-          smoother_data[0].degree              = 3;
-          smoother_data[0].eig_cg_n_iterations = 20;
-        }
-    }
 
-  mg_smoother.set_steps(2);
-  mg_smoother.initialize(multigrid_matrices, smoother_data);
+    system_matrix.compress(VectorOperation::add);
+    system_rhs.compress(VectorOperation::add);
 
-  Utils::MGCoarseDirect<VectorType,
-                        TrilinosWrappers::SparseMatrix,
-                        TrilinosWrappers::SolverDirect>
-    mg_coarse(*multigrid_matrices[0]);
+    // Set up level matrices via AmgProjector
+    AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
+      injection_matrices);
 
-  MGLevelObject<TrilinosWrappers::SparseMatrix *> mg_level_transfers(0,
-                                                                     mg_levels -
-                                                                       1);
-  for (unsigned int l = 0; l < mg_levels - 1; ++l)
-    mg_level_transfers[l] = &injection_matrices[l];
+    MGLevelObject<std::unique_ptr<TrilinosWrappers::SparseMatrix>>
+      multigrid_matrices(0, mg_levels - 1);
 
-  std::vector<DoFHandler<dim> *> dof_handlers(support_dof_handlers.size() + 1);
-  for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
-    dof_handlers[i] = support_dof_handlers[i].get();
-  dof_handlers[support_dof_handlers.size()] = &dof_handler;
+    multigrid_matrices[multigrid_matrices.max_level()] =
+      std::make_unique<TrilinosWrappers::SparseMatrix>();
+    multigrid_matrices[multigrid_matrices.max_level()]->reinit(system_matrix);
+    multigrid_matrices[multigrid_matrices.max_level()]->copy_from(
+      system_matrix);
 
-  MGTransferAgglomeration<dim, VectorType> mg_transfer(mg_level_transfers,
-                                                       dof_handlers);
+    amg_projector.compute_level_matrices(multigrid_matrices);
 
-  Multigrid<VectorType> mg(mg_matrix,
-                           mg_coarse,
-                           mg_transfer,
-                           mg_smoother,
-                           mg_smoother,
-                           0,
-                           numbers::invalid_unsigned_int,
-                           Multigrid<VectorType>::v_cycle);
+    // Set up multigrid solver
+    using LevelMatrixType = TrilinosWrappers::SparseMatrix;
+    using VectorType      = LinearAlgebra::distributed::Vector<double>;
+    mg::Matrix<VectorType> mg_matrix(multigrid_matrices);
 
-  PreconditionMG<dim, VectorType, MGTransferAgglomeration<dim, VectorType>>
-    preconditioner(dof_handler, mg, mg_transfer);
+    using SmootherType = PreconditionChebyshev<LevelMatrixType, VectorType>;
+    mg::SmootherRelaxation<SmootherType, VectorType>     mg_smoother;
+    MGLevelObject<typename SmootherType::AdditionalData> smoother_data;
+    smoother_data.resize(0, mg_levels - 1);
 
-  // Solve with CG
-  VectorType dist_solution(locally_owned_dofs, comm);
-  dist_solution = 0.0;
+    VectorType diag_inverse(system_matrix.locally_owned_range_indices(), comm);
+    for (unsigned int row = system_matrix.local_range().first;
+         row < system_matrix.local_range().second;
+         ++row)
+      diag_inverse[row] = 1. / system_matrix.diag_element(row);
+    diag_inverse.compress(VectorOperation::insert);
 
-  ReductionControl     solver_control(1000, 1e-12, 1e-9);
-  SolverCG<VectorType> cg(solver_control);
-  cg.solve(system_matrix, dist_solution, system_rhs, preconditioner);
-  if (my_rank == 0)
-    std::cout << "CG converged in " << solver_control.last_step()
-              << " steps, final residual = " << solver_control.last_value()
-              << std::endl;
+    std::vector<VectorType> diag_inverses(mg_levels);
+    diag_inverses[mg_levels - 1] = diag_inverse;
 
-  constraints.distribute(dist_solution);
+    smoother_data[mg_levels - 1].preconditioner =
+      std::make_shared<DiagonalMatrix<VectorType>>(
+        diag_inverses[mg_levels - 1]);
 
-  const double rhs_norm      = system_rhs.l2_norm();
-  const double solution_norm = dist_solution.l2_norm();
+    for (unsigned int level = 0; level < mg_levels - 1; ++level)
+      {
+        smoother_data[level].smoothing_range = 8;
+        diag_inverses[level].reinit(
+          multigrid_matrices[level]->locally_owned_range_indices(), comm);
+        for (unsigned int row = multigrid_matrices[level]->local_range().first;
+             row < multigrid_matrices[level]->local_range().second;
+             ++row)
+          diag_inverses[level][row] =
+            1. / multigrid_matrices[level]->diag_element(row);
+        diag_inverses[level].compress(VectorOperation::insert);
 
-  if (my_rank == 0)
-    std::cout << "RHS norm = " << rhs_norm
-              << ", solution norm = " << solution_norm << std::endl;
+        smoother_data[level].preconditioner =
+          std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[level]);
+      }
 
-  // Compute L2 error against exact solution u(x,y) = x + y
-  VectorType solution_ghosted(locally_owned_dofs, locally_relevant_dofs, comm);
-  solution_ghosted = dist_solution;
-  solution_ghosted.update_ghost_values();
+    for (unsigned int level = 0; level < mg_levels; ++level)
+      {
+        if (level > 0)
+          {
+            smoother_data[level].smoothing_range     = 20.;
+            smoother_data[level].degree              = 3;
+            smoother_data[level].eig_cg_n_iterations = 20;
+          }
+        else
+          {
+            smoother_data[0].smoothing_range     = 1e-3;
+            smoother_data[0].degree              = 3;
+            smoother_data[0].eig_cg_n_iterations = 20;
+          }
+      }
 
-  Vector<double> error_per_cell(starting_tria_pft.n_active_cells());
-  VectorTools::integrate_difference(mapping,
-                                    dof_handler,
-                                    solution_ghosted,
-                                    linear_bc,
-                                    error_per_cell,
-                                    QGauss<dim>(fe.degree + 2),
-                                    VectorTools::L2_norm);
+    mg_smoother.set_steps(2);
+    mg_smoother.initialize(multigrid_matrices, smoother_data);
 
-  double l2_error =
-    std::sqrt(Utilities::MPI::sum(error_per_cell.norm_sqr(), comm));
+    Utils::MGCoarseDirect<VectorType,
+                          TrilinosWrappers::SparseMatrix,
+                          TrilinosWrappers::SolverDirect>
+      mg_coarse(*multigrid_matrices[0]);
 
-  if (my_rank == 0)
-    std::cout << "L2 error: " << l2_error << std::endl;
+    MGLevelObject<TrilinosWrappers::SparseMatrix *> mg_level_transfers(
+      0, mg_levels - 1);
+    for (unsigned int l = 0; l < mg_levels - 1; ++l)
+      mg_level_transfers[l] = &injection_matrices[l];
 
-  Assert(l2_error < tolerance,
-         ExcMessage("L2 error too large: " + std::to_string(l2_error)));
+    std::vector<DoFHandler<dim> *> dof_handlers(support_dof_handlers.size() +
+                                                1);
+    for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+      dof_handlers[i] = support_dof_handlers[i].get();
+    dof_handlers[support_dof_handlers.size()] = &dof_handler;
+
+    MGTransferAgglomeration<dim, VectorType> mg_transfer(mg_level_transfers,
+                                                         dof_handlers);
+
+    Multigrid<VectorType> mg(mg_matrix,
+                             mg_coarse,
+                             mg_transfer,
+                             mg_smoother,
+                             mg_smoother,
+                             0,
+                             numbers::invalid_unsigned_int,
+                             Multigrid<VectorType>::v_cycle);
+
+    PreconditionMG<dim, VectorType, MGTransferAgglomeration<dim, VectorType>>
+      preconditioner(dof_handler, mg, mg_transfer);
+
+    // Solve with CG
+    VectorType dist_solution(locally_owned_dofs, comm);
+    dist_solution = 0.0;
+
+    ReductionControl     solver_control(1000, 1e-12, 1e-9);
+    SolverCG<VectorType> cg(solver_control);
+    cg.solve(system_matrix, dist_solution, system_rhs, preconditioner);
+    if (my_rank == 0)
+      std::cout << "CG converged in " << solver_control.last_step()
+                << " steps, final residual = " << solver_control.last_value()
+                << std::endl;
+
+    constraints.distribute(dist_solution);
+
+    const double rhs_norm      = system_rhs.l2_norm();
+    const double solution_norm = dist_solution.l2_norm();
+
+    if (my_rank == 0)
+      std::cout << "RHS norm = " << rhs_norm
+                << ", solution norm = " << solution_norm << std::endl;
+
+    // Compute L2 error against exact solution u(x,y) = x + y
+    VectorType solution_ghosted(locally_owned_dofs,
+                                locally_relevant_dofs,
+                                comm);
+    solution_ghosted = dist_solution;
+    solution_ghosted.update_ghost_values();
+
+    Vector<double> error_per_cell(starting_tria_pft.n_active_cells());
+    VectorTools::integrate_difference(mapping,
+                                      dof_handler,
+                                      solution_ghosted,
+                                      linear_bc,
+                                      error_per_cell,
+                                      QGauss<dim>(fe.degree + 2),
+                                      VectorTools::L2_norm);
+
+    double l2_error =
+      std::sqrt(Utilities::MPI::sum(error_per_cell.norm_sqr(), comm));
+
+    if (my_rank == 0)
+      std::cout << "L2 error: " << l2_error << std::endl;
+
+    Assert(l2_error < tolerance,
+           ExcMessage("L2 error too large: " + std::to_string(l2_error)));
+  }
 }

--- a/test/polydeal/continuous_poisson_distributed_sanity.cc
+++ b/test/polydeal/continuous_poisson_distributed_sanity.cc
@@ -1,0 +1,344 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/multigrid/mg_coarse.h>
+#include <deal.II/multigrid/mg_matrix.h>
+#include <deal.II/multigrid/mg_smoother.h>
+#include <deal.II/multigrid/mg_tools.h>
+#include <deal.II/multigrid/multigrid.h>
+
+#include <deal.II/numerics/matrix_tools.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/vector_tools_integrate_difference.h>
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+using namespace dealii;
+
+#include "continuous_agglo_utils.h"
+#include "multigrid_amg.h"
+#include "utils.h"
+
+static constexpr double       tolerance  = 1e-6;
+static constexpr unsigned int dim        = 2;
+static constexpr bool         use_points = true;
+
+class LinearSumFunction : public Function<dim>
+{
+public:
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override
+  {
+    (void)component;
+    return p[0] + p[1];
+  }
+};
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  const MPI_Comm                  &comm = MPI_COMM_WORLD;
+  const unsigned int n_ranks            = Utilities::MPI::n_mpi_processes(comm);
+  const unsigned int my_rank = Utilities::MPI::this_mpi_process(comm);
+
+  AssertThrow(n_ranks == 3,
+              ExcMessage(
+                "This test is meant to be run with 3 MPI ranks only."));
+
+  if (my_rank == 0)
+    std::cout << "Running distributed continuous transfer test with " << n_ranks
+              << " MPI ranks." << std::endl;
+
+  static constexpr unsigned int min_elem_per_node = 2;
+  static constexpr unsigned int max_elem_per_node = 4;
+
+  Triangulation<dim> starting_tria;
+  GridGenerator::hyper_cube(starting_tria, 0.0, 1.0);
+  starting_tria.refine_global(4);
+  GridTools::partition_triangulation(n_ranks, starting_tria);
+
+  const auto construction_data =
+    TriangulationDescription::Utilities::create_description_from_triangulation(
+      starting_tria, comm);
+
+  parallel::fullydistributed::Triangulation<dim, dim> starting_tria_pft(comm);
+  starting_tria_pft.create_triangulation(construction_data);
+
+  DoFHandler<dim> dof_handler(starting_tria_pft);
+  FE_Q<dim>       fe(1);
+  dof_handler.distribute_dofs(fe);
+  MappingQ1<dim> mapping;
+
+  std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
+  std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
+  unsigned int                                   mg_levels            = 3;
+  std::vector<unsigned int>                      coarse_space_degrees = {1, 1};
+
+  std::vector<
+    std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
+                                                triangulations(mg_levels - 1);
+  std::vector<std::unique_ptr<DoFHandler<dim>>> support_dof_handlers(mg_levels -
+                                                                     1);
+
+  ContinuousAggloUtils::PointsAgglo::
+    parallel_agglomerate_and_compute_injection_matrices<dim,
+                                                        min_elem_per_node,
+                                                        max_elem_per_node>(
+      dof_handler,
+      mapping,
+      true,
+      injection_matrices,
+      injection_sparsity_patterns,
+      mg_levels,
+      coarse_space_degrees,
+      triangulations,
+      support_dof_handlers);
+
+  // Set up Dirichlet boundary conditions using AffineConstraints
+  const IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
+
+  AffineConstraints<double> constraints;
+  constraints.clear();
+  constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
+  LinearSumFunction linear_bc;
+  VectorTools::interpolate_boundary_values(
+    mapping, dof_handler, 0, linear_bc, constraints);
+  constraints.close();
+
+  // Build distributed sparsity pattern and system matrix
+  TrilinosWrappers::SparsityPattern sparsity_pattern(locally_owned_dofs, comm);
+  DoFTools::make_sparsity_pattern(dof_handler,
+                                  sparsity_pattern,
+                                  constraints,
+                                  false);
+  sparsity_pattern.compress();
+  TrilinosWrappers::SparseMatrix system_matrix;
+  system_matrix.reinit(sparsity_pattern);
+
+  // Assemble Laplace matrix
+  FEValues<dim>             fe_values(mapping,
+                          fe,
+                          QGauss<dim>(fe.degree + 1),
+                          update_gradients | update_JxW_values |
+                            update_quadrature_points);
+  const unsigned int        dofs_per_cell = fe.n_dofs_per_cell();
+  FullMatrix<double>        cell_matrix(dofs_per_cell, dofs_per_cell);
+  Vector<double>            cell_rhs(dofs_per_cell);
+  std::vector<unsigned int> local_dof_indices(dofs_per_cell);
+
+  LinearAlgebra::distributed::Vector<double> system_rhs(locally_owned_dofs,
+                                                        locally_relevant_dofs,
+                                                        comm);
+  system_rhs = 0.0;
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        cell_matrix = 0.0;
+        cell_rhs    = 0.0;
+        fe_values.reinit(cell);
+
+        for (const unsigned int q : fe_values.quadrature_point_indices())
+          for (unsigned int i = 0; i < dofs_per_cell; ++i)
+            for (unsigned int j = 0; j < dofs_per_cell; ++j)
+              cell_matrix(i, j) += fe_values.shape_grad(i, q) *
+                                   fe_values.shape_grad(j, q) *
+                                   fe_values.JxW(q);
+
+        cell->get_dof_indices(local_dof_indices);
+        constraints.distribute_local_to_global(
+          cell_matrix, cell_rhs, local_dof_indices, system_matrix, system_rhs);
+      }
+
+  system_matrix.compress(VectorOperation::add);
+  system_rhs.compress(VectorOperation::add);
+
+  // Set up level matrices via AmgProjector
+  AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
+    injection_matrices);
+
+  MGLevelObject<std::unique_ptr<TrilinosWrappers::SparseMatrix>>
+    multigrid_matrices(0, mg_levels - 1);
+
+  multigrid_matrices[multigrid_matrices.max_level()] =
+    std::make_unique<TrilinosWrappers::SparseMatrix>();
+  multigrid_matrices[multigrid_matrices.max_level()]->reinit(system_matrix);
+  multigrid_matrices[multigrid_matrices.max_level()]->copy_from(system_matrix);
+
+  amg_projector.compute_level_matrices(multigrid_matrices);
+
+  // Set up multigrid solver
+  using LevelMatrixType = TrilinosWrappers::SparseMatrix;
+  using VectorType      = LinearAlgebra::distributed::Vector<double>;
+  mg::Matrix<VectorType> mg_matrix(multigrid_matrices);
+
+  using SmootherType = PreconditionChebyshev<LevelMatrixType, VectorType>;
+  mg::SmootherRelaxation<SmootherType, VectorType>     mg_smoother;
+  MGLevelObject<typename SmootherType::AdditionalData> smoother_data;
+  smoother_data.resize(0, mg_levels - 1);
+
+  VectorType diag_inverse(system_matrix.locally_owned_range_indices(), comm);
+  for (unsigned int row = system_matrix.local_range().first;
+       row < system_matrix.local_range().second;
+       ++row)
+    diag_inverse[row] = 1. / system_matrix.diag_element(row);
+  diag_inverse.compress(VectorOperation::insert);
+
+  std::vector<VectorType> diag_inverses(mg_levels);
+  diag_inverses[mg_levels - 1] = diag_inverse;
+
+  smoother_data[mg_levels - 1].preconditioner =
+    std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[mg_levels - 1]);
+
+  for (unsigned int level = 0; level < mg_levels - 1; ++level)
+    {
+      smoother_data[level].smoothing_range = 8;
+      diag_inverses[level].reinit(
+        multigrid_matrices[level]->locally_owned_range_indices(), comm);
+      for (unsigned int row = multigrid_matrices[level]->local_range().first;
+           row < multigrid_matrices[level]->local_range().second;
+           ++row)
+        diag_inverses[level][row] =
+          1. / multigrid_matrices[level]->diag_element(row);
+      diag_inverses[level].compress(VectorOperation::insert);
+
+      smoother_data[level].preconditioner =
+        std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[level]);
+    }
+
+  for (unsigned int level = 0; level < mg_levels; ++level)
+    {
+      if (level > 0)
+        {
+          smoother_data[level].smoothing_range     = 20.;
+          smoother_data[level].degree              = 3;
+          smoother_data[level].eig_cg_n_iterations = 20;
+        }
+      else
+        {
+          smoother_data[0].smoothing_range     = 1e-3;
+          smoother_data[0].degree              = 3;
+          smoother_data[0].eig_cg_n_iterations = 20;
+        }
+    }
+
+  mg_smoother.set_steps(2);
+  mg_smoother.initialize(multigrid_matrices, smoother_data);
+
+  Utils::MGCoarseDirect<VectorType,
+                        TrilinosWrappers::SparseMatrix,
+                        TrilinosWrappers::SolverDirect>
+    mg_coarse(*multigrid_matrices[0]);
+
+  MGLevelObject<TrilinosWrappers::SparseMatrix *> mg_level_transfers(0,
+                                                                     mg_levels -
+                                                                       1);
+  for (unsigned int l = 0; l < mg_levels - 1; ++l)
+    mg_level_transfers[l] = &injection_matrices[l];
+
+  std::vector<DoFHandler<dim> *> dof_handlers(support_dof_handlers.size() + 1);
+  for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+    dof_handlers[i] = support_dof_handlers[i].get();
+  dof_handlers[support_dof_handlers.size()] = &dof_handler;
+
+  MGTransferAgglomeration<dim, VectorType> mg_transfer(mg_level_transfers,
+                                                       dof_handlers);
+
+  Multigrid<VectorType> mg(mg_matrix,
+                           mg_coarse,
+                           mg_transfer,
+                           mg_smoother,
+                           mg_smoother,
+                           0,
+                           numbers::invalid_unsigned_int,
+                           Multigrid<VectorType>::v_cycle);
+
+  PreconditionMG<dim, VectorType, MGTransferAgglomeration<dim, VectorType>>
+    preconditioner(dof_handler, mg, mg_transfer);
+
+  // Solve with CG
+  VectorType dist_solution(locally_owned_dofs, comm);
+  dist_solution = 0.0;
+
+  ReductionControl     solver_control(1000, 1e-12, 1e-9);
+  SolverCG<VectorType> cg(solver_control);
+  cg.solve(system_matrix, dist_solution, system_rhs, preconditioner);
+  if (my_rank == 0)
+    std::cout << "CG converged in " << solver_control.last_step()
+              << " steps, final residual = " << solver_control.last_value()
+              << std::endl;
+
+  constraints.distribute(dist_solution);
+
+  const double rhs_norm      = system_rhs.l2_norm();
+  const double solution_norm = dist_solution.l2_norm();
+
+  if (my_rank == 0)
+    std::cout << "RHS norm = " << rhs_norm
+              << ", solution norm = " << solution_norm << std::endl;
+
+  // Compute L2 error against exact solution u(x,y) = x + y
+  VectorType solution_ghosted(locally_owned_dofs, locally_relevant_dofs, comm);
+  solution_ghosted = dist_solution;
+  solution_ghosted.update_ghost_values();
+
+  Vector<double> error_per_cell(starting_tria_pft.n_active_cells());
+  VectorTools::integrate_difference(mapping,
+                                    dof_handler,
+                                    solution_ghosted,
+                                    linear_bc,
+                                    error_per_cell,
+                                    QGauss<dim>(fe.degree + 2),
+                                    VectorTools::L2_norm);
+
+  double l2_error =
+    std::sqrt(Utilities::MPI::sum(error_per_cell.norm_sqr(), comm));
+
+  if (my_rank == 0)
+    std::cout << "L2 error: " << l2_error << std::endl;
+
+  Assert(l2_error < tolerance,
+         ExcMessage("L2 error too large: " + std::to_string(l2_error)));
+}

--- a/test/polydeal/continuous_poisson_distributed_sanity.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/test/polydeal/continuous_poisson_distributed_sanity.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,4 @@
+Running distributed continuous transfer test with 3 MPI ranks.
+CG converged in 5 steps, final residual = 6.25928e-09
+RHS norm = 9.14923, solution norm = 18.5253
+L2 error: 1.86636e-10

--- a/test/polydeal/continuous_poisson_distributed_sanity.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/test/polydeal/continuous_poisson_distributed_sanity.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,4 +1,9 @@
 Running distributed continuous transfer test with 3 MPI ranks.
+Running point agglomeration test
 CG converged in 5 steps, final residual = 6.25928e-09
 RHS norm = 9.14923, solution norm = 18.5253
 L2 error: 1.86636e-10
+Running cell agglomeration test
+CG converged in 5 steps, final residual = 6.30976e-09
+RHS norm = 9.14923, solution norm = 18.5253
+L2 error: 1.62005e-10

--- a/test/polydeal/continuous_poisson_serial_sanity.cc
+++ b/test/polydeal/continuous_poisson_serial_sanity.cc
@@ -58,9 +58,8 @@
 #include "continuous_agglo_utils.h"
 #include "poly_utils.h"
 
-static constexpr double       tolerance  = 1e-6;
-static constexpr unsigned int dim        = 2;
-static constexpr bool         use_points = true;
+static constexpr double       tolerance = 1e-6;
+static constexpr unsigned int dim       = 2;
 using namespace dealii;
 
 // Custom linear function: f(x,y) = x + y
@@ -98,236 +97,480 @@ main(int argc, char *argv[])
                                        dof_handler,
                                        support_points_vector);
 
-  std::vector<SparseMatrix<double>> injection_matrices;
-  std::vector<SparsityPattern>      injection_sparsity_patterns;
-  std::vector<unsigned int>         coarse_space_degrees = {1, 1};
-  const unsigned int                mg_levels            = 3;
+  // Point agglo section
+  {
+    std::vector<SparseMatrix<double>> injection_matrices;
+    std::vector<SparsityPattern>      injection_sparsity_patterns;
+    std::vector<unsigned int>         coarse_space_degrees = {1, 1};
+    const unsigned int                mg_levels            = 3;
 
-  // Output vectors for triangulations and DoFHandlers
-  std::vector<std::unique_ptr<Triangulation<dim>>> triangulations;
-  std::vector<std::unique_ptr<DoFHandler<dim>>>    support_dof_handlers;
+    // Output vectors for triangulations and DoFHandlers
+    std::vector<std::unique_ptr<Triangulation<dim>>> triangulations;
+    std::vector<std::unique_ptr<DoFHandler<dim>>>    support_dof_handlers;
 
-  ContinuousAggloUtils::PointsAgglo::agglomerate_and_compute_injection_matrices<
-    2,
-    min_elem_per_node,
-    max_elem_per_node>(support_points_vector,
-                       true, // skip_leaves
-                       injection_matrices,
-                       injection_sparsity_patterns,
-                       mg_levels,
-                       coarse_space_degrees,
-                       triangulations,
-                       support_dof_handlers);
+    ContinuousAggloUtils::PointsAgglo::
+      agglomerate_and_compute_injection_matrices<2,
+                                                 min_elem_per_node,
+                                                 max_elem_per_node>(
+        support_points_vector,
+        true, // skip_leaves
+        injection_matrices,
+        injection_sparsity_patterns,
+        mg_levels,
+        coarse_space_degrees,
+        triangulations,
+        support_dof_handlers);
 
-  for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
-    {
-      std::cout << "Level " << i << ":" << std::endl;
-      std::cout << "  - Triangulation cells: "
-                << triangulations[i]->n_active_cells() << std::endl;
-      std::cout << "  - DoFs: " << support_dof_handlers[i]->n_dofs()
-                << std::endl;
-      if (i < injection_matrices.size())
-        {
-          std::cout << "  - Injection matrix: " << injection_matrices[i].m()
-                    << " x " << injection_matrices[i].n() << std::endl;
-        }
-      std::cout << std::endl;
-    }
+    for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+      {
+        std::cout << "Level " << i << ":" << std::endl;
+        std::cout << "  - Triangulation cells: "
+                  << triangulations[i]->n_active_cells() << std::endl;
+        std::cout << "  - DoFs: " << support_dof_handlers[i]->n_dofs()
+                  << std::endl;
+        if (i < injection_matrices.size())
+          {
+            std::cout << "  - Injection matrix: " << injection_matrices[i].m()
+                      << " x " << injection_matrices[i].n() << std::endl;
+          }
+        std::cout << std::endl;
+      }
 
-  std::cout << "Level " << support_dof_handlers.size()
-            << " (finest level):" << std::endl;
-  std::cout << "  - Triangulation cells: " << tria.n_active_cells()
-            << std::endl;
-  std::cout << "  - DoFs: " << dof_handler.n_dofs() << std::endl;
-  std::cout << std::endl;
+    std::cout << "Level " << support_dof_handlers.size()
+              << " (finest level):" << std::endl;
+    std::cout << "  - Triangulation cells: " << tria.n_active_cells()
+              << std::endl;
+    std::cout << "  - DoFs: " << dof_handler.n_dofs() << std::endl;
+    std::cout << std::endl;
 
-  // Check that the sizes of the matrices match expectations
-  Assert(injection_matrices.size() == mg_levels - 1,
-         ExcMessage(
-           "The number of injection matrices should be mg_levels - 1."));
-  Assert(
-    injection_sparsity_patterns.size() == mg_levels - 1,
-    ExcMessage(
-      "The number of injection sparsity patterns should be mg_levels - 1."));
-  Assert(
-    injection_matrices[mg_levels - 2].m() == dof_handler.n_dofs(),
-    ExcMessage(
-      "The number of rows of the first injection matrix should match the number of DoFs on the finest level."));
-  Assert(
-    injection_matrices[mg_levels - 3].m() ==
-      injection_matrices[mg_levels - 2].n(),
-    ExcMessage(
-      "The number of rows of the second injection matrix should match the number of columns of the first injection matrix."));
+    // Check that the sizes of the matrices match expectations
+    Assert(injection_matrices.size() == mg_levels - 1,
+           ExcMessage(
+             "The number of injection matrices should be mg_levels - 1."));
+    Assert(
+      injection_sparsity_patterns.size() == mg_levels - 1,
+      ExcMessage(
+        "The number of injection sparsity patterns should be mg_levels - 1."));
+    Assert(
+      injection_matrices[mg_levels - 2].m() == dof_handler.n_dofs(),
+      ExcMessage(
+        "The number of rows of the first injection matrix should match the number of DoFs on the finest level."));
+    Assert(
+      injection_matrices[mg_levels - 3].m() ==
+        injection_matrices[mg_levels - 2].n(),
+      ExcMessage(
+        "The number of rows of the second injection matrix should match the number of columns of the first injection matrix."));
 
-  std::vector<TrilinosWrappers::SparseMatrix> trilinos_transfer_matrices(
-    mg_levels - 1);
+    std::vector<TrilinosWrappers::SparseMatrix> trilinos_transfer_matrices(
+      mg_levels - 1);
 
-  for (unsigned int level = 0; level < mg_levels - 1; ++level)
-    {
-      trilinos_transfer_matrices[level].reinit(injection_matrices[level]);
-    }
+    for (unsigned int level = 0; level < mg_levels - 1; ++level)
+      {
+        trilinos_transfer_matrices[level].reinit(injection_matrices[level]);
+      }
 
-  AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
-    trilinos_transfer_matrices);
+    AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
+      trilinos_transfer_matrices);
 
-  MGLevelObject<std::unique_ptr<TrilinosWrappers::SparseMatrix>>
-    multigrid_matrices(0, mg_levels - 1);
+    MGLevelObject<std::unique_ptr<TrilinosWrappers::SparseMatrix>>
+      multigrid_matrices(0, mg_levels - 1);
 
-  // Create Laplace matrix for Poisson problem
-  SparseMatrix<double> system_matrix;
-  SparsityPattern      sparsity_pattern;
-  Vector<double>       system_rhs(dof_handler.n_dofs());
-  system_rhs = 0.0;
-  Vector<double> solution(dof_handler.n_dofs());
+    // Create Laplace matrix for Poisson problem
+    SparseMatrix<double> system_matrix;
+    SparsityPattern      sparsity_pattern;
+    Vector<double>       system_rhs(dof_handler.n_dofs());
+    system_rhs = 0.0;
+    Vector<double> solution(dof_handler.n_dofs());
 
-  DynamicSparsityPattern dsp(dof_handler.n_dofs(), dof_handler.n_dofs());
-  DoFTools::make_sparsity_pattern(dof_handler, dsp);
-  sparsity_pattern.copy_from(dsp);
-  system_matrix.reinit(sparsity_pattern);
+    DynamicSparsityPattern dsp(dof_handler.n_dofs(), dof_handler.n_dofs());
+    DoFTools::make_sparsity_pattern(dof_handler, dsp);
+    sparsity_pattern.copy_from(dsp);
+    system_matrix.reinit(sparsity_pattern);
 
-  MatrixCreator::create_laplace_matrix(mapping,
-                                       dof_handler,
-                                       QGauss<dim>(fe.degree + 1),
-                                       system_matrix);
+    MatrixCreator::create_laplace_matrix(mapping,
+                                         dof_handler,
+                                         QGauss<dim>(fe.degree + 1),
+                                         system_matrix);
 
-  // Interpolate linear boundary conditions: f(x,y) = x + y
-  std::map<types::global_dof_index, double> boundary_values;
-  LinearSumFunction                         linear_bc;
-  VectorTools::interpolate_boundary_values(mapping,
-                                           dof_handler,
-                                           0,         // boundary id
-                                           linear_bc, // f(x,y) = x + y
-                                           boundary_values);
+    // Interpolate linear boundary conditions: f(x,y) = x + y
+    std::map<types::global_dof_index, double> boundary_values;
+    LinearSumFunction                         linear_bc;
+    VectorTools::interpolate_boundary_values(mapping,
+                                             dof_handler,
+                                             0,         // boundary id
+                                             linear_bc, // f(x,y) = x + y
+                                             boundary_values);
 
-  MatrixTools::apply_boundary_values(boundary_values,
-                                     system_matrix,
-                                     solution,
-                                     system_rhs);
+    MatrixTools::apply_boundary_values(boundary_values,
+                                       system_matrix,
+                                       solution,
+                                       system_rhs);
 
-  multigrid_matrices[multigrid_matrices.max_level()] =
-    std::make_unique<TrilinosWrappers::SparseMatrix>();
+    multigrid_matrices[multigrid_matrices.max_level()] =
+      std::make_unique<TrilinosWrappers::SparseMatrix>();
 
-  multigrid_matrices[multigrid_matrices.max_level()]->reinit(system_matrix);
+    multigrid_matrices[multigrid_matrices.max_level()]->reinit(system_matrix);
 
-  amg_projector.compute_level_matrices(multigrid_matrices);
+    amg_projector.compute_level_matrices(multigrid_matrices);
 
-  using LevelMatrixType = TrilinosWrappers::SparseMatrix;
-  using VectorType      = LinearAlgebra::distributed::Vector<double>;
-  mg::Matrix<VectorType> mg_matrix(multigrid_matrices);
+    using LevelMatrixType = TrilinosWrappers::SparseMatrix;
+    using VectorType      = LinearAlgebra::distributed::Vector<double>;
+    mg::Matrix<VectorType> mg_matrix(multigrid_matrices);
 
-  using SmootherType = PreconditionChebyshev<LevelMatrixType, VectorType>;
-  mg::SmootherRelaxation<SmootherType, VectorType>     mg_smoother;
-  MGLevelObject<typename SmootherType::AdditionalData> smoother_data;
-  smoother_data.resize(0, mg_levels - 1);
+    using SmootherType = PreconditionChebyshev<LevelMatrixType, VectorType>;
+    mg::SmootherRelaxation<SmootherType, VectorType>     mg_smoother;
+    MGLevelObject<typename SmootherType::AdditionalData> smoother_data;
+    smoother_data.resize(0, mg_levels - 1);
 
-  VectorType diag_inverse(system_matrix.m());
-  for (unsigned int row = 0; row < system_matrix.m(); ++row)
-    diag_inverse[row] = 1. / system_matrix.diag_element(row);
-  diag_inverse.compress(VectorOperation::insert);
+    VectorType diag_inverse(system_matrix.m());
+    for (unsigned int row = 0; row < system_matrix.m(); ++row)
+      diag_inverse[row] = 1. / system_matrix.diag_element(row);
+    diag_inverse.compress(VectorOperation::insert);
 
-  std::vector<VectorType> diag_inverses(mg_levels);
-  diag_inverses[mg_levels - 1] = diag_inverse;
+    std::vector<VectorType> diag_inverses(mg_levels);
+    diag_inverses[mg_levels - 1] = diag_inverse;
 
-  smoother_data[mg_levels - 1].preconditioner =
-    std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[mg_levels - 1]);
+    smoother_data[mg_levels - 1].preconditioner =
+      std::make_shared<DiagonalMatrix<VectorType>>(
+        diag_inverses[mg_levels - 1]);
 
-  for (unsigned int level = 0; level < mg_levels - 1; ++level)
-    {
-      // For simplicity using the same degree for all levels
-      smoother_data[level].smoothing_range = 8;
-      diag_inverses[level].reinit(
-        multigrid_matrices[level]->m()); // need to reinit
-      for (unsigned int row = 0; row < multigrid_matrices[level]->m(); ++row)
-        diag_inverses[level][row] =
-          1. / multigrid_matrices[level]->diag_element(row);
-      diag_inverses[level].compress(VectorOperation::insert);
+    for (unsigned int level = 0; level < mg_levels - 1; ++level)
+      {
+        // For simplicity using the same degree for all levels
+        smoother_data[level].smoothing_range = 8;
+        diag_inverses[level].reinit(
+          multigrid_matrices[level]->m()); // need to reinit
+        for (unsigned int row = 0; row < multigrid_matrices[level]->m(); ++row)
+          diag_inverses[level][row] =
+            1. / multigrid_matrices[level]->diag_element(row);
+        diag_inverses[level].compress(VectorOperation::insert);
 
-      smoother_data[level].preconditioner =
-        std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[level]);
-    }
+        smoother_data[level].preconditioner =
+          std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[level]);
+      }
 
-  for (unsigned int level = 0; level < mg_levels; ++level)
-    {
-      if (level > 0)
-        {
-          smoother_data[level].smoothing_range = 20.; // 15.;
-          smoother_data[level].degree          = 3; // parameters.smoother_steps
-          smoother_data[level].eig_cg_n_iterations = 20;
-        }
-      else
-        {
-          smoother_data[0].smoothing_range = 1e-3;
-          smoother_data[0].degree = 3; // numbers::invalid_unsigned_int;
-          smoother_data[0].eig_cg_n_iterations = 20;
-        }
-    }
+    for (unsigned int level = 0; level < mg_levels; ++level)
+      {
+        if (level > 0)
+          {
+            smoother_data[level].smoothing_range = 20.; // 15.;
+            smoother_data[level].degree = 3; // parameters.smoother_steps
+            smoother_data[level].eig_cg_n_iterations = 20;
+          }
+        else
+          {
+            smoother_data[0].smoothing_range = 1e-3;
+            smoother_data[0].degree = 3; // numbers::invalid_unsigned_int;
+            smoother_data[0].eig_cg_n_iterations = 20;
+          }
+      }
 
-  mg_smoother.set_steps(2);
-  mg_smoother.initialize(multigrid_matrices, smoother_data);
+    mg_smoother.set_steps(2);
+    mg_smoother.initialize(multigrid_matrices, smoother_data);
 
-  Utils::MGCoarseDirect<VectorType,
-                        TrilinosWrappers::SparseMatrix,
-                        TrilinosWrappers::SolverDirect>
-    mg_coarse(*multigrid_matrices[0]);
+    Utils::MGCoarseDirect<VectorType,
+                          TrilinosWrappers::SparseMatrix,
+                          TrilinosWrappers::SolverDirect>
+      mg_coarse(*multigrid_matrices[0]);
 
-  MGLevelObject<TrilinosWrappers::SparseMatrix *> mg_level_transfers(0,
-                                                                     mg_levels -
-                                                                       1);
-  for (unsigned int l = 0; l < mg_levels - 1; ++l)
-    mg_level_transfers[l] = &trilinos_transfer_matrices[l];
+    MGLevelObject<TrilinosWrappers::SparseMatrix *> mg_level_transfers(
+      0, mg_levels - 1);
+    for (unsigned int l = 0; l < mg_levels - 1; ++l)
+      mg_level_transfers[l] = &trilinos_transfer_matrices[l];
 
-  std::vector<DoFHandler<dim> *> dof_handlers(support_dof_handlers.size() + 1);
+    std::vector<DoFHandler<dim> *> dof_handlers(support_dof_handlers.size() +
+                                                1);
 
-  for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
-    dof_handlers[i] = support_dof_handlers[i].get();
+    for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+      dof_handlers[i] = support_dof_handlers[i].get();
 
-  dof_handlers[support_dof_handlers.size()] = &dof_handler;
+    dof_handlers[support_dof_handlers.size()] = &dof_handler;
 
-  MGTransferAgglomeration<dim, VectorType> mg_transfer(mg_level_transfers,
-                                                       dof_handlers);
+    MGTransferAgglomeration<dim, VectorType> mg_transfer(mg_level_transfers,
+                                                         dof_handlers);
 
-  Multigrid<VectorType> mg(mg_matrix,
-                           mg_coarse,
-                           mg_transfer,
-                           mg_smoother,
-                           mg_smoother,
-                           0, // min_level
-                           numbers::invalid_unsigned_int,
-                           Multigrid<VectorType>::v_cycle);
+    Multigrid<VectorType> mg(mg_matrix,
+                             mg_coarse,
+                             mg_transfer,
+                             mg_smoother,
+                             mg_smoother,
+                             0, // min_level
+                             numbers::invalid_unsigned_int,
+                             Multigrid<VectorType>::v_cycle);
 
-  PreconditionMG<dim, VectorType, MGTransferAgglomeration<dim, VectorType>>
-    preconditioner(dof_handler, mg, mg_transfer);
+    PreconditionMG<dim, VectorType, MGTransferAgglomeration<dim, VectorType>>
+      preconditioner(dof_handler, mg, mg_transfer);
 
 
-  VectorType dist_solution;
-  VectorType dist_rhs;
-  dist_solution.reinit(dof_handler.n_dofs());
-  dist_rhs.reinit(dof_handler.n_dofs());
-  for (unsigned int i = 0; i < system_rhs.size(); ++i)
-    dist_rhs[i] = system_rhs[i];
-  dist_rhs.compress(VectorOperation::insert);
+    VectorType dist_solution;
+    VectorType dist_rhs;
+    dist_solution.reinit(dof_handler.n_dofs());
+    dist_rhs.reinit(dof_handler.n_dofs());
+    for (unsigned int i = 0; i < system_rhs.size(); ++i)
+      dist_rhs[i] = system_rhs[i];
+    dist_rhs.compress(VectorOperation::insert);
 
-  ReductionControl solver_control(100, 1e-9, 1e-6);
+    ReductionControl solver_control(100, 1e-9, 1e-6);
 
-  SolverCG<VectorType> cg(solver_control);
-  cg.solve(system_matrix, dist_solution, dist_rhs, preconditioner);
+    SolverCG<VectorType> cg(solver_control);
+    cg.solve(system_matrix, dist_solution, dist_rhs, preconditioner);
 
-  for (unsigned int i = 0; i < solution.size(); ++i)
-    solution[i] = dist_solution[i];
+    for (unsigned int i = 0; i < solution.size(); ++i)
+      solution[i] = dist_solution[i];
 
-  // Verify solution against analytical solution u(x,y) = x + y
-  Vector<double> error_per_cell(tria.n_active_cells());
+    // Verify solution against analytical solution u(x,y) = x + y
+    Vector<double> error_per_cell(tria.n_active_cells());
 
-  VectorTools::integrate_difference(mapping,
-                                    dof_handler,
-                                    solution,
-                                    linear_bc,
-                                    error_per_cell,
-                                    QGauss<dim>(fe.degree + 2),
-                                    VectorTools::L2_norm);
+    VectorTools::integrate_difference(mapping,
+                                      dof_handler,
+                                      solution,
+                                      linear_bc,
+                                      error_per_cell,
+                                      QGauss<dim>(fe.degree + 2),
+                                      VectorTools::L2_norm);
 
-  double l2_error = error_per_cell.l2_norm();
+    double l2_error = error_per_cell.l2_norm();
 
-  Assert(l2_error < tolerance,
-         ExcMessage("L2 error too large: " + std::to_string(l2_error)));
+    Assert(l2_error < tolerance,
+           ExcMessage("L2 error too large: " + std::to_string(l2_error)));
+  }
+
+  // Cell agglo section
+  {
+    std::vector<SparseMatrix<double>> injection_matrices;
+    std::vector<SparsityPattern>      injection_sparsity_patterns;
+    std::vector<unsigned int>         coarse_space_degrees = {1, 1};
+    const unsigned int                mg_levels            = 3;
+
+    // Output vectors for triangulations and DoFHandlers
+    std::vector<std::unique_ptr<Triangulation<dim>>> triangulations;
+    std::vector<std::unique_ptr<DoFHandler<dim>>>    support_dof_handlers;
+
+    ContinuousAggloUtils::CellsAgglo::
+      agglomerate_and_compute_injection_matrices<2,
+                                                 min_elem_per_node,
+                                                 max_elem_per_node>(
+        dof_handler,
+        mapping,
+        true, // skip_leaves
+        injection_matrices,
+        injection_sparsity_patterns,
+        mg_levels,
+        coarse_space_degrees,
+        triangulations,
+        support_dof_handlers);
+
+    for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+      {
+        std::cout << "Level " << i << ":" << std::endl;
+        std::cout << "  - Triangulation cells: "
+                  << triangulations[i]->n_active_cells() << std::endl;
+        std::cout << "  - DoFs: " << support_dof_handlers[i]->n_dofs()
+                  << std::endl;
+        if (i < injection_matrices.size())
+          {
+            std::cout << "  - Injection matrix: " << injection_matrices[i].m()
+                      << " x " << injection_matrices[i].n() << std::endl;
+          }
+        std::cout << std::endl;
+      }
+
+    std::cout << "Level " << support_dof_handlers.size()
+              << " (finest level):" << std::endl;
+    std::cout << "  - Triangulation cells: " << tria.n_active_cells()
+              << std::endl;
+    std::cout << "  - DoFs: " << dof_handler.n_dofs() << std::endl;
+    std::cout << std::endl;
+
+    // Check that the sizes of the matrices match expectations
+    Assert(injection_matrices.size() == mg_levels - 1,
+           ExcMessage(
+             "The number of injection matrices should be mg_levels - 1."));
+    Assert(
+      injection_sparsity_patterns.size() == mg_levels - 1,
+      ExcMessage(
+        "The number of injection sparsity patterns should be mg_levels - 1."));
+    Assert(
+      injection_matrices[mg_levels - 2].m() == dof_handler.n_dofs(),
+      ExcMessage(
+        "The number of rows of the first injection matrix should match the number of DoFs on the finest level."));
+    Assert(
+      injection_matrices[mg_levels - 3].m() ==
+        injection_matrices[mg_levels - 2].n(),
+      ExcMessage(
+        "The number of rows of the second injection matrix should match the number of columns of the first injection matrix."));
+
+    std::vector<TrilinosWrappers::SparseMatrix> trilinos_transfer_matrices(
+      mg_levels - 1);
+
+    for (unsigned int level = 0; level < mg_levels - 1; ++level)
+      {
+        trilinos_transfer_matrices[level].reinit(injection_matrices[level]);
+      }
+
+    AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
+      trilinos_transfer_matrices);
+
+    MGLevelObject<std::unique_ptr<TrilinosWrappers::SparseMatrix>>
+      multigrid_matrices(0, mg_levels - 1);
+
+    // Create Laplace matrix for Poisson problem
+    SparseMatrix<double> system_matrix;
+    SparsityPattern      sparsity_pattern;
+    Vector<double>       system_rhs(dof_handler.n_dofs());
+    system_rhs = 0.0;
+    Vector<double> solution(dof_handler.n_dofs());
+
+    DynamicSparsityPattern dsp(dof_handler.n_dofs(), dof_handler.n_dofs());
+    DoFTools::make_sparsity_pattern(dof_handler, dsp);
+    sparsity_pattern.copy_from(dsp);
+    system_matrix.reinit(sparsity_pattern);
+
+    MatrixCreator::create_laplace_matrix(mapping,
+                                         dof_handler,
+                                         QGauss<dim>(fe.degree + 1),
+                                         system_matrix);
+
+    // Interpolate linear boundary conditions: f(x,y) = x + y
+    std::map<types::global_dof_index, double> boundary_values;
+    LinearSumFunction                         linear_bc;
+    VectorTools::interpolate_boundary_values(mapping,
+                                             dof_handler,
+                                             0,         // boundary id
+                                             linear_bc, // f(x,y) = x + y
+                                             boundary_values);
+
+    MatrixTools::apply_boundary_values(boundary_values,
+                                       system_matrix,
+                                       solution,
+                                       system_rhs);
+
+    multigrid_matrices[multigrid_matrices.max_level()] =
+      std::make_unique<TrilinosWrappers::SparseMatrix>();
+
+    multigrid_matrices[multigrid_matrices.max_level()]->reinit(system_matrix);
+
+    amg_projector.compute_level_matrices(multigrid_matrices);
+
+    using LevelMatrixType = TrilinosWrappers::SparseMatrix;
+    using VectorType      = LinearAlgebra::distributed::Vector<double>;
+    mg::Matrix<VectorType> mg_matrix(multigrid_matrices);
+
+    using SmootherType = PreconditionChebyshev<LevelMatrixType, VectorType>;
+    mg::SmootherRelaxation<SmootherType, VectorType>     mg_smoother;
+    MGLevelObject<typename SmootherType::AdditionalData> smoother_data;
+    smoother_data.resize(0, mg_levels - 1);
+
+    VectorType diag_inverse(system_matrix.m());
+    for (unsigned int row = 0; row < system_matrix.m(); ++row)
+      diag_inverse[row] = 1. / system_matrix.diag_element(row);
+    diag_inverse.compress(VectorOperation::insert);
+
+    std::vector<VectorType> diag_inverses(mg_levels);
+    diag_inverses[mg_levels - 1] = diag_inverse;
+
+    smoother_data[mg_levels - 1].preconditioner =
+      std::make_shared<DiagonalMatrix<VectorType>>(
+        diag_inverses[mg_levels - 1]);
+
+    for (unsigned int level = 0; level < mg_levels - 1; ++level)
+      {
+        // For simplicity using the same degree for all levels
+        smoother_data[level].smoothing_range = 8;
+        diag_inverses[level].reinit(
+          multigrid_matrices[level]->m()); // need to reinit
+        for (unsigned int row = 0; row < multigrid_matrices[level]->m(); ++row)
+          diag_inverses[level][row] =
+            1. / multigrid_matrices[level]->diag_element(row);
+        diag_inverses[level].compress(VectorOperation::insert);
+
+        smoother_data[level].preconditioner =
+          std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[level]);
+      }
+
+    for (unsigned int level = 0; level < mg_levels; ++level)
+      {
+        if (level > 0)
+          {
+            smoother_data[level].smoothing_range = 20.; // 15.;
+            smoother_data[level].degree = 3; // parameters.smoother_steps
+            smoother_data[level].eig_cg_n_iterations = 20;
+          }
+        else
+          {
+            smoother_data[0].smoothing_range = 1e-3;
+            smoother_data[0].degree = 3; // numbers::invalid_unsigned_int;
+            smoother_data[0].eig_cg_n_iterations = 20;
+          }
+      }
+
+    mg_smoother.set_steps(2);
+    mg_smoother.initialize(multigrid_matrices, smoother_data);
+
+    Utils::MGCoarseDirect<VectorType,
+                          TrilinosWrappers::SparseMatrix,
+                          TrilinosWrappers::SolverDirect>
+      mg_coarse(*multigrid_matrices[0]);
+
+    MGLevelObject<TrilinosWrappers::SparseMatrix *> mg_level_transfers(
+      0, mg_levels - 1);
+    for (unsigned int l = 0; l < mg_levels - 1; ++l)
+      mg_level_transfers[l] = &trilinos_transfer_matrices[l];
+
+    std::vector<DoFHandler<dim> *> dof_handlers(support_dof_handlers.size() +
+                                                1);
+
+    for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+      dof_handlers[i] = support_dof_handlers[i].get();
+
+    dof_handlers[support_dof_handlers.size()] = &dof_handler;
+
+    MGTransferAgglomeration<dim, VectorType> mg_transfer(mg_level_transfers,
+                                                         dof_handlers);
+
+    Multigrid<VectorType> mg(mg_matrix,
+                             mg_coarse,
+                             mg_transfer,
+                             mg_smoother,
+                             mg_smoother,
+                             0, // min_level
+                             numbers::invalid_unsigned_int,
+                             Multigrid<VectorType>::v_cycle);
+
+    PreconditionMG<dim, VectorType, MGTransferAgglomeration<dim, VectorType>>
+      preconditioner(dof_handler, mg, mg_transfer);
+
+
+    VectorType dist_solution;
+    VectorType dist_rhs;
+    dist_solution.reinit(dof_handler.n_dofs());
+    dist_rhs.reinit(dof_handler.n_dofs());
+    for (unsigned int i = 0; i < system_rhs.size(); ++i)
+      dist_rhs[i] = system_rhs[i];
+    dist_rhs.compress(VectorOperation::insert);
+
+    ReductionControl solver_control(100, 1e-9, 1e-6);
+
+    SolverCG<VectorType> cg(solver_control);
+    cg.solve(system_matrix, dist_solution, dist_rhs, preconditioner);
+
+    for (unsigned int i = 0; i < solution.size(); ++i)
+      solution[i] = dist_solution[i];
+
+    // Verify solution against analytical solution u(x,y) = x + y
+    Vector<double> error_per_cell(tria.n_active_cells());
+
+    VectorTools::integrate_difference(mapping,
+                                      dof_handler,
+                                      solution,
+                                      linear_bc,
+                                      error_per_cell,
+                                      QGauss<dim>(fe.degree + 2),
+                                      VectorTools::L2_norm);
+
+    double l2_error = error_per_cell.l2_norm();
+
+    Assert(l2_error < tolerance,
+           ExcMessage("L2 error too large: " + std::to_string(l2_error)));
+  }
 }

--- a/test/polydeal/continuous_poisson_serial_sanity.cc
+++ b/test/polydeal/continuous_poisson_serial_sanity.cc
@@ -1,0 +1,333 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/multigrid/mg_coarse.h>
+#include <deal.II/multigrid/mg_matrix.h>
+#include <deal.II/multigrid/mg_smoother.h>
+#include <deal.II/multigrid/mg_tools.h>
+#include <deal.II/multigrid/multigrid.h>
+
+#include <deal.II/numerics/matrix_creator.h>
+#include <deal.II/numerics/matrix_tools.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include "agglomeration_handler.h"
+#include "continuous_agglo_utils.h"
+#include "poly_utils.h"
+
+static constexpr double       tolerance  = 1e-6;
+static constexpr unsigned int dim        = 2;
+static constexpr bool         use_points = true;
+using namespace dealii;
+
+// Custom linear function: f(x,y) = x + y
+class LinearSumFunction : public Function<2>
+{
+public:
+  virtual double
+  value(const Point<2> &p, const unsigned int component = 0) const override
+  {
+    (void)component;
+    return p[0] + p[1];
+  }
+};
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  namespace bgi                                   = boost::geometry::index;
+  static constexpr unsigned int min_elem_per_node = 2;
+  static constexpr unsigned int max_elem_per_node = 4;
+
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, 0., 1.);
+  tria.refine_global(5);
+
+  DoFHandler<dim> dof_handler(tria);
+  FE_Q<dim>       fe(1);
+  dof_handler.distribute_dofs(fe);
+
+  std::vector<Point<dim>> support_points_vector(dof_handler.n_dofs());
+  MappingQ1<dim>          mapping;
+
+  DoFTools::map_dofs_to_support_points(mapping,
+                                       dof_handler,
+                                       support_points_vector);
+
+  std::vector<SparseMatrix<double>> injection_matrices;
+  std::vector<SparsityPattern>      injection_sparsity_patterns;
+  std::vector<unsigned int>         coarse_space_degrees = {1, 1};
+  const unsigned int                mg_levels            = 3;
+
+  // Output vectors for triangulations and DoFHandlers
+  std::vector<std::unique_ptr<Triangulation<dim>>> triangulations;
+  std::vector<std::unique_ptr<DoFHandler<dim>>>    support_dof_handlers;
+
+  ContinuousAggloUtils::PointsAgglo::agglomerate_and_compute_injection_matrices<
+    2,
+    min_elem_per_node,
+    max_elem_per_node>(support_points_vector,
+                       true, // skip_leaves
+                       injection_matrices,
+                       injection_sparsity_patterns,
+                       mg_levels,
+                       coarse_space_degrees,
+                       triangulations,
+                       support_dof_handlers);
+
+  for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+    {
+      std::cout << "Level " << i << ":" << std::endl;
+      std::cout << "  - Triangulation cells: "
+                << triangulations[i]->n_active_cells() << std::endl;
+      std::cout << "  - DoFs: " << support_dof_handlers[i]->n_dofs()
+                << std::endl;
+      if (i < injection_matrices.size())
+        {
+          std::cout << "  - Injection matrix: " << injection_matrices[i].m()
+                    << " x " << injection_matrices[i].n() << std::endl;
+        }
+      std::cout << std::endl;
+    }
+
+  std::cout << "Level " << support_dof_handlers.size()
+            << " (finest level):" << std::endl;
+  std::cout << "  - Triangulation cells: " << tria.n_active_cells()
+            << std::endl;
+  std::cout << "  - DoFs: " << dof_handler.n_dofs() << std::endl;
+  std::cout << std::endl;
+
+  // Check that the sizes of the matrices match expectations
+  Assert(injection_matrices.size() == mg_levels - 1,
+         ExcMessage(
+           "The number of injection matrices should be mg_levels - 1."));
+  Assert(
+    injection_sparsity_patterns.size() == mg_levels - 1,
+    ExcMessage(
+      "The number of injection sparsity patterns should be mg_levels - 1."));
+  Assert(
+    injection_matrices[mg_levels - 2].m() == dof_handler.n_dofs(),
+    ExcMessage(
+      "The number of rows of the first injection matrix should match the number of DoFs on the finest level."));
+  Assert(
+    injection_matrices[mg_levels - 3].m() ==
+      injection_matrices[mg_levels - 2].n(),
+    ExcMessage(
+      "The number of rows of the second injection matrix should match the number of columns of the first injection matrix."));
+
+  std::vector<TrilinosWrappers::SparseMatrix> trilinos_transfer_matrices(
+    mg_levels - 1);
+
+  for (unsigned int level = 0; level < mg_levels - 1; ++level)
+    {
+      trilinos_transfer_matrices[level].reinit(injection_matrices[level]);
+    }
+
+  AmgProjector<dim, TrilinosWrappers::SparseMatrix, double> amg_projector(
+    trilinos_transfer_matrices);
+
+  MGLevelObject<std::unique_ptr<TrilinosWrappers::SparseMatrix>>
+    multigrid_matrices(0, mg_levels - 1);
+
+  // Create Laplace matrix for Poisson problem
+  SparseMatrix<double> system_matrix;
+  SparsityPattern      sparsity_pattern;
+  Vector<double>       system_rhs(dof_handler.n_dofs());
+  system_rhs = 0.0;
+  Vector<double> solution(dof_handler.n_dofs());
+
+  DynamicSparsityPattern dsp(dof_handler.n_dofs(), dof_handler.n_dofs());
+  DoFTools::make_sparsity_pattern(dof_handler, dsp);
+  sparsity_pattern.copy_from(dsp);
+  system_matrix.reinit(sparsity_pattern);
+
+  MatrixCreator::create_laplace_matrix(mapping,
+                                       dof_handler,
+                                       QGauss<dim>(fe.degree + 1),
+                                       system_matrix);
+
+  // Interpolate linear boundary conditions: f(x,y) = x + y
+  std::map<types::global_dof_index, double> boundary_values;
+  LinearSumFunction                         linear_bc;
+  VectorTools::interpolate_boundary_values(mapping,
+                                           dof_handler,
+                                           0,         // boundary id
+                                           linear_bc, // f(x,y) = x + y
+                                           boundary_values);
+
+  MatrixTools::apply_boundary_values(boundary_values,
+                                     system_matrix,
+                                     solution,
+                                     system_rhs);
+
+  multigrid_matrices[multigrid_matrices.max_level()] =
+    std::make_unique<TrilinosWrappers::SparseMatrix>();
+
+  multigrid_matrices[multigrid_matrices.max_level()]->reinit(system_matrix);
+
+  amg_projector.compute_level_matrices(multigrid_matrices);
+
+  using LevelMatrixType = TrilinosWrappers::SparseMatrix;
+  using VectorType      = LinearAlgebra::distributed::Vector<double>;
+  mg::Matrix<VectorType> mg_matrix(multigrid_matrices);
+
+  using SmootherType = PreconditionChebyshev<LevelMatrixType, VectorType>;
+  mg::SmootherRelaxation<SmootherType, VectorType>     mg_smoother;
+  MGLevelObject<typename SmootherType::AdditionalData> smoother_data;
+  smoother_data.resize(0, mg_levels - 1);
+
+  VectorType diag_inverse(system_matrix.m());
+  for (unsigned int row = 0; row < system_matrix.m(); ++row)
+    diag_inverse[row] = 1. / system_matrix.diag_element(row);
+  diag_inverse.compress(VectorOperation::insert);
+
+  std::vector<VectorType> diag_inverses(mg_levels);
+  diag_inverses[mg_levels - 1] = diag_inverse;
+
+  smoother_data[mg_levels - 1].preconditioner =
+    std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[mg_levels - 1]);
+
+  for (unsigned int level = 0; level < mg_levels - 1; ++level)
+    {
+      // For simplicity using the same degree for all levels
+      smoother_data[level].smoothing_range = 8;
+      diag_inverses[level].reinit(
+        multigrid_matrices[level]->m()); // need to reinit
+      for (unsigned int row = 0; row < multigrid_matrices[level]->m(); ++row)
+        diag_inverses[level][row] =
+          1. / multigrid_matrices[level]->diag_element(row);
+      diag_inverses[level].compress(VectorOperation::insert);
+
+      smoother_data[level].preconditioner =
+        std::make_shared<DiagonalMatrix<VectorType>>(diag_inverses[level]);
+    }
+
+  for (unsigned int level = 0; level < mg_levels; ++level)
+    {
+      if (level > 0)
+        {
+          smoother_data[level].smoothing_range = 20.; // 15.;
+          smoother_data[level].degree          = 3; // parameters.smoother_steps
+          smoother_data[level].eig_cg_n_iterations = 20;
+        }
+      else
+        {
+          smoother_data[0].smoothing_range = 1e-3;
+          smoother_data[0].degree = 3; // numbers::invalid_unsigned_int;
+          smoother_data[0].eig_cg_n_iterations = 20;
+        }
+    }
+
+  mg_smoother.set_steps(2);
+  mg_smoother.initialize(multigrid_matrices, smoother_data);
+
+  Utils::MGCoarseDirect<VectorType,
+                        TrilinosWrappers::SparseMatrix,
+                        TrilinosWrappers::SolverDirect>
+    mg_coarse(*multigrid_matrices[0]);
+
+  MGLevelObject<TrilinosWrappers::SparseMatrix *> mg_level_transfers(0,
+                                                                     mg_levels -
+                                                                       1);
+  for (unsigned int l = 0; l < mg_levels - 1; ++l)
+    mg_level_transfers[l] = &trilinos_transfer_matrices[l];
+
+  std::vector<DoFHandler<dim> *> dof_handlers(support_dof_handlers.size() + 1);
+
+  for (unsigned int i = 0; i < support_dof_handlers.size(); ++i)
+    dof_handlers[i] = support_dof_handlers[i].get();
+
+  dof_handlers[support_dof_handlers.size()] = &dof_handler;
+
+  MGTransferAgglomeration<dim, VectorType> mg_transfer(mg_level_transfers,
+                                                       dof_handlers);
+
+  Multigrid<VectorType> mg(mg_matrix,
+                           mg_coarse,
+                           mg_transfer,
+                           mg_smoother,
+                           mg_smoother,
+                           0, // min_level
+                           numbers::invalid_unsigned_int,
+                           Multigrid<VectorType>::v_cycle);
+
+  PreconditionMG<dim, VectorType, MGTransferAgglomeration<dim, VectorType>>
+    preconditioner(dof_handler, mg, mg_transfer);
+
+
+  VectorType dist_solution;
+  VectorType dist_rhs;
+  dist_solution.reinit(dof_handler.n_dofs());
+  dist_rhs.reinit(dof_handler.n_dofs());
+  for (unsigned int i = 0; i < system_rhs.size(); ++i)
+    dist_rhs[i] = system_rhs[i];
+  dist_rhs.compress(VectorOperation::insert);
+
+  ReductionControl solver_control(100, 1e-9, 1e-6);
+
+  SolverCG<VectorType> cg(solver_control);
+  cg.solve(system_matrix, dist_solution, dist_rhs, preconditioner);
+
+  for (unsigned int i = 0; i < solution.size(); ++i)
+    solution[i] = dist_solution[i];
+
+  // Verify solution against analytical solution u(x,y) = x + y
+  Vector<double> error_per_cell(tria.n_active_cells());
+
+  VectorTools::integrate_difference(mapping,
+                                    dof_handler,
+                                    solution,
+                                    linear_bc,
+                                    error_per_cell,
+                                    QGauss<dim>(fe.degree + 2),
+                                    VectorTools::L2_norm);
+
+  double l2_error = error_per_cell.l2_norm();
+
+  Assert(l2_error < tolerance,
+         ExcMessage("L2 error too large: " + std::to_string(l2_error)));
+}

--- a/test/polydeal/continuous_poisson_serial_sanity.output
+++ b/test/polydeal/continuous_poisson_serial_sanity.output
@@ -1,0 +1,13 @@
+Level 0:
+  - Triangulation cells: 18
+  - DoFs: 72
+  - Injection matrix: 276 x 72
+
+Level 1:
+  - Triangulation cells: 69
+  - DoFs: 276
+  - Injection matrix: 1089 x 276
+
+Level 2 (finest level):
+  - Triangulation cells: 1024
+  - DoFs: 1089

--- a/test/polydeal/continuous_poisson_serial_sanity.output
+++ b/test/polydeal/continuous_poisson_serial_sanity.output
@@ -11,3 +11,18 @@ Level 1:
 Level 2 (finest level):
   - Triangulation cells: 1024
   - DoFs: 1089
+
+Level 0:
+  - Triangulation cells: 16
+  - DoFs: 64
+  - Injection matrix: 256 x 64
+
+Level 1:
+  - Triangulation cells: 64
+  - DoFs: 256
+  - Injection matrix: 1089 x 256
+
+Level 2 (finest level):
+  - Triangulation cells: 1024
+  - DoFs: 1089
+  

--- a/test/polydeal/create_distributed_tria_of_bboxes.cc
+++ b/test/polydeal/create_distributed_tria_of_bboxes.cc
@@ -1,0 +1,74 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include "continuous_agglo_utils.h"
+
+using namespace dealii;
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  const MPI_Comm     comm    = MPI_COMM_WORLD;
+  const unsigned int n_ranks = Utilities::MPI::n_mpi_processes(comm);
+  const unsigned int my_rank = Utilities::MPI::this_mpi_process(comm);
+
+  Assert(n_ranks == 3,
+         ExcMessage("This test is meant to be run with 3 MPI ranks only."));
+
+  if (my_rank == 0)
+    std::cout << "Running distributed bounding box triangulation test with "
+              << n_ranks << " MPI ranks." << std::endl;
+
+  std::vector<BoundingBox<2>> local_boxes;
+  const Point<2>              p_min(static_cast<double>(my_rank), 0.0);
+  const Point<2>              p_max(static_cast<double>(my_rank) + 1.0, 1.0);
+  local_boxes.emplace_back(std::make_pair(p_min, p_max));
+
+  parallel::fullydistributed::Triangulation<2, 2> distributed_tria(comm);
+
+  dealii::ContinuousAggloUtils::PointsAgglo::
+    create_distributed_tria_from_local_boxes(distributed_tria,
+                                             local_boxes,
+                                             comm);
+
+  assert(distributed_tria.n_global_active_cells() == n_ranks);
+  assert(distributed_tria.n_locally_owned_active_cells() == local_boxes.size());
+
+  for (const auto &cell : distributed_tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        const Point<2> center = cell->center();
+        assert(std::abs(center[0] - (static_cast<double>(my_rank) + 0.5)) <
+               1e-10);
+        assert(std::abs(center[1] - 0.5) < 1e-10);
+      }
+
+  if (my_rank == 0)
+    std::cout << "Distributed bounding box triangulation test passed!"
+              << std::endl;
+
+  return 0;
+}

--- a/test/polydeal/create_distributed_tria_of_bboxes.cc
+++ b/test/polydeal/create_distributed_tria_of_bboxes.cc
@@ -49,10 +49,8 @@ main(int argc, char *argv[])
 
   parallel::fullydistributed::Triangulation<2, 2> distributed_tria(comm);
 
-  dealii::ContinuousAggloUtils::PointsAgglo::
-    create_distributed_tria_from_local_boxes(distributed_tria,
-                                             local_boxes,
-                                             comm);
+  dealii::ContinuousAggloUtils::create_distributed_tria_from_local_boxes(
+    distributed_tria, local_boxes, comm);
 
   assert(distributed_tria.n_global_active_cells() == n_ranks);
   assert(distributed_tria.n_locally_owned_active_cells() == local_boxes.size());

--- a/test/polydeal/create_distributed_tria_of_bboxes.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/test/polydeal/create_distributed_tria_of_bboxes.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,2 @@
+Running distributed bounding box triangulation test with 3 MPI ranks.
+Distributed bounding box triangulation test passed!

--- a/test/polydeal/create_tria_of_bboxes.cc
+++ b/test/polydeal/create_tria_of_bboxes.cc
@@ -51,8 +51,8 @@ test_create_tria_2d_single_box()
   boxes.push_back(box);
 
   Triangulation<dim> tria;
-  dealii::ContinuousAggloUtils::PointsAgglo::
-    create_triangulation_from_bounding_boxes(tria, boxes);
+  dealii::ContinuousAggloUtils::create_triangulation_from_bounding_boxes(tria,
+                                                                         boxes);
 
   assert(tria.n_active_cells() == 1);
   assert(tria.n_vertices() == 4);
@@ -83,8 +83,8 @@ test_create_tria_2d_multiple_boxes()
   boxes.push_back(BoundingBox<dim>(std::make_pair(p7, p8)));
 
   Triangulation<dim> tria;
-  dealii::ContinuousAggloUtils::PointsAgglo::
-    create_triangulation_from_bounding_boxes(tria, boxes);
+  dealii::ContinuousAggloUtils::create_triangulation_from_bounding_boxes(tria,
+                                                                         boxes);
 
   assert(tria.n_active_cells() == 4);
   assert(tria.n_vertices() == 16);
@@ -111,8 +111,8 @@ test_create_tria_2d_overlapping_boxes()
   boxes.push_back(BoundingBox<dim>(std::make_pair(p3, p4)));
 
   Triangulation<dim> tria;
-  dealii::ContinuousAggloUtils::PointsAgglo::
-    create_triangulation_from_bounding_boxes(tria, boxes);
+  dealii::ContinuousAggloUtils::create_triangulation_from_bounding_boxes(tria,
+                                                                         boxes);
 
   assert(tria.n_active_cells() == 2);
   assert(tria.n_vertices() == 8);
@@ -132,8 +132,8 @@ test_create_tria_3d_single_box()
   boxes.push_back(box);
 
   Triangulation<dim> tria;
-  dealii::ContinuousAggloUtils::PointsAgglo::
-    create_triangulation_from_bounding_boxes(tria, boxes);
+  dealii::ContinuousAggloUtils::create_triangulation_from_bounding_boxes(tria,
+                                                                         boxes);
 
   assert(tria.n_active_cells() == 1);
   assert(tria.n_vertices() == 8);
@@ -159,8 +159,8 @@ test_create_tria_3d_multiple_boxes()
   boxes.push_back(BoundingBox<dim>(std::make_pair(p3, p4)));
 
   Triangulation<dim> tria;
-  dealii::ContinuousAggloUtils::PointsAgglo::
-    create_triangulation_from_bounding_boxes(tria, boxes);
+  dealii::ContinuousAggloUtils::create_triangulation_from_bounding_boxes(tria,
+                                                                         boxes);
 
   assert(tria.n_active_cells() == 2);
   assert(tria.n_vertices() == 16);
@@ -185,8 +185,8 @@ test_create_tria_3d_rectangular_boxes()
   boxes.push_back(BoundingBox<dim>(std::make_pair(p1, p2)));
 
   Triangulation<dim> tria;
-  dealii::ContinuousAggloUtils::PointsAgglo::
-    create_triangulation_from_bounding_boxes(tria, boxes);
+  dealii::ContinuousAggloUtils::create_triangulation_from_bounding_boxes(tria,
+                                                                         boxes);
 
   assert(tria.n_active_cells() == 1);
 
@@ -207,8 +207,8 @@ test_create_tria_2d_vertex_positions()
   boxes.push_back(BoundingBox<dim>(std::make_pair(p1, p2)));
 
   Triangulation<dim> tria;
-  dealii::ContinuousAggloUtils::PointsAgglo::
-    create_triangulation_from_bounding_boxes(tria, boxes);
+  dealii::ContinuousAggloUtils::create_triangulation_from_bounding_boxes(tria,
+                                                                         boxes);
 
   std::vector<Point<dim>> expected_vertices = {Point<dim>(0.5, 1.5),
                                                Point<dim>(2.5, 1.5),

--- a/test/polydeal/create_tria_of_bboxes.cc
+++ b/test/polydeal/create_tria_of_bboxes.cc
@@ -1,0 +1,250 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/point.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <vector>
+
+#include "continuous_agglo_utils.h"
+
+using namespace dealii;
+
+/**
+ * Test the sequential implementation of
+ * create_triangulation_from_bounding_boxes
+ */
+
+// Test for 2D case
+void
+test_create_tria_2d_single_box()
+{
+  const int                     dim = 2;
+  std::vector<BoundingBox<dim>> boxes;
+  Point<dim>                    p1(0.0, 0.0);
+  Point<dim>                    p2(1.0, 1.0);
+  BoundingBox<dim>              box(std::make_pair(p1, p2));
+  boxes.push_back(box);
+
+  Triangulation<dim> tria;
+  dealii::ContinuousAggloUtils::PointsAgglo::
+    create_triangulation_from_bounding_boxes(tria, boxes);
+
+  assert(tria.n_active_cells() == 1);
+  assert(tria.n_vertices() == 4);
+
+  auto cell = tria.begin_active();
+  assert(cell->measure() == 1.0);
+
+  std::cout << "2D single box test passed!" << std::endl;
+}
+
+// Test for 2D case with multiple non-overlapping boxes
+void
+test_create_tria_2d_multiple_boxes()
+{
+  const int                     dim = 2;
+  std::vector<BoundingBox<dim>> boxes;
+
+  Point<dim> p1(0.0, 0.0), p2(1.0, 1.0);
+  boxes.push_back(BoundingBox<dim>(std::make_pair(p1, p2)));
+
+  Point<dim> p3(1.0, 0.0), p4(2.0, 1.0);
+  boxes.push_back(BoundingBox<dim>(std::make_pair(p3, p4)));
+
+  Point<dim> p5(0.0, 1.0), p6(1.0, 2.0);
+  boxes.push_back(BoundingBox<dim>(std::make_pair(p5, p6)));
+
+  Point<dim> p7(1.0, 1.0), p8(2.0, 2.0);
+  boxes.push_back(BoundingBox<dim>(std::make_pair(p7, p8)));
+
+  Triangulation<dim> tria;
+  dealii::ContinuousAggloUtils::PointsAgglo::
+    create_triangulation_from_bounding_boxes(tria, boxes);
+
+  assert(tria.n_active_cells() == 4);
+  assert(tria.n_vertices() == 16);
+
+  double total_area = 0.0;
+  for (const auto &cell : tria.active_cell_iterators())
+    total_area += cell->measure();
+  assert(std::abs(total_area - 4.0) < 1e-10);
+
+  std::cout << "2D multiple boxes test passed!" << std::endl;
+}
+
+// Test for 2D case with overlapping boxes
+void
+test_create_tria_2d_overlapping_boxes()
+{
+  const int                     dim = 2;
+  std::vector<BoundingBox<dim>> boxes;
+
+  Point<dim> p1(0.0, 0.0), p2(1.5, 1.0);
+  boxes.push_back(BoundingBox<dim>(std::make_pair(p1, p2)));
+
+  Point<dim> p3(0.5, 0.0), p4(2.0, 1.0);
+  boxes.push_back(BoundingBox<dim>(std::make_pair(p3, p4)));
+
+  Triangulation<dim> tria;
+  dealii::ContinuousAggloUtils::PointsAgglo::
+    create_triangulation_from_bounding_boxes(tria, boxes);
+
+  assert(tria.n_active_cells() == 2);
+  assert(tria.n_vertices() == 8);
+
+  std::cout << "2D overlapping boxes test passed!" << std::endl;
+}
+
+// Test for 3D case
+void
+test_create_tria_3d_single_box()
+{
+  const int                     dim = 3;
+  std::vector<BoundingBox<dim>> boxes;
+  Point<dim>                    p1(0.0, 0.0, 0.0);
+  Point<dim>                    p2(1.0, 1.0, 1.0);
+  BoundingBox<dim>              box(std::make_pair(p1, p2));
+  boxes.push_back(box);
+
+  Triangulation<dim> tria;
+  dealii::ContinuousAggloUtils::PointsAgglo::
+    create_triangulation_from_bounding_boxes(tria, boxes);
+
+  assert(tria.n_active_cells() == 1);
+  assert(tria.n_vertices() == 8);
+
+  auto cell = tria.begin_active();
+  assert(std::abs(cell->measure() - 1.0) < 1e-10);
+
+  std::cout << "3D single box test passed!" << std::endl;
+}
+
+// Test for 3D case with multiple boxes
+void
+test_create_tria_3d_multiple_boxes()
+{
+  const int                     dim = 3;
+  std::vector<BoundingBox<dim>> boxes;
+
+  // Create 2 unit cubes
+  Point<dim> p1(0.0, 0.0, 0.0), p2(1.0, 1.0, 1.0);
+  boxes.push_back(BoundingBox<dim>(std::make_pair(p1, p2)));
+
+  Point<dim> p3(1.0, 0.0, 0.0), p4(2.0, 1.0, 1.0);
+  boxes.push_back(BoundingBox<dim>(std::make_pair(p3, p4)));
+
+  Triangulation<dim> tria;
+  dealii::ContinuousAggloUtils::PointsAgglo::
+    create_triangulation_from_bounding_boxes(tria, boxes);
+
+  assert(tria.n_active_cells() == 2);
+  assert(tria.n_vertices() == 16);
+
+  double total_volume = 0.0;
+  for (const auto &cell : tria.active_cell_iterators())
+    total_volume += cell->measure();
+  assert(std::abs(total_volume - 2.0) < 1e-10);
+
+  std::cout << "3D multiple boxes test passed!" << std::endl;
+}
+
+// Test for 3D case with rectangular boxes (non-cubic)
+void
+test_create_tria_3d_rectangular_boxes()
+{
+  const int                     dim = 3;
+  std::vector<BoundingBox<dim>> boxes;
+
+  // Create a rectangular box (2x3x4)
+  Point<dim> p1(0.0, 0.0, 0.0), p2(2.0, 3.0, 4.0);
+  boxes.push_back(BoundingBox<dim>(std::make_pair(p1, p2)));
+
+  Triangulation<dim> tria;
+  dealii::ContinuousAggloUtils::PointsAgglo::
+    create_triangulation_from_bounding_boxes(tria, boxes);
+
+  assert(tria.n_active_cells() == 1);
+
+  auto cell = tria.begin_active();
+  assert(std::abs(cell->measure() - 24.0) < 1e-10); // 2*3*4 = 24
+
+  std::cout << "3D rectangular boxes test passed!" << std::endl;
+}
+
+// Test that vertices are correctly positioned
+void
+test_create_tria_2d_vertex_positions()
+{
+  const int                     dim = 2;
+  std::vector<BoundingBox<dim>> boxes;
+  Point<dim>                    p1(0.5, 1.5);
+  Point<dim>                    p2(2.5, 3.5);
+  boxes.push_back(BoundingBox<dim>(std::make_pair(p1, p2)));
+
+  Triangulation<dim> tria;
+  dealii::ContinuousAggloUtils::PointsAgglo::
+    create_triangulation_from_bounding_boxes(tria, boxes);
+
+  std::vector<Point<dim>> expected_vertices = {Point<dim>(0.5, 1.5),
+                                               Point<dim>(2.5, 1.5),
+                                               Point<dim>(0.5, 3.5),
+                                               Point<dim>(2.5, 3.5)};
+
+  const auto &vertices = tria.get_vertices();
+  assert(vertices.size() == expected_vertices.size());
+
+  for (size_t i = 0; i < expected_vertices.size(); ++i)
+    {
+      assert(std::abs(vertices[i][0] - expected_vertices[i][0]) < 1e-10);
+      assert(std::abs(vertices[i][1] - expected_vertices[i][1]) < 1e-10);
+    }
+
+  std::cout << "2D vertex positions test passed!" << std::endl;
+}
+
+int
+main()
+{
+  std::cout << "Running tests for create_triangulation_from_bounding_boxes..."
+            << std::endl;
+
+  // 2D tests
+  test_create_tria_2d_single_box();
+  test_create_tria_2d_multiple_boxes();
+  test_create_tria_2d_overlapping_boxes();
+  test_create_tria_2d_vertex_positions();
+
+  // 3D tests
+  test_create_tria_3d_single_box();
+  test_create_tria_3d_multiple_boxes();
+  test_create_tria_3d_rectangular_boxes();
+
+  std::cout << "\nAll tests passed!" << std::endl;
+
+  return 0;
+}

--- a/test/polydeal/create_tria_of_bboxes.output
+++ b/test/polydeal/create_tria_of_bboxes.output
@@ -1,0 +1,10 @@
+Running tests for create_triangulation_from_bounding_boxes...
+2D single box test passed!
+2D multiple boxes test passed!
+2D overlapping boxes test passed!
+2D vertex positions test passed!
+3D single box test passed!
+3D multiple boxes test passed!
+3D rectangular boxes test passed!
+
+All tests passed!

--- a/test/polydeal/distributed_build_all_continuous_transfers.cc
+++ b/test/polydeal/distributed_build_all_continuous_transfers.cc
@@ -44,8 +44,8 @@
 
 #include "continuous_agglo_utils.h"
 
-static constexpr double       tolerance  = 1e-12;
-static constexpr unsigned int dim        = 2;
+static constexpr double       tolerance = 1e-12;
+static constexpr unsigned int dim       = 2;
 using namespace dealii;
 
 namespace
@@ -103,95 +103,188 @@ main(int argc, char *argv[])
 
   MappingQ1<dim> mapping;
 
-  // Build injection matrices for all levels
-  std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
-  std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
-  std::vector<unsigned int> coarse_space_degrees(mg_levels - 1, 1);
-  std::vector<
-    std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
-                                              triangulations;
-  std::vector<std::unique_ptr<DoFHandler<dim>>> support_dof_handlers;
+  // Point agglo part
+  {
+    // Build injection matrices for all levels
+    std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
+    std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
+    std::vector<unsigned int> coarse_space_degrees(mg_levels - 1, 1);
+    std::vector<
+      std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
+                                                  triangulations;
+    std::vector<std::unique_ptr<DoFHandler<dim>>> support_dof_handlers;
 
-  ContinuousAggloUtils::PointsAgglo::
-    parallel_agglomerate_and_compute_injection_matrices<dim,
-                                                        min_elem_per_node,
-                                                        max_elem_per_node>(
-      dof_handler,
-      mapping,
-      skip_leaves,
-      injection_matrices,
-      injection_sparsity_patterns,
-      mg_levels,
-      coarse_space_degrees,
-      triangulations,
-      support_dof_handlers);
+    ContinuousAggloUtils::PointsAgglo::
+      parallel_agglomerate_and_compute_injection_matrices<dim,
+                                                          min_elem_per_node,
+                                                          max_elem_per_node>(
+        dof_handler,
+        mapping,
+        skip_leaves,
+        injection_matrices,
+        injection_sparsity_patterns,
+        mg_levels,
+        coarse_space_degrees,
+        triangulations,
+        support_dof_handlers);
 
-  if (my_rank == 0)
-    std::cout << "Built " << injection_matrices.size() << " injection matrices"
-              << std::endl;
+    if (my_rank == 0)
+      std::cout << "Built " << injection_matrices.size()
+                << " injection matrices" << std::endl;
 
-  LinearField<dim> linear_field;
+    LinearField<dim> linear_field;
 
-  for (unsigned int level = 0; level < injection_matrices.size(); ++level)
-    {
-      const auto &mat = injection_matrices[level];
+    for (unsigned int level = 0; level < injection_matrices.size(); ++level)
+      {
+        const auto &mat = injection_matrices[level];
 
-      TrilinosWrappers::MPI::Vector coarse_values(
-        mat.locally_owned_domain_indices());
-      TrilinosWrappers::MPI::Vector fine_values(
-        mat.locally_owned_range_indices());
-      TrilinosWrappers::MPI::Vector transferred_values(
-        mat.locally_owned_range_indices());
+        TrilinosWrappers::MPI::Vector coarse_values(
+          mat.locally_owned_domain_indices());
+        TrilinosWrappers::MPI::Vector fine_values(
+          mat.locally_owned_range_indices());
+        TrilinosWrappers::MPI::Vector transferred_values(
+          mat.locally_owned_range_indices());
 
-      if (level < mg_levels - 2)
-        {
-          VectorTools::interpolate(mapping,
-                                   *support_dof_handlers[level],
-                                   linear_field,
-                                   coarse_values);
-          VectorTools::interpolate(mapping,
-                                   *support_dof_handlers[level + 1],
-                                   linear_field,
-                                   fine_values);
-        }
-      else
-        {
-          VectorTools::interpolate(mapping,
-                                   *support_dof_handlers[level],
-                                   linear_field,
-                                   coarse_values);
-          VectorTools::interpolate(mapping,
-                                   dof_handler,
-                                   linear_field,
-                                   fine_values);
-        }
+        if (level < mg_levels - 2)
+          {
+            VectorTools::interpolate(mapping,
+                                     *support_dof_handlers[level],
+                                     linear_field,
+                                     coarse_values);
+            VectorTools::interpolate(mapping,
+                                     *support_dof_handlers[level + 1],
+                                     linear_field,
+                                     fine_values);
+          }
+        else
+          {
+            VectorTools::interpolate(mapping,
+                                     *support_dof_handlers[level],
+                                     linear_field,
+                                     coarse_values);
+            VectorTools::interpolate(mapping,
+                                     dof_handler,
+                                     linear_field,
+                                     fine_values);
+          }
 
-      mat.vmult(transferred_values, coarse_values);
+        mat.vmult(transferred_values, coarse_values);
 
-      transferred_values -= fine_values;
-      const double l2_error = transferred_values.l2_norm();
+        transferred_values -= fine_values;
+        const double l2_error = transferred_values.l2_norm();
 
-      AssertThrow(
-        l2_error < tolerance,
-        ExcMessage(
-          std::string("Injection matrix at level ") + std::to_string(level) +
-          " failed the linear field test with error " +
-          std::to_string(l2_error)));
+        AssertThrow(l2_error < tolerance,
+                    ExcMessage(std::string("Injection matrix at level ") +
+                               std::to_string(level) +
+                               " failed the linear field test with error " +
+                               std::to_string(l2_error)));
 
-      if (my_rank == 0)
-        {
-          if (level < mg_levels - 2)
-            std::cout << "Level " << level << " (" << mat.m() << " x "
-                      << mat.n() << "): L2 error = " << l2_error << std::endl;
-          else
-            std::cout << "Level " << level << " (" << mat.m() << " x "
-                      << mat.n() << "): L2 error = " << l2_error
-                      << " (agglo->original)" << std::endl;
-        }
-    }
+        if (my_rank == 0)
+          {
+            if (level < mg_levels - 2)
+              std::cout << "Level " << level << " (" << mat.m() << " x "
+                        << mat.n() << "): L2 error = " << l2_error << std::endl;
+            else
+              std::cout << "Level " << level << " (" << mat.m() << " x "
+                        << mat.n() << "): L2 error = " << l2_error
+                        << " (agglo->original)" << std::endl;
+          }
+      }
 
-  if (my_rank == 0)
-    std::cout << "All continuous transfer tests: OK" << std::endl;
+    if (my_rank == 0)
+      std::cout << "All point-agglo continuous transfer tests: OK" << std::endl;
+  }
 
+  // Cells agglo part
+  {
+    // Build injection matrices for all levels
+    std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
+    std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
+    std::vector<unsigned int> coarse_space_degrees(mg_levels - 1, 1);
+    std::vector<
+      std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
+                                                  triangulations;
+    std::vector<std::unique_ptr<DoFHandler<dim>>> support_dof_handlers;
+
+    ContinuousAggloUtils::CellsAgglo::
+      parallel_agglomerate_and_compute_injection_matrices<dim,
+                                                          min_elem_per_node,
+                                                          max_elem_per_node>(
+        dof_handler,
+        mapping,
+        skip_leaves,
+        injection_matrices,
+        injection_sparsity_patterns,
+        mg_levels,
+        coarse_space_degrees,
+        triangulations,
+        support_dof_handlers);
+
+    if (my_rank == 0)
+      std::cout << "Built " << injection_matrices.size()
+                << " injection matrices" << std::endl;
+
+    LinearField<dim> linear_field;
+
+    for (unsigned int level = 0; level < injection_matrices.size(); ++level)
+      {
+        const auto &mat = injection_matrices[level];
+
+        TrilinosWrappers::MPI::Vector coarse_values(
+          mat.locally_owned_domain_indices());
+        TrilinosWrappers::MPI::Vector fine_values(
+          mat.locally_owned_range_indices());
+        TrilinosWrappers::MPI::Vector transferred_values(
+          mat.locally_owned_range_indices());
+
+        if (level < mg_levels - 2)
+          {
+            VectorTools::interpolate(mapping,
+                                     *support_dof_handlers[level],
+                                     linear_field,
+                                     coarse_values);
+            VectorTools::interpolate(mapping,
+                                     *support_dof_handlers[level + 1],
+                                     linear_field,
+                                     fine_values);
+          }
+        else
+          {
+            VectorTools::interpolate(mapping,
+                                     *support_dof_handlers[level],
+                                     linear_field,
+                                     coarse_values);
+            VectorTools::interpolate(mapping,
+                                     dof_handler,
+                                     linear_field,
+                                     fine_values);
+          }
+
+        mat.vmult(transferred_values, coarse_values);
+
+        transferred_values -= fine_values;
+        const double l2_error = transferred_values.l2_norm();
+
+        AssertThrow(l2_error < tolerance,
+                    ExcMessage(std::string("Injection matrix at level ") +
+                               std::to_string(level) +
+                               " failed the linear field test with error " +
+                               std::to_string(l2_error)));
+
+        if (my_rank == 0)
+          {
+            if (level < mg_levels - 2)
+              std::cout << "Level " << level << " (" << mat.m() << " x "
+                        << mat.n() << "): L2 error = " << l2_error << std::endl;
+            else
+              std::cout << "Level " << level << " (" << mat.m() << " x "
+                        << mat.n() << "): L2 error = " << l2_error
+                        << " (agglo->original)" << std::endl;
+          }
+      }
+
+    if (my_rank == 0)
+      std::cout << "All cell-agglo continuous transfer tests: OK" << std::endl;
+  }
   return 0;
 }

--- a/test/polydeal/distributed_build_all_continuous_transfers.cc
+++ b/test/polydeal/distributed_build_all_continuous_transfers.cc
@@ -1,0 +1,197 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+// Distributed version of build_all_continuous_transfers.cc: builds all
+// injection matrices using
+// parallel_agglomerate_and_compute_injection_matrices and verifies that each
+// transfer reproduces a linear field exactly.
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include "continuous_agglo_utils.h"
+
+static constexpr double       tolerance  = 1e-12;
+static constexpr unsigned int dim        = 2;
+using namespace dealii;
+
+namespace
+{
+  template <int dim>
+  class LinearField : public Function<dim>
+  {
+  public:
+    LinearField()
+      : Function<dim>()
+    {}
+
+    double
+    value(const Point<dim> &p, const unsigned int component = 0) const override
+    {
+      (void)component;
+      return p[0] + p[1];
+    }
+  };
+} // namespace
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  const MPI_Comm                  &comm = MPI_COMM_WORLD;
+  const unsigned int n_ranks            = Utilities::MPI::n_mpi_processes(comm);
+  const unsigned int my_rank = Utilities::MPI::this_mpi_process(comm);
+
+  AssertThrow(n_ranks == 3,
+              ExcMessage(
+                "This test is meant to be run with 3 MPI ranks only."));
+
+  static constexpr unsigned int min_elem_per_node = 2;
+  static constexpr unsigned int max_elem_per_node = 4;
+  static constexpr unsigned int mg_levels         = 3;
+  static constexpr bool         skip_leaves       = true;
+
+  // Build a distributed triangulation
+  Triangulation<dim> tria_serial;
+  GridGenerator::hyper_cube(tria_serial, 0., 1.);
+  tria_serial.refine_global(4);
+  GridTools::partition_triangulation(n_ranks, tria_serial);
+
+  const auto construction_data =
+    TriangulationDescription::Utilities::create_description_from_triangulation(
+      tria_serial, comm);
+
+  parallel::fullydistributed::Triangulation<dim, dim> tria_pft(comm);
+  tria_pft.create_triangulation(construction_data);
+
+  DoFHandler<dim> dof_handler(tria_pft);
+  FE_Q<dim>       fe(1);
+  dof_handler.distribute_dofs(fe);
+
+  MappingQ1<dim> mapping;
+
+  // Build injection matrices for all levels
+  std::vector<TrilinosWrappers::SparseMatrix>    injection_matrices;
+  std::vector<TrilinosWrappers::SparsityPattern> injection_sparsity_patterns;
+  std::vector<unsigned int> coarse_space_degrees(mg_levels - 1, 1);
+  std::vector<
+    std::unique_ptr<parallel::fullydistributed::Triangulation<dim, dim>>>
+                                              triangulations;
+  std::vector<std::unique_ptr<DoFHandler<dim>>> support_dof_handlers;
+
+  ContinuousAggloUtils::PointsAgglo::
+    parallel_agglomerate_and_compute_injection_matrices<dim,
+                                                        min_elem_per_node,
+                                                        max_elem_per_node>(
+      dof_handler,
+      mapping,
+      skip_leaves,
+      injection_matrices,
+      injection_sparsity_patterns,
+      mg_levels,
+      coarse_space_degrees,
+      triangulations,
+      support_dof_handlers);
+
+  if (my_rank == 0)
+    std::cout << "Built " << injection_matrices.size() << " injection matrices"
+              << std::endl;
+
+  LinearField<dim> linear_field;
+
+  for (unsigned int level = 0; level < injection_matrices.size(); ++level)
+    {
+      const auto &mat = injection_matrices[level];
+
+      TrilinosWrappers::MPI::Vector coarse_values(
+        mat.locally_owned_domain_indices());
+      TrilinosWrappers::MPI::Vector fine_values(
+        mat.locally_owned_range_indices());
+      TrilinosWrappers::MPI::Vector transferred_values(
+        mat.locally_owned_range_indices());
+
+      if (level < mg_levels - 2)
+        {
+          VectorTools::interpolate(mapping,
+                                   *support_dof_handlers[level],
+                                   linear_field,
+                                   coarse_values);
+          VectorTools::interpolate(mapping,
+                                   *support_dof_handlers[level + 1],
+                                   linear_field,
+                                   fine_values);
+        }
+      else
+        {
+          VectorTools::interpolate(mapping,
+                                   *support_dof_handlers[level],
+                                   linear_field,
+                                   coarse_values);
+          VectorTools::interpolate(mapping,
+                                   dof_handler,
+                                   linear_field,
+                                   fine_values);
+        }
+
+      mat.vmult(transferred_values, coarse_values);
+
+      transferred_values -= fine_values;
+      const double l2_error = transferred_values.l2_norm();
+
+      AssertThrow(
+        l2_error < tolerance,
+        ExcMessage(
+          std::string("Injection matrix at level ") + std::to_string(level) +
+          " failed the linear field test with error " +
+          std::to_string(l2_error)));
+
+      if (my_rank == 0)
+        {
+          if (level < mg_levels - 2)
+            std::cout << "Level " << level << " (" << mat.m() << " x "
+                      << mat.n() << "): L2 error = " << l2_error << std::endl;
+          else
+            std::cout << "Level " << level << " (" << mat.m() << " x "
+                      << mat.n() << "): L2 error = " << l2_error
+                      << " (agglo->original)" << std::endl;
+        }
+    }
+
+  if (my_rank == 0)
+    std::cout << "All continuous transfer tests: OK" << std::endl;
+
+  return 0;
+}

--- a/test/polydeal/distributed_build_all_continuous_transfers.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/test/polydeal/distributed_build_all_continuous_transfers.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,4 +1,8 @@
 Built 2 injection matrices
 Level 0 (80 x 24): L2 error = 1.8411e-16
 Level 1 (289 x 80): L2 error = 9.01949e-16 (agglo->original)
-All continuous transfer tests: OK
+All point-agglo continuous transfer tests: OK
+Built 2 injection matrices
+Level 0 (72 x 24): L2 error = 2.54384e-16
+Level 1 (289 x 72): L2 error = 6.63817e-16 (agglo->original)
+All cell-agglo continuous transfer tests: OK

--- a/test/polydeal/distributed_build_all_continuous_transfers.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/test/polydeal/distributed_build_all_continuous_transfers.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,4 @@
+Built 2 injection matrices
+Level 0 (80 x 24): L2 error = 1.8411e-16
+Level 1 (289 x 80): L2 error = 9.01949e-16 (agglo->original)
+All continuous transfer tests: OK

--- a/test/polydeal/distributed_build_continuous_transfer.cc
+++ b/test/polydeal/distributed_build_continuous_transfer.cc
@@ -1,0 +1,339 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) XXXX - YYYY by the polyDEAL authors
+//
+// This file is part of the polyDEAL library.
+//
+// Detailed license information governing the source code
+// can be found in LICENSE.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+// Note for me: in this test the results are slightly different from the
+// sequential one. It does make sense to me since the agglomeration is different
+// since i have more than one tree and more boxes might come out since all boxes
+// might not be filled up. Maybe check in with Marco too.
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include "continuous_agglo_utils.h"
+
+static constexpr double       tolerance  = 1e-12;
+static constexpr unsigned int dim        = 2;
+static constexpr bool         use_points = true;
+using namespace dealii;
+
+namespace
+{
+  template <int dim>
+  class LinearField : public Function<dim>
+  {
+  public:
+    LinearField()
+      : Function<dim>()
+    {}
+
+    double
+    value(const Point<dim> &p, const unsigned int component = 0) const override
+    {
+      (void)component;
+      double sum = 0.0;
+      for (unsigned int d = 0; d < dim; ++d)
+        sum += p[d];
+      return sum;
+    }
+  };
+} // namespace
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  const MPI_Comm                  &comm = MPI_COMM_WORLD;
+  const unsigned int n_ranks            = Utilities::MPI::n_mpi_processes(comm);
+  const unsigned int my_rank = Utilities::MPI::this_mpi_process(comm);
+
+  AssertThrow(n_ranks == 3,
+              ExcMessage(
+                "This test is meant to be run with 3 MPI ranks only."));
+
+  if (my_rank == 0)
+    std::cout << "Running distributed continuous transfer test with " << n_ranks
+              << " MPI ranks." << std::endl;
+
+  namespace bgi                                   = boost::geometry::index;
+  static constexpr unsigned int min_elem_per_node = 2;
+  static constexpr unsigned int max_elem_per_node = 4;
+
+  Triangulation<dim> starting_tria;
+  GridGenerator::hyper_cube(starting_tria, 0.0, 1.0);
+  starting_tria.refine_global(4);
+  GridTools::partition_triangulation(n_ranks, starting_tria);
+
+  const auto construction_data =
+    TriangulationDescription::Utilities::create_description_from_triangulation(
+      starting_tria, comm);
+
+  parallel::fullydistributed::Triangulation<dim, dim> starting_tria_pft(comm);
+  starting_tria_pft.create_triangulation(construction_data);
+
+  const unsigned int locally_owned_active_cells =
+    starting_tria_pft.n_locally_owned_active_cells();
+  const unsigned int global_active_cells =
+    starting_tria_pft.n_global_active_cells();
+  const unsigned int summed_local_active_cells =
+    Utilities::MPI::sum(locally_owned_active_cells, comm);
+
+  AssertThrow(
+    summed_local_active_cells == global_active_cells,
+    ExcMessage(
+      "Sum of locally owned cells does not match the global cell count."));
+
+  DoFHandler<dim> dof_handler(starting_tria_pft);
+  FE_Q<dim>       fe(1);
+  FE_DGQ<dim>     fe_dgq(1);
+  dof_handler.distribute_dofs(fe);
+
+  const unsigned int locally_owned_dofs_number =
+    dof_handler.locally_owned_dofs().n_elements();
+  const unsigned int global_dofs = dof_handler.n_dofs();
+  const unsigned int summed_local_dofs =
+    Utilities::MPI::sum(locally_owned_dofs_number, comm);
+
+  AssertThrow(
+    summed_local_dofs == global_dofs,
+    ExcMessage(
+      "Sum of locally owned DoFs does not match the global DoF count."));
+
+  MappingQ1<dim>                                mapping;
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(mapping, dof_handler);
+
+  const IndexSet &locally_owned_dofs_set = dof_handler.locally_owned_dofs();
+  std::vector<types::global_dof_index> local_dof_indices;
+  std::vector<Point<dim>>              local_support_points_vector;
+  local_support_points_vector.reserve(locally_owned_dofs_number);
+  local_dof_indices.reserve(locally_owned_dofs_number);
+  for (const auto &entry : support_points)
+    if (locally_owned_dofs_set.is_element(entry.first))
+      {
+        local_dof_indices.push_back(entry.first);
+        local_support_points_vector.push_back(entry.second);
+      }
+
+  AssertThrow(
+    local_dof_indices.size() == locally_owned_dofs_number,
+    ExcMessage(
+      "Filtered support-point count does not match the locally owned DoF count."));
+
+  auto local_tree =
+    pack_rtree_of_indices<bgi::rstar<max_elem_per_node, min_elem_per_node>>(
+      local_support_points_vector);
+
+  const unsigned int fine_level   = n_levels(local_tree);
+  const unsigned int coarse_level = fine_level - 1;
+
+  std::vector<BoundingBox<dim>> fine_level_boxes;
+  std::vector<BoundingBox<dim>> coarse_level_boxes;
+
+  parallel::fullydistributed::Triangulation<dim, dim> fine_tria(comm);
+  parallel::fullydistributed::Triangulation<dim, dim> coarse_tria(comm);
+  DoFHandler<dim>                                     fine_dh(fine_tria);
+  DoFHandler<dim>                                     coarse_dh(coarse_tria);
+
+  {
+    CellsAgglomerator<dim, decltype(local_tree), use_points> agglomerator{
+      local_tree, fine_level};
+    const auto agglomerates = agglomerator.extract_agglomerates();
+
+    fine_level_boxes.reserve(agglomerates.size());
+    for (const auto &agglo : agglomerates)
+      {
+        std::vector<Point<dim>> points_in_current_agglomerate;
+        points_in_current_agglomerate.reserve(agglo.size());
+
+        for (const auto &index : agglo)
+          points_in_current_agglomerate.push_back(
+            local_support_points_vector[index]);
+
+        fine_level_boxes.emplace_back(points_in_current_agglomerate);
+      }
+
+    ContinuousAggloUtils::PointsAgglo::create_distributed_tria_from_local_boxes(
+      fine_tria, fine_level_boxes, comm);
+
+    const unsigned int fine_local_boxes = fine_level_boxes.size();
+    const unsigned int fine_locally_owned_cells =
+      fine_tria.n_locally_owned_active_cells();
+    const unsigned int fine_global_cells = fine_tria.n_global_active_cells();
+    const unsigned int fine_summed_local_cells =
+      Utilities::MPI::sum(fine_locally_owned_cells, comm);
+
+    AssertThrow(
+      fine_locally_owned_cells == fine_local_boxes,
+      ExcMessage(
+        "Local fine boxes do not match the number of locally owned fine cells."));
+    AssertThrow(
+      fine_summed_local_cells == fine_global_cells,
+      ExcMessage(
+        "Sum of locally owned fine cells does not match the global fine cell count."));
+
+    // This check might be useless, in a sense complements the check for
+    // create_distributed_tria_from_local_boxes.
+    for (const auto &cell : fine_tria.active_cell_iterators())
+      if (cell->is_locally_owned())
+        {
+          const Point<dim> center = cell->center();
+          const Point<dim> p_min  = cell->vertex(0);
+          const Point<dim> p_max  = cell->vertex(3);
+          AssertThrow(center[0] >= p_min[0] && center[0] <= p_max[0],
+                      ExcMessage(
+                        "Fine cell center is outside the expected x-range."));
+          AssertThrow(center[1] >= p_min[1] && center[1] <= p_max[1],
+                      ExcMessage(
+                        "Fine cell center is outside the expected y-range."));
+        }
+    fine_dh.distribute_dofs(fe_dgq);
+  }
+
+  TrilinosWrappers::SparseMatrix    transfer_matrix;
+  TrilinosWrappers::SparsityPattern sparsity_pattern;
+
+  {
+    CellsAgglomerator<dim, decltype(local_tree), use_points> agglomerator{
+      local_tree, coarse_level};
+    const auto agglomerates = agglomerator.extract_agglomerates();
+
+    coarse_level_boxes.reserve(agglomerates.size());
+    for (const auto &agglo : agglomerates)
+      {
+        std::vector<Point<dim>> points_in_current_agglomerate;
+        points_in_current_agglomerate.reserve(agglo.size());
+
+        for (const auto &index : agglo)
+          points_in_current_agglomerate.push_back(
+            local_support_points_vector[index]);
+
+        coarse_level_boxes.emplace_back(points_in_current_agglomerate);
+      }
+
+    ContinuousAggloUtils::PointsAgglo::create_distributed_tria_from_local_boxes(
+      coarse_tria, coarse_level_boxes, comm);
+
+    const unsigned int coarse_local_boxes = coarse_level_boxes.size();
+    const unsigned int coarse_locally_owned_cells =
+      coarse_tria.n_locally_owned_active_cells();
+    const unsigned int coarse_global_cells =
+      coarse_tria.n_global_active_cells();
+    const unsigned int coarse_summed_local_cells =
+      Utilities::MPI::sum(coarse_locally_owned_cells, comm);
+
+    AssertThrow(
+      coarse_locally_owned_cells == coarse_local_boxes,
+      ExcMessage(
+        "Local coarse boxes do not match the number of locally owned coarse cells."));
+    AssertThrow(
+      coarse_summed_local_cells == coarse_global_cells,
+      ExcMessage(
+        "Sum of locally owned coarse cells does not match the global coarse cell count."));
+
+    coarse_dh.distribute_dofs(fe_dgq);
+
+    const std::map<
+      std::pair<types::global_cell_index, types::global_cell_index>,
+      std::vector<types::global_cell_index>> &parent_to_child_info =
+      agglomerator.get_hierarchy();
+
+
+    // print the whole content of parent_to_child_info for debugging
+    // if (my_rank == 0)
+    //   {
+    //     std::cout << "Parent to child info on rank 0 content:" << std::endl;
+    //     for (const auto &entry : parent_to_child_info)
+    //       {
+    //         std::cout << "Parent cell index: " << entry.first.first
+    //                   << ", Parent level: " << entry.first.second
+    //                   << ", Child cell indices: ";
+    //         for (const auto &child_idx : entry.second)
+    //           std::cout << child_idx << " ";
+    //         std::cout << std::endl;
+    //       }
+    //   }
+
+    ContinuousAggloUtils::PointsAgglo::fill_injection_matrix<dim>(
+      coarse_dh,
+      fine_dh,
+      sparsity_pattern,
+      transfer_matrix,
+      parent_to_child_info,
+      coarse_level_boxes,
+      fine_level_boxes,
+      coarse_level - 1);
+  }
+
+  AssertThrow(transfer_matrix.m() == fine_dh.n_dofs(),
+              ExcDimensionMismatch(transfer_matrix.m(), fine_dh.n_dofs()));
+  AssertThrow(transfer_matrix.n() == coarse_dh.n_dofs(),
+              ExcDimensionMismatch(transfer_matrix.n(), coarse_dh.n_dofs()));
+
+  LinearField<dim> linear_field;
+
+  TrilinosWrappers::MPI::Vector coarse_values(
+    transfer_matrix.locally_owned_domain_indices());
+  TrilinosWrappers::MPI::Vector fine_values(
+    transfer_matrix.locally_owned_range_indices());
+  TrilinosWrappers::MPI::Vector transferred_values(
+    transfer_matrix.locally_owned_range_indices());
+
+  VectorTools::interpolate(mapping, coarse_dh, linear_field, coarse_values);
+  VectorTools::interpolate(mapping, fine_dh, linear_field, fine_values);
+
+  transfer_matrix.vmult(transferred_values, coarse_values);
+  transferred_values -= fine_values;
+
+  const double l2_error = transferred_values.l2_norm();
+
+  AssertThrow(
+    l2_error < tolerance,
+    ExcMessage(
+      "Distributed continuous transfer matrix failed the linear field test."));
+
+  if (my_rank == 0)
+    {
+      std::cout << "Coarse DoFs: " << coarse_dh.n_dofs() << std::endl;
+      std::cout << "Fine DoFs: " << fine_dh.n_dofs() << std::endl;
+      std::cout << "Transfer matrix: " << transfer_matrix.m() << " x "
+                << transfer_matrix.n() << std::endl;
+      std::cout << "Linear transfer L2 error: " << l2_error << std::endl;
+      std::cout << "Distributed continuous transfer matrix test: OK"
+                << std::endl;
+    }
+
+  return 0;
+}

--- a/test/polydeal/distributed_build_continuous_transfer.cc
+++ b/test/polydeal/distributed_build_continuous_transfer.cc
@@ -185,7 +185,7 @@ main(int argc, char *argv[])
         fine_level_boxes.emplace_back(points_in_current_agglomerate);
       }
 
-    ContinuousAggloUtils::PointsAgglo::create_distributed_tria_from_local_boxes(
+    ContinuousAggloUtils::create_distributed_tria_from_local_boxes(
       fine_tria, fine_level_boxes, comm);
 
     const unsigned int fine_local_boxes = fine_level_boxes.size();
@@ -243,7 +243,7 @@ main(int argc, char *argv[])
         coarse_level_boxes.emplace_back(points_in_current_agglomerate);
       }
 
-    ContinuousAggloUtils::PointsAgglo::create_distributed_tria_from_local_boxes(
+    ContinuousAggloUtils::create_distributed_tria_from_local_boxes(
       coarse_tria, coarse_level_boxes, comm);
 
     const unsigned int coarse_local_boxes = coarse_level_boxes.size();
@@ -286,15 +286,14 @@ main(int argc, char *argv[])
     //       }
     //   }
 
-    ContinuousAggloUtils::PointsAgglo::fill_injection_matrix<dim>(
-      coarse_dh,
-      fine_dh,
-      sparsity_pattern,
-      transfer_matrix,
-      parent_to_child_info,
-      coarse_level_boxes,
-      fine_level_boxes,
-      coarse_level - 1);
+    ContinuousAggloUtils::fill_injection_matrix<dim>(coarse_dh,
+                                                     fine_dh,
+                                                     sparsity_pattern,
+                                                     transfer_matrix,
+                                                     parent_to_child_info,
+                                                     coarse_level_boxes,
+                                                     fine_level_boxes,
+                                                     coarse_level - 1);
   }
 
   AssertThrow(transfer_matrix.m() == fine_dh.n_dofs(),

--- a/test/polydeal/distributed_build_continuous_transfer.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/test/polydeal/distributed_build_continuous_transfer.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,6 @@
+Running distributed continuous transfer test with 3 MPI ranks.
+Coarse DoFs: 80
+Fine DoFs: 296
+Transfer matrix: 296 x 80
+Linear transfer L2 error: 7.92858e-16
+Distributed continuous transfer matrix test: OK


### PR DESCRIPTION
I am opening this PR to add functionalities to build transfer matrices for AMG with the R-tree agglomerated Nicolaides (or high order Nicolaides) coarse space in the conforming FEM setting. An example program is WIP, the added tests check all the functionalities added. 

Cell agglomeration and support point agglomeration are both supported. The relative functions have been added in two different namespaces.

I open the PR for a first review. Both distributed matrices (TrilinosWrappers::SparseMatrix) and serial matrices (SparseMatrix<double>) are supported and tested. 

@fdrmrc @luca-heltai 